### PR TITLE
implemented issue #38 (added pom file)

### DIFF
--- a/lib/install-in-maven.sh
+++ b/lib/install-in-maven.sh
@@ -1,0 +1,4 @@
+cd lib
+mvn3 install:install-file -Dfile=android-support-v4.jar -DgroupId=android.support -DartifactId=compatibility-v4 -Dversion=r4 -Dpackaging=jar
+mvn3 install:install-file -Dfile=flattr-android-sdk-0.0.1.4.jar -DgroupId=com.flattr4android.sdk -DartifactId=flattr-android-sdk -Dversion=0.0.1.4 -Dpackaging=jar
+mvn3 install:install-file -Dfile=java-flattr-rest-0.0.1.4.jar -DgroupId=com.flattr4android.rest -DartifactId=java-flattr-rest -Dversion=0.0.1.4 -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.reichholf</groupId>
+	<artifactId>dreamdroid</artifactId>
+	<version>0.9.8-SNAPSHOT</version>
+	<packaging>apk</packaging>
+
+	<name>droidDroid</name>
+	<description>Open source Android client for Dreamboxes based on Enigma2</description>
+	<url>https://github.com/sreichholf/dreamDroid/</url>
+	<inceptionYear>2010</inceptionYear>
+
+	<scm>
+		<url>http://github.com/sreichholf/dreamDroid/</url>
+		<connection>scm:git:git://github.com/sreichholf/dreamDroid.git</connection>
+		<developerConnection>scm:git:git@github.com/sreichholf/dreamDroid.git</developerConnection>
+	</scm>
+	
+	<licenses>
+		<license>
+			<name>Create-Commons Attribution-Noncommercial-Share Alike 3.0 Unported</name>
+			<url>http://creativecommons.org/licenses/by-nc-sa/3.0/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/sreichholf/dreamDroid/issues</url>
+	</issueManagement>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<java.version>1.6</java.version>
+		<android.version>2.3.3</android.version>
+		<android.platform>11</android.platform>
+		<android.support.version>r4</android.support.version>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>jakewharton</id>
+			<url>http://r.jakewharton.com/maven/release/</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.google.android</groupId>
+			<artifactId>android</artifactId>
+			<version>2.3.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>android.support</groupId>
+			<artifactId>compatibility-v4</artifactId>
+			<version>r4</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.flattr4android.sdk</groupId>
+			<artifactId>flattr-android-sdk</artifactId>
+			<version>0.0.1.4</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.flattr4android.rest</groupId>
+			<artifactId>java-flattr-rest</artifactId>
+			<version>0.0.1.4</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>oauth.signpost</groupId>
+			<artifactId>signpost-core</artifactId>
+			<version>1.2.1.1</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.viewpagerindicator</groupId>
+			<artifactId>library</artifactId>
+			<version>2.2.0</version>
+			<type>apklib</type>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.jmdns</groupId>
+			<artifactId>jmdns</artifactId>
+			<version>3.4.1</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+	
+	<build>
+		<finalName>${project.artifactId}</finalName>
+		<sourceDirectory>src</sourceDirectory>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+					<artifactId>android-maven-plugin</artifactId>
+					<version>3.0.0</version>
+					<extensions>true</extensions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<source>1.6</source>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<artifactId>android-maven-plugin</artifactId>
+				<configuration>
+					<sdk>
+						<!-- platform or api level (api level 4 = platform 1.6)-->
+						<platform>11</platform>
+					</sdk>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
I added an initial maven project file to dreamDroid.

To build the apk via maven you need at least maven 3.0.3.  Moreover one has to install some of the libraries in the lib directory as maven libraries.  Thereto, run install-in-maven.sh in the lib directory.  Afterwards one can run "mvn package" in the main directory in order to build the dreamdroid.apk (located in target directory).

Merry Christmas!
