### PR TITLE
Dark navigation bar color

### DIFF
--- a/app/res/values-night/themes.xml
+++ b/app/res/values-night/themes.xml
@@ -3,6 +3,7 @@
 
     <style name="Theme.DreamDroid" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:listSelector">@drawable/list_selector_dark</item>
+        <item name="android:navigationBarColor">@color/primary_material_dark</item>
         <item name="android:windowTranslucentStatus">@bool/requireTranslucentStatusbar</item>
         <item name="cardPreventCornerOverlap">true</item>
         <item name="cardBackgroundColor">@color/cardview_dark_background</item>

--- a/app/res/values/themes.xml
+++ b/app/res/values/themes.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.DreamDroid" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:listSelector">@drawable/list_selector_light</item>
+        <item name="android:navigationBarColor">@color/primary_material_dark</item>
         <item name="android:windowTranslucentStatus">@bool/requireTranslucentStatusbar</item>
         <item name="cardPreventCornerOverlap">true</item>
         <item name="cardBackgroundColor">@color/cardview_light_background</item>


### PR DESCRIPTION
This is only an issue for phones which have a white navigation bar as default (like OnePlus 6 with OxygenOS). Alternatively can set those values to `@android:color/transparent`, then it takes the color of theme.

<img src="https://user-images.githubusercontent.com/18537755/45765427-54651780-bc35-11e8-8050-bb3d7ac87fc8.jpg" width="200">
 