### PR TITLE
chore(build): raise minSdk to 26 and drop jcenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'com.github.StephenVinouze:MaterialNumberPicker:1.0.5'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'commons-net:commons-net:3.6'
     implementation 'commons-io:commons-io:2.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         flatDir{
             dirs 'libs'
         }
@@ -21,7 +20,7 @@ apply plugin: 'kotlin-android'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven { url "https://jitpack.io" }
 }
 
@@ -51,7 +50,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'commons-net:commons-net:3.6'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'org.openhab.jmdns:jmdns:3.4.2'
+    implementation 'org.jmdns:jmdns:3.5.9'
     implementation 'io.noties.markwon:core:4.6.2'
     implementation project(':libraries:AttributionPresenter:library')
     implementation project(':libraries:simple-gauge-android:gaugelibrary')
@@ -62,11 +61,8 @@ dependencies {
     implementation 'com.github.livefront:bridge:v2.0.2'
     implementation 'com.jakewharton:butterknife:10.2.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
-    //noinspection KtxExtensionAvailable
-    implementation 'androidx.navigation:navigation-fragment:2.5.3'
-    //noinspection KtxExtensionAvailable
-    implementation 'androidx.navigation:navigation-ui:2.5.3'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 android {
@@ -76,14 +72,21 @@ android {
     defaultConfig {
         versionCode 460
         versionName="1.15.460"
-        minSdkVersion 17
+        minSdkVersion 26
         targetSdkVersion 34
         multiDexEnabled true
+        buildConfigField "int", "MIN_SDK", "${minSdkVersion.apiLevel}"
         sourceSets {
             main {
                 manifest.srcFile 'AndroidManifest.xml'
-                java.srcDirs = ['src']
+                java {
+                    srcDirs = ['src']
+                    exclude 'test/**'
+                }
                 res.srcDirs = ['res']
+            }
+            test {
+                java.srcDirs = ['src/test/java']
             }
         }
     }
@@ -141,8 +144,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     lint {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'com.github.StephenVinouze:MaterialNumberPicker:1.0.5'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.7'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'commons-net:commons-net:3.6'
     implementation 'commons-io:commons-io:2.6'

--- a/app/src/test/java/net/reichholf/dreamdroid/MinSdkSmokeTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/MinSdkSmokeTest.java
@@ -1,0 +1,14 @@
+package net.reichholf.dreamdroid;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MinSdkSmokeTest {
+    @Test
+    public void minSdkIsAtLeast26() {
+        assertEquals(26, BuildConfig.MIN_SDK);
+        assertTrue(BuildConfig.MIN_SDK >= 26);
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/MinSdkSmokeTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/MinSdkSmokeTest.java
@@ -3,12 +3,10 @@ package net.reichholf.dreamdroid;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MinSdkSmokeTest {
     @Test
-    public void minSdkIsAtLeast26() {
+    public void minSdkIs26() {
         assertEquals(26, BuildConfig.MIN_SDK);
-        assertTrue(BuildConfig.MIN_SDK >= 26);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,5 @@
 org.gradle.daemon=true
-org.gradle.jvmargs=-XX:MaxPermSize=1536m \
-  -XX:+CMSClassUnloadingEnabled \
-  -XX:+HeapDumpOnOutOfMemoryError \
-  -Xmx2048m \
-  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
-  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 BUILD_TOOLS_VERSION 34.0.0
 COMPILE_SDK_VERSION 34


### PR DESCRIPTION
## Why

jcenter is gone, so `org.openhab.jmdns:jmdns:3.4.2` no longer resolves and `:app:assembleGoogleDebug` fails. JDK 17 also rejects `-XX:MaxPermSize` and CMS flags in `gradle.properties`, so the Gradle daemon cannot start. This PR raises the install floor to minSdk 26 and Java 17, and it restores a resolve path that does not use jcenter.

## Scope

- `app/build.gradle`: `minSdkVersion 26`, `JavaVersion.VERSION_17`, `mavenCentral()` and `google()` only, `org.jmdns:jmdns:3.5.9`, unused `androidx.navigation` lines removed, `BuildConfig.MIN_SDK`, JUnit 4, test sourceSet, OkHttp 3.14.9
- `gradle.properties`: daemon jvmargs without MaxPermSize or CMS
- `MinSdkSmokeTest` asserts `BuildConfig.MIN_SDK` is 26

Out of scope: product Java and Kotlin, TV sources, changelog, versionCode, AGP, the Kotlin plugin, and jcenter lines in library modules.

## Tradeoffs

`android-retrostreams` stays. Backup still compiles against `java9.util.stream.StreamSupport`, and product code is outside the fence. OkHttp is 3.14.9. Picasso 2.8 is the consumer. OkHttp 4.12.0 fails `:app:compileGoogleDebugKotlin` on Kotlin 1.6.21, and that plugin stays. Enigma2 HTTP is still `HttpURLConnection`.

## Blast Radius

Google, F-Droid, and Amazon flavors all install only on API 26 and newer. Installs on Android 8.0 and older stop. Picasso still uses OkHttp. The Kotlin plugin stays at 1.6.21.

## Verification

`:app:assembleGoogleDebug` BUILD SUCCESSFUL on JDK 17 after a full `:app:compileGoogleDebugKotlin` rerun with OkHttp 3.14.9. Merged googleDebug manifest has `android:minSdkVersion="26"`. `:app:testGoogleDebugUnitTest` ran `MinSdkSmokeTest.minSdkIs26` with 1 test, 0 failures. Live lanes 2 through 10 passed on AVD `dreamdroid-verify`. Lane 1 trunk is blocked because origin/master cannot start the Gradle daemon. Warm-daemon head assemble was 1.38s, all UP-TO-DATE. Trunk has no successful assemble seconds, so the 1.25x gate has no comparison. `/deslop` skipped, plugin absent.
