### PR TITLE
more UI refinements

### DIFF
--- a/app/res/drawable/ic_action_clean.xml
+++ b/app/res/drawable/ic_action_clean.xml
@@ -1,10 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
         android:height="24dp"
-        android:autoMirrored="true"
-        android:viewportHeight="24.0"
-        android:viewportWidth="24.0">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M7,14c-1.66,0 -3,1.34 -3,3 0,1.31 -1.16,2 -2,2 0.92,1.22 2.49,2 4,2 2.21,0 4,-1.79 4,-4 0,-1.66 -1.34,-3 -3,-3zM20.71,4.63l-1.34,-1.34c-0.39,-0.39 -1.02,-0.39 -1.41,0L9,12.25 11.75,15l8.96,-8.96c0.39,-0.39 0.39,-1.02 0,-1.41z"/>
+        android:width="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M19.36,2.72L20.78,4.14L15.06,9.85C16.13,11.39 16.28,13.24 15.38,14.44L9.06,8.12C10.26,7.22 12.11,7.37 13.65,8.44L19.36,2.72M5.93,17.57C3.92,15.56 2.69,13.16 2.35,10.92L7.23,8.83L14.67,16.27L12.58,21.15C10.34,20.81 7.94,19.58 5.93,17.57Z" />
 </vector>

--- a/app/res/drawable/ic_action_devices.xml
+++ b/app/res/drawable/ic_action_devices.xml
@@ -1,10 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
         android:height="24dp"
-        android:autoMirrored="true"
-        android:viewportHeight="24.0"
-        android:viewportWidth="24.0">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M21,3L3,3c-1.11,0 -2,0.89 -2,2v12c0,1.1 0.89,2 2,2h5v2h8v-2h5c1.1,0 1.99,-0.9 1.99,-2L23,5c0,-1.11 -0.9,-2 -2,-2zM21,17L3,17L3,5h18v12zM16,10v2h-3v3h-2v-3L8,12v-2h3L11,7h2v3h3z"/>
+        android:width="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M7.5,5.6L5,7L6.4,4.5L5,2L7.5,3.4L10,2L8.6,4.5L10,7L7.5,5.6M19.5,15.4L22,14L20.6,16.5L22,19L19.5,17.6L17,19L18.4,16.5L17,14L19.5,15.4M22,2L20.6,4.5L22,7L19.5,5.6L17,7L18.4,4.5L17,2L19.5,3.4L22,2M13.34,12.78L15.78,10.34L13.66,8.22L11.22,10.66L13.34,12.78M14.37,7.29L16.71,9.63C17.1,10 17.1,10.65 16.71,11.04L5.04,22.71C4.65,23.1 4,23.1 3.63,22.71L1.29,20.37C0.9,20 0.9,19.35 1.29,18.96L12.96,7.29C13.35,6.9 14,6.9 14.37,7.29Z" />
 </vector>

--- a/app/res/menu/save.xml
+++ b/app/res/menu/save.xml
@@ -4,7 +4,6 @@
 
     <item
         android:id="@+id/menu_save"
-        android:icon="@drawable/ic_action_save"
         android:title="@string/save"
         dreamDroid:showAsAction="ifRoom|withText"/>
 

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -44,6 +44,7 @@ import net.reichholf.dreamdroid.asynctask.CheckProfileTask;
 import net.reichholf.dreamdroid.fragment.ActivityCallbackHandler;
 import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
 import net.reichholf.dreamdroid.fragment.ProfileEditFragment;
+import net.reichholf.dreamdroid.fragment.ProfileListFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
 import net.reichholf.dreamdroid.fragment.dialogs.ConnectionErrorDialog;
 import net.reichholf.dreamdroid.fragment.dialogs.MultiChoiceDialog;
@@ -308,7 +309,7 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 						callbackHandler.onDrawerOpened();
 				}
 			};
-			mDrawerLayout.setDrawerListener(mDrawerToggle);
+			mDrawerLayout.addDrawerListener(mDrawerToggle);
 
             NavigationView navigationView = (NavigationView) findViewById(R.id.navigation_view);
             View navHeader = navigationView.getHeaderView(0);
@@ -641,15 +642,8 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 			if (mDetailFragment != null && ProfileEditFragment.class.equals(mDetailFragment.getClass()))
 				return;
-			Bundle args = new Bundle();
-			args.putString("action", Intent.ACTION_EDIT);
-			args.putSerializable("profile", DreamDroid.getCurrentProfile());
 
-			Fragment f = new ProfileEditFragment();
-			f.setArguments(args);
-			if (mDetailFragment != null)
-				f.setTargetFragment(mDetailFragment, Statics.REQUEST_EDIT_PROFILE);
-			showDetails(f, true);
+			ProfileListFragment.openProfileEditActivity(this, DreamDroid.getCurrentProfile());
 			return;
 		}
 

--- a/app/src/net/reichholf/dreamdroid/activities/SimpleFragmentActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/SimpleFragmentActivity.java
@@ -6,14 +6,6 @@
 
 package net.reichholf.dreamdroid.activities;
 
-import net.reichholf.dreamdroid.DreamDroid;
-import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.activities.abs.BaseActivity;
-import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
-import net.reichholf.dreamdroid.fragment.ActivityCallbackHandler;
-import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
-import net.reichholf.dreamdroid.fragment.dialogs.MultiChoiceDialog;
-
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -25,7 +17,17 @@ import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.Window;
+
+import net.reichholf.dreamdroid.DreamDroid;
+import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.activities.abs.BaseActivity;
+import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
+import net.reichholf.dreamdroid.fragment.ActivityCallbackHandler;
+import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
+import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
+import net.reichholf.dreamdroid.fragment.dialogs.MultiChoiceDialog;
+
+import java.util.List;
 
 /**
  * @author sre
@@ -42,7 +44,6 @@ public class SimpleFragmentActivity extends BaseActivity implements MultiPaneHan
 	public void onCreate(Bundle savedInstanceState) {
 		if (!mThemeSet)
 			DreamDroid.setTheme(this);
-		supportRequestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
 		super.onCreate(savedInstanceState);
 
 
@@ -58,6 +59,14 @@ public class SimpleFragmentActivity extends BaseActivity implements MultiPaneHan
 		}
 
 		initViews(initFragment);
+		handleExtras(getIntent().getExtras());
+	}
+
+	protected void handleExtras(Bundle extras) {
+		Bundle args = new Bundle();
+		args.putSerializable(BaseHttpFragment.sData, extras.getSerializable("serializableData"));
+		args.putString("action", extras.getString("action"));
+		mFragment.setArguments(args);
 	}
 
 	protected void initViews(boolean initFragment) {
@@ -71,6 +80,7 @@ public class SimpleFragmentActivity extends BaseActivity implements MultiPaneHan
 				Class<Fragment> c = (Class<Fragment>) getIntent().getExtras().get("fragmentClass");
 				Bundle args = new Bundle();
 				try {
+					//noinspection ConstantConditions
 					f = c.newInstance();
 					args.putAll(getIntent().getExtras());
 					f.setArguments(args);
@@ -94,8 +104,7 @@ public class SimpleFragmentActivity extends BaseActivity implements MultiPaneHan
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
-		super.onCreateOptionsMenu(menu);
-		return true;
+		return super.onCreateOptionsMenu(menu);
 	}
 
 	@Override
@@ -197,9 +206,8 @@ public class SimpleFragmentActivity extends BaseActivity implements MultiPaneHan
 
 	@Override
 	public void showDialogFragment(Class<? extends DialogFragment> fragmentClass, Bundle args, String tag) {
-		DialogFragment f = null;
 		try {
-			f = fragmentClass.newInstance();
+			DialogFragment f = fragmentClass.newInstance();
 			f.setArguments(args);
 			showDialogFragment(f, tag);
 		} catch (InstantiationException | IllegalAccessException e) {

--- a/app/src/net/reichholf/dreamdroid/activities/SimpleToolbarFragmentActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/SimpleToolbarFragmentActivity.java
@@ -14,17 +14,25 @@ public class SimpleToolbarFragmentActivity extends SimpleFragmentActivity {
     }
 
     @Override
-    @SuppressWarnings("ConstantConditions") // titleResource must not be null
     protected void initViews(boolean initFragment) {
         super.initViews(initFragment);
 
         setContentView(R.layout.simple_layout_with_toolbar);
-        Integer titleResource = (Integer) getIntent().getExtras().get("titleResource");
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
+        //noinspection ConstantConditions
         getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle(titleResource);
+    }
+
+    @Override
+    protected void handleExtras(Bundle extras) {
+        super.handleExtras(extras);
+
+        if (extras.getInt("titleResource", -1) != -1) {
+            //noinspection ConstantConditions
+            getSupportActionBar().setTitle(extras.getInt("titleResource"));
+        }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -228,10 +229,20 @@ public class BaseActivity extends AppCompatActivity implements ActionDialog.Dial
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 		Log.i(TAG, "onActivityResult(" + requestCode + "," + resultCode + "," + data);
-		if (!mIabHelper.handleActivityResult(requestCode, resultCode, data)) {
+		if (mIabHelper == null) {
+			Log.i(TAG, "IABUtil not yet initialized.");
+		} else if (!mIabHelper.handleActivityResult(requestCode, resultCode, data)) {
 			super.onActivityResult(requestCode, resultCode, data);
 		} else {
 			Log.i(TAG, "onActivityResult handled by IABUtil.");
+		}
+
+		List<Fragment> fragments = getSupportFragmentManager().getFragments();
+		for (Fragment fragment : fragments) {
+			if (fragment == null)
+				continue;
+
+			fragment.onActivityResult(requestCode, resultCode, data);
 		}
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/ProfileEditFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ProfileEditFragment.java
@@ -6,6 +6,7 @@
 
 package net.reichholf.dreamdroid.fragment;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -28,7 +29,12 @@ import net.reichholf.dreamdroid.DatabaseHelper;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.Statics;
+
+import java.util.HashMap;
+
+import static net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment.sData;
 
 /**
  * Used to edit connection profiles
@@ -108,8 +114,11 @@ public class ProfileEditFragment extends BaseFragment {
 		mLayoutStream = (LinearLayout) view.findViewById(R.id.linearLayoutStream);
 		mLayoutLogin = (LinearLayout) view.findViewById(R.id.LoginLayout);
 
-		if (Intent.ACTION_EDIT.equals(getArguments().getString("action"))) {
-			mCurrentProfile = (Profile) getArguments().getSerializable("profile");
+		HashMap extras = (HashMap) getArguments().getSerializable(sData);
+		assert extras != null;
+
+		if (Intent.ACTION_EDIT.equals(extras.get("action"))) {
+			mCurrentProfile = (Profile) extras.get("profile");
 			if (mCurrentProfile == null)
 				mCurrentProfile = Profile.getDefault();
 			assignProfile();
@@ -159,7 +168,7 @@ public class ProfileEditFragment extends BaseFragment {
 
 	@Override
 	public void createOptionsMenu(Menu menu, MenuInflater inflater) {
-		inflater.inflate(R.menu.cancel, menu);
+		inflater.inflate(R.menu.save, menu);
 	}
 
 	public boolean onOptionsItemSelected(MenuItem item) {
@@ -176,6 +185,7 @@ public class ProfileEditFragment extends BaseFragment {
 		return true;
 	}
 
+	@SuppressLint("SetTextI18n")
 	private void onSslChanged(boolean checked) {
 		if (checked)
 			mPort.setText("443");

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListFragment.java
@@ -35,6 +35,7 @@ import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.ServiceAdapter;
 import net.reichholf.dreamdroid.adapter.recyclerview.SimpleTextAdapter;
+import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerEventFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailDialog;
 import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
@@ -115,11 +116,19 @@ public class ServiceListFragment extends BaseHttpRecyclerEventFragment {
 		super.onCreate(savedInstanceState);
 		mCurrentTitle = getString(R.string.services);
 		mReload = true;
-		Bundle args = getArguments();
+		mExtras = getArguments();
 		String mode = null;
 
-		if (args != null) {
-			mode = args.getString("action");
+		if (mExtras != null) {
+			mode = mExtras.getString("action");
+
+			HashMap<String, Object> map = (HashMap<String, Object>) mExtras.getSerializable(sData);
+			if (map != null) {
+				mData = new ExtendedHashMap();
+				mData.putAll(map);
+			}
+		} else {
+			mExtras = new Bundle();
 		}
 
 		mPickMode = Intent.ACTION_PICK.equals(mode);
@@ -146,7 +155,6 @@ public class ServiceListFragment extends BaseHttpRecyclerEventFragment {
 
 				mHistory.add(map);
 
-				mExtras = getArguments();
 				mNavItems = new ArrayList<>();
 				mDetailItems = new ArrayList<>();
 			}
@@ -160,16 +168,6 @@ public class ServiceListFragment extends BaseHttpRecyclerEventFragment {
 		if( mNavReference == null ){
 			mNavReference = DreamDroid.getCurrentProfile().getDefaultRef2();
 			mNavName = DreamDroid.getCurrentProfile().getDefaultRef2Name();
-		}
-
-		if (mExtras != null) {
-			HashMap<String, Object> map = (HashMap<String, Object>) mExtras.getSerializable("data");
-			if (map != null) {
-				mData = new ExtendedHashMap();
-				mData.putAll(map);
-			}
-		} else {
-			mExtras = new Bundle();
 		}
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
@@ -12,7 +12,6 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -35,7 +34,7 @@ import com.wdullaer.materialdatetimepicker.time.TimePickerDialog;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
+import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
 import net.reichholf.dreamdroid.asynctask.GetLocationsAndTagsTask;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.MultiChoiceDialog;
@@ -50,6 +49,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Tag;
 import net.reichholf.dreamdroid.helpers.enigma2.Timer;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerChangeRequestHandler;
 
+import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -179,7 +179,7 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 			mTimer = new ExtendedHashMap();
 			mTimer.putAll((HashMap<String, Object>) data.get("timer"));
 
-			if (Intent.ACTION_EDIT.equals(getArguments().get("action"))) {
+			if (Intent.ACTION_EDIT.equals(data.get("action"))) {
 				mTimerOld = mTimer.clone();
 			} else {
 				mTimerOld = null;
@@ -213,7 +213,7 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 	}
 
 	public void createOptionsMenu(Menu menu, MenuInflater inflater) {
-		inflater.inflate(R.menu.cancel, menu);
+		inflater.inflate(R.menu.save, menu);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -279,10 +279,6 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 		getMultiPaneHandler().showDialogFragment(f, "dialog_select_tags");
 	}
 
-	/**
-	 * @param v
-	 * @param id
-	 */
 	protected void registerOnClickListener(View v, final int id) {
 		v.setOnClickListener(new OnClickListener() {
 			@Override
@@ -292,9 +288,6 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 		});
 	}
 
-	/**
-	 * @param id
-	 */
 	protected boolean onItemSelected(int id) {
 		boolean consumed;
 		Calendar calendar;
@@ -379,22 +372,16 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 		return consumed;
 	}
 
-	/**
-	 *
-	 */
 	private void pickService() {
-		ServiceListFragment f = new ServiceListFragment();
-		Bundle args = new Bundle();
-
 		ExtendedHashMap data = new ExtendedHashMap();
 		data.put(Service.KEY_REFERENCE, "default");
 
-		args.putSerializable(sData, data);
-		args.putString("action", Intent.ACTION_PICK);
-
-		f.setArguments(args);
-		f.setTargetFragment(this, Statics.REQUEST_PICK_SERVICE);
-		((MultiPaneHandler) getAppCompatActivity()).showDetails(f, true);
+		Intent intent = new Intent(getContext(), SimpleToolbarFragmentActivity.class);
+		intent.putExtra("fragmentClass", ServiceListFragment.class);
+		intent.putExtra("titleResource", R.string.service);
+		intent.putExtra("action", Intent.ACTION_PICK);
+		intent.putExtra("serializableData", (Serializable) data);
+		getActivity().startActivityForResult(intent, Statics.REQUEST_PICK_SERVICE);
 	}
 
 	/**
@@ -468,6 +455,7 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 		try {
 			repeatedValue = DateTime.parseTimestamp(mTimer.getString(Timer.KEY_REPEATED));
 		} catch (NumberFormatException ex) {
+			ex.printStackTrace();
 		}
 
 		String repeatedText = getRepeated(repeatedValue);
@@ -586,8 +574,8 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 				mProgress.dismiss();
 			}
 		}
-		Activity activtiy = getAppCompatActivity();
-		mProgress = ProgressDialog.show(activtiy, "", getText(R.string.saving), true);
+		Activity activity = getAppCompatActivity();
+		mProgress = ProgressDialog.show(activity, "", getText(R.string.saving), true);
 
 		applyViewValues();
 		ArrayList<NameValuePair> params = Timer.getSaveParams(mTimer, mTimerOld);

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseHttpFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseHttpFragment.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 public abstract class BaseHttpFragment extends BaseFragment implements
 		LoaderManager.LoaderCallbacks<LoaderResult<ExtendedHashMap>>, IHttpBase, SwipeRefreshLayout.OnRefreshListener, SimpleResultTask.SimpleResultTaskHandler {
 
-	protected final String sData = "data";
+	public static final String sData = "data";
 	protected HttpFragmentHelper mHttpHelper;
 	protected boolean mReload = false;
 

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
@@ -33,7 +33,7 @@ import net.reichholf.dreamdroid.widget.helper.ItemSelectionSupport;
 import net.reichholf.dreamdroid.widget.helper.SpacesItemDecoration;
 
 /**
- * Created by Stephan on 03.05.2015.
+ * @author Stephan
  */
 public abstract class BaseRecyclerFragment extends Fragment implements ActivityCallbackHandler, IMutliPaneContent, IBaseFragment, ItemClickSupport.OnItemClickListener, ItemClickSupport.OnItemLongClickListener, SwipeRefreshLayout.OnRefreshListener, ActionDialog.DialogActionListener {
 
@@ -49,6 +49,8 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	protected ActionMode mActionMode;
 	protected boolean mIsActionMode;
 	protected boolean mIsActionModeRequired;
+
+	protected SwipeRefreshLayout mSwipeRefreshLayout;
 
 	public BaseRecyclerFragment() {
 		super();
@@ -84,14 +86,13 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 		super.onViewCreated(view, savedInstanceState);
 		setFabEnabled(R.id.fab_reload, mEnableReload);
 		setFabEnabled(R.id.fab_main, mHasFabMain);
-
-		getAppCompatActivity().findViewById(R.id.ptr_layout).setEnabled(mEnableReload);
-		SwipeRefreshLayout srl = (SwipeRefreshLayout) getAppCompatActivity().findViewById(R.id.ptr_layout);
-		srl.setOnRefreshListener(this);
 	}
 
 	protected void setFabEnabled(int id, boolean enabled) {
 		FloatingActionButton fab = (FloatingActionButton) getAppCompatActivity().findViewById(id);
+		if (fab == null)
+			return;
+
 		fab.setTag(R.id.fab_scrolling_view_behavior_enabled, enabled);
 		if (enabled) {
 			fab.show();
@@ -104,6 +105,9 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
 		super.onActivityCreated(savedInstanceState);
+		//noinspection ConstantConditions
+		mSwipeRefreshLayout = (SwipeRefreshLayout) getView().findViewById(R.id.ptr_layout);
+		mSwipeRefreshLayout.setOnRefreshListener(this);
 		mHelper.onActivityCreated(savedInstanceState);
 	}
 
@@ -194,6 +198,7 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	}
 
 	public RecyclerView getRecyclerView() {
+		//noinspection ConstantConditions
 		return (RecyclerView) getView().findViewById(android.R.id.list);
 	}
 
@@ -202,6 +207,7 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	}
 
 	protected void setEmptyText(CharSequence emptyText, int topDrawable) {
+		//noinspection ConstantConditions
 		TextView textView = (TextView) getView().findViewById(android.R.id.empty);
 		if (textView == null)
 			return;
@@ -226,8 +232,7 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 
 	@Override
 	public void onRefresh() {
-		SwipeRefreshLayout srl = (SwipeRefreshLayout) getAppCompatActivity().findViewById(R.id.ptr_layout);
-		srl.setRefreshing(false);
+		mSwipeRefreshLayout.setRefreshing(false);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/Timer.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/Timer.java
@@ -6,13 +6,13 @@
 
 package net.reichholf.dreamdroid.helpers.enigma2;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import android.app.Activity;
+import android.content.Intent;
+import android.support.v4.app.Fragment;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.fragment.TimerEditFragment;
 import net.reichholf.dreamdroid.helpers.DateTime;
@@ -20,18 +20,18 @@ import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
 
-import android.app.Activity;
-import android.content.Intent;
-import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 /**
  * @author sreichholf
- * 
  */
 public class Timer {
 	public static final String DATA = "data";
-	
+
 	public static final String KEY_REFERENCE = "reference";
 	public static final String KEY_SERVICE_NAME = "servicename";
 	public static final String KEY_EIT = "eit";
@@ -60,12 +60,12 @@ public class Timer {
 	public static final String KEY_DONT_SAVE = "dontsave";
 	public static final String KEY_CANCELED = "canceled";
 	public static final String KEY_TOGGLE_DISABLED = "toggledisabled";
-	
+
 	public static final int STATE_WAITING = 0;
 	public static final int STATE_PREPARED = 1;
 	public static final int STATE_RUNNING = 2;
-	public static final int STATE_ENDED = 3;	
-	
+	public static final int STATE_ENDED = 3;
+
 	public static enum Afterevents {
 		NOTHING(0), STANDBY(1), DEEP_STANDBY(2), AUTO(3);
 
@@ -138,7 +138,7 @@ public class Timer {
 
 		return timer;
 	}
-	
+
 	public static ArrayList<NameValuePair> getSaveParams(ExtendedHashMap timer, ExtendedHashMap timerOld){
 		/*
 		 * URL to create /web/timerchange? sRef= &begin= &end= &name=
@@ -170,19 +170,19 @@ public class Timer {
 		} else {
 			params.add(new NameValuePair("deleteOldOnSave", "0"));
 		}
-		
+
 		return params;
 	}
-	
+
 	public static ArrayList<NameValuePair> getEventIdParams(ExtendedHashMap event){
 		ArrayList<NameValuePair> params = new ArrayList<>();
 
 		params.add(new NameValuePair("sRef", event.getString(Event.KEY_SERVICE_REFERENCE)));
 		params.add(new NameValuePair("eventid", event.getString(Event.KEY_EVENT_ID)));
-		
+
 		return params;
 	}
-	
+
 	public static ArrayList<NameValuePair> getDeleteParams(ExtendedHashMap timer){
 		// URL - web/timerdelete?sRef=&begin=&end=
 		ArrayList<NameValuePair> params = new ArrayList<>();
@@ -190,42 +190,37 @@ public class Timer {
 		params.add(new NameValuePair("sRef", timer.getString(KEY_REFERENCE)));
 		params.add(new NameValuePair("begin", timer.getString(KEY_BEGIN)));
 		params.add(new NameValuePair("end", timer.getString(KEY_END)));
-		
+
 		return params;
 	}
-	
-	
-	
+
+
+
 	/**
 	 * @param mph - A MultiPaneHandler instance
-	 * @param timer - A timer (ExtendedHashMap)
+	 * @param event - A timer (ExtendedHashMap)
 	 * @param target - The target fragment (after saving/cancellation)
 	 */
 	public static void editUsingEvent(MultiPaneHandler mph, ExtendedHashMap event, Fragment target){
 		Timer.edit(mph, Timer.createByEvent(event), target, true);
 	}
-	
+
 	/**
 	 * @param mph - A MultiPaneHandler instance
 	 * @param timer - A timer (ExtendedHashMap)
 	 * @param target - The target fragment (after saving/cancellation)
 	 * @param create - set to true if a new timer should be created instead of editing an existing one
 	 */
-	public static void edit(MultiPaneHandler mph, ExtendedHashMap timer, Fragment target, boolean create){
-		ExtendedHashMap data = new ExtendedHashMap();
-		
-		TimerEditFragment f = new TimerEditFragment();
-		Bundle args = new Bundle();
-		data.put("timer", timer);
-		args.putSerializable(DATA, data);
-		
-		String action = create ? DreamDroid.ACTION_CREATE : Intent.ACTION_EDIT;
-		args.putString("action", action);
-		
-		f.setArguments(args);
-		if(target != null){
-			f.setTargetFragment(target, Statics.REQUEST_EDIT_TIMER);
-		}
-		mph.showDetails(f, true);
+	public static void edit(MultiPaneHandler mph, ExtendedHashMap timer, Fragment target, boolean create) {
+        ExtendedHashMap data = new ExtendedHashMap();
+        data.put("timer", timer);
+        data.put("action", create ? DreamDroid.ACTION_CREATE : Intent.ACTION_EDIT);
+
+        Intent intent = new Intent(target.getContext(), SimpleToolbarFragmentActivity.class);
+        intent.putExtra("fragmentClass", TimerEditFragment.class);
+        intent.putExtra("titleResource", create ? R.string.new_timer : R.string.edit_timer);
+        //intent.putExtra("menuResource", R.menu.save);
+        intent.putExtra("serializableData", (Serializable) data);
+        target.getActivity().startActivityForResult(intent, Statics.REQUEST_EDIT_TIMER);
 	}
 }


### PR DESCRIPTION
* change profile wizard icon to a wand: [auto-fix](https://materialdesignicons.com/icon/auto-fix)
* change timer clean icon to a better broom: [broom](https://materialdesignicons.com/icon/broom) instead of [brush](https://materialdesignicons.com/icon/brush)
* remove save action menu item's icon like in other Material apps (just show text)
* open timer and profile edit dialogs in own activities instead of fragment to avoid the drawer from being opened