### PR TITLE
Added support for http stream urls from bouquet lists

### DIFF
--- a/app/src/net/reichholf/dreamdroid/helpers/SimpleHttpClient.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/SimpleHttpClient.java
@@ -32,6 +32,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -161,6 +162,14 @@ public class SimpleHttpClient {
 	public String buildServiceStreamUrl(String ref) {
 		if (mProfile.getHost().equals("dreamdroid.org"))
 			return BIG_BUCK_BUNNY_URL;
+
+		if (ref.contains("http")) { // service ref already is a http stream url
+			try{
+				return java.net.URLDecoder.decode(ref.substring(ref.indexOf("http")), "utf-8").replace(" ","%20");
+			} catch (UnsupportedEncodingException e) {
+			}
+		}
+
 		try {
 			ref = URLEncoder.encode(ref, "utf-8").replace("+", "%20");
 		} catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Sometimes a bouqet list contains urls for streams from the box 
like http://boxIP:17999/#ref# 
These are working fine now