### PR TITLE
feat(enigma): type the Enigma2 client

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'com.github.StephenVinouze:MaterialNumberPicker:1.0.5'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'commons-net:commons-net:3.6'
     implementation 'commons-io:commons-io:2.6'
@@ -109,6 +110,7 @@ android {
             }
             test {
                 java.srcDirs = ['src/test/java']
+                resources.srcDirs = ['src/test/resources']
             }
             androidTest {
                 java.srcDirs = ['androidTest/java']

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,8 +137,8 @@ android {
         abi {
             enable true
             reset()
-            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a' //select ABIs to build APKs for
-            universalApk true //generate an additional APK that contains all the ABIs
+            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+            universalApk true
         }
     }
 
@@ -165,7 +165,6 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             debuggable false
-            // Add build date object to BuildConfig
             buildConfigField "long", "BUILD_TIME", "" + System.currentTimeMillis() + "L"
             resValue "string", "app_name", "@string/app_name_release"
             resValue "string", "app_name_tv", "@string/app_name_tv_release"

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetBouquetListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetBouquetListTask.java
@@ -5,10 +5,9 @@ import android.content.res.Resources;
 import androidx.annotation.NonNull;
 
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+import net.reichholf.dreamdroid.enigma.Service;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.AbstractListRequestHandler;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ServiceListRequestHandler;
 
 import java.util.ArrayList;
 
@@ -18,8 +17,8 @@ import java.util.ArrayList;
  */
 public class GetBouquetListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
 	public class Bouquets {
-		public ArrayList<ExtendedHashMap> tv;
-		public ArrayList<ExtendedHashMap> radio;
+		public ArrayList<Service> tv;
+		public ArrayList<Service> radio;
 
 		public Bouquets() {
 			tv = new ArrayList<>();
@@ -46,18 +45,19 @@ public class GetBouquetListTask extends AsyncHttpTaskBase<Void, String, Boolean>
 		if (isCancelled())
 			return false;
 
-		AbstractListRequestHandler handler = new ServiceListRequestHandler();
-		addBouquets(handler, mTV, mBouquets.tv);
-		addBouquets(handler, mRadio, mBouquets.radio);
+		addBouquets(mTV, mBouquets.tv);
+		addBouquets(mRadio, mBouquets.radio);
 
 		return true;
 	}
 
-	private boolean addBouquets(@NonNull AbstractListRequestHandler handler, String ref, ArrayList<ExtendedHashMap> target) {
+	private boolean addBouquets(String ref, ArrayList<Service> target) {
 		ArrayList<NameValuePair> params = new ArrayList<>();
 		params.add(new NameValuePair("sRef", ref));
-		String xml = handler.getList(getHttpClient(), params);
-		return xml != null && !isCancelled() && handler.parseList(xml, target);
+		if (isCancelled())
+			return false;
+		target.addAll(HttpFragmentHelper.fetchServices(getHttpClient(), params));
+		return true;
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetBouquetListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetBouquetListTask.java
@@ -11,10 +11,6 @@ import net.reichholf.dreamdroid.helpers.NameValuePair;
 
 import java.util.ArrayList;
 
-/**
- * @author sreichholf Fetches a service list async. Does all the
- *         error-handling, refreshing and title-setting
- */
 public class GetBouquetListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
 	public class Bouquets {
 		public ArrayList<Service> tv;
@@ -34,8 +30,8 @@ public class GetBouquetListTask extends AsyncHttpTaskBase<Void, String, Boolean>
 	public GetBouquetListTask(AsyncHttpTaskBaseHandler taskHandler) {
 		super(taskHandler);
 		GetBouquetListTaskHandler t = (GetBouquetListTaskHandler) mTaskHandler.get();
-		mTV = t.getResources().getStringArray(R.array.servicerefs)[0]; //Favorites TV;
-		mRadio = t.getResources().getStringArray(R.array.servicerefs)[3]; // Favorites Radio
+		mTV = t.getResources().getStringArray(R.array.servicerefstv)[0];
+		mRadio = t.getResources().getStringArray(R.array.servicerefsradio)[0];
 	}
 
 	@NonNull

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -1,0 +1,31 @@
+package net.reichholf.dreamdroid.enigma
+
+import kotlinx.coroutines.runBlocking
+import net.reichholf.dreamdroid.helpers.NameValuePair
+import net.reichholf.dreamdroid.helpers.SimpleHttpClient
+import net.reichholf.dreamdroid.helpers.enigma2.URIStore
+import java.util.ArrayList
+
+class EnigmaClient(private val http: SimpleHttpClient) {
+    suspend fun getServices(params: List<NameValuePair> = emptyList()): List<Service> {
+        val requestParams = ArrayList(params)
+        if (!http.fetchPageContent(URIStore.SERVICES, requestParams)) {
+            return emptyList()
+        }
+        return ServiceParser.parse(http.pageContentString)
+    }
+
+    companion object {
+        @JvmStatic
+        fun of(http: SimpleHttpClient): EnigmaClient {
+            return EnigmaClient(http)
+        }
+
+        @JvmStatic
+        fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
+            return runBlocking {
+                EnigmaClient(http).getServices(params)
+            }
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -1,6 +1,8 @@
 package net.reichholf.dreamdroid.enigma
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import net.reichholf.dreamdroid.helpers.NameValuePair
 import net.reichholf.dreamdroid.helpers.SimpleHttpClient
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore
@@ -8,19 +10,17 @@ import java.util.ArrayList
 
 class EnigmaClient(private val http: SimpleHttpClient) {
     suspend fun getServices(params: List<NameValuePair> = emptyList()): List<Service> {
-        val requestParams = ArrayList(params)
-        if (!http.fetchPageContent(URIStore.SERVICES, requestParams)) {
-            return emptyList()
+        return withContext(Dispatchers.IO) {
+            val requestParams = ArrayList(params)
+            if (!http.fetchPageContent(URIStore.SERVICES, requestParams)) {
+                emptyList()
+            } else {
+                ServiceParser.parse(http.pageContentString)
+            }
         }
-        return ServiceParser.parse(http.pageContentString)
     }
 
     companion object {
-        @JvmStatic
-        fun of(http: SimpleHttpClient): EnigmaClient {
-            return EnigmaClient(http)
-        }
-
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
             return runBlocking {

--- a/app/src/net/reichholf/dreamdroid/enigma/Event.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Event.kt
@@ -1,0 +1,13 @@
+package net.reichholf.dreamdroid.enigma
+
+data class Event(
+    val eventId: String = "",
+    val title: String = "",
+    val start: String = "",
+    val duration: String = "",
+    val currentTime: String = "",
+    val description: String = "",
+    val descriptionExtended: String = "",
+    val serviceReference: String = "",
+    val serviceName: String = ""
+)

--- a/app/src/net/reichholf/dreamdroid/enigma/Movie.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Movie.kt
@@ -1,0 +1,14 @@
+package net.reichholf.dreamdroid.enigma
+
+data class Movie(
+    val reference: String = "",
+    val title: String = "",
+    val description: String = "",
+    val descriptionExtended: String = "",
+    val serviceName: String = "",
+    val time: String = "",
+    val length: String = "",
+    val tags: String = "",
+    val fileName: String = "",
+    val fileSize: String = ""
+)

--- a/app/src/net/reichholf/dreamdroid/enigma/Service.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Service.kt
@@ -1,0 +1,6 @@
+package net.reichholf.dreamdroid.enigma
+
+data class Service(
+    val reference: String,
+    val name: String
+)

--- a/app/src/net/reichholf/dreamdroid/enigma/ServiceParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/ServiceParser.kt
@@ -1,0 +1,75 @@
+package net.reichholf.dreamdroid.enigma
+
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object ServiceParser {
+    fun parse(xml: String): List<Service> {
+        if (xml.isEmpty()) {
+            return emptyList()
+        }
+        return try {
+            val handler = ServiceListHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(xml)))
+            handler.services
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+}
+
+private class ServiceListHandler : DefaultHandler() {
+    val services = ArrayList<Service>()
+    private var inService = false
+    private var inReference = false
+    private var inName = false
+    private val reference = StringBuilder()
+    private val name = StringBuilder()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2service" -> {
+                inService = true
+                reference.setLength(0)
+                name.setLength(0)
+            }
+            "e2servicereference" -> inReference = true
+            "e2servicename" -> inName = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2service" -> {
+                inService = false
+                services.add(Service(reference.toString(), name.toString().replace("\\p{Cntrl}".toRegex(), "")))
+            }
+            "e2servicereference" -> inReference = false
+            "e2servicename" -> inName = false
+        }
+    }
+
+    override fun characters(ch: CharArray, start: Int, length: Int) {
+        if (!inService) {
+            return
+        }
+        if (inReference) {
+            reference.append(ch, start, length)
+        } else if (inName) {
+            name.append(ch, start, length)
+        }
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/Timer.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Timer.kt
@@ -1,0 +1,21 @@
+package net.reichholf.dreamdroid.enigma
+
+data class Timer(
+    val reference: String = "",
+    val serviceName: String = "",
+    val eit: String = "",
+    val name: String = "",
+    val description: String = "",
+    val descriptionExtended: String = "",
+    val disabled: String = "",
+    val begin: String = "",
+    val end: String = "",
+    val duration: String = "",
+    val justPlay: String = "",
+    val afterEvent: String = "",
+    val location: String = "",
+    val tags: String = "",
+    val fileName: String = "",
+    val state: String = "",
+    val repeated: String = ""
+)

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -23,10 +23,9 @@ import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.asynctask.GetBouquetListTask;
 import net.reichholf.dreamdroid.asynctask.GetLocationsAndTagsTask;
+import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
-import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.enigma2.Event;
-import net.reichholf.dreamdroid.helpers.enigma2.Service;
 
 import java.util.ArrayList;
 
@@ -80,14 +79,14 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 	}
 
 	public class ServicelistAdapter extends FragmentStateAdapter {
-		ArrayList<ExtendedHashMap> mItems;
+		ArrayList<Service> mItems;
 
 		public ServicelistAdapter(@NonNull Fragment fragment) {
 			super(fragment);
 			mItems = new ArrayList();
 		}
 
-		public ExtendedHashMap get(int i) {
+		public Service get(int i) {
 			return mItems.get(i);
 		}
 
@@ -95,7 +94,7 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			mItems.clear();
 		}
 
-		public void add(ExtendedHashMap e) {
+		public void add(Service e) {
 			mItems.add(e);
 		}
 
@@ -105,9 +104,9 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			Fragment f = new ServiceListPageFragment();
 
 			Bundle args = new Bundle();
-			ExtendedHashMap service = mItems.get(position);
-			args.putString(Service.KEY_REFERENCE, service.getString(Service.KEY_REFERENCE));
-			args.putString(Service.KEY_NAME, service.getString(Service.KEY_NAME));
+			Service service = mItems.get(position);
+			args.putString(Event.KEY_SERVICE_REFERENCE, service.getReference());
+			args.putString(Event.KEY_SERVICE_NAME, service.getName());
 			f.setArguments(args);
 			return f;
 		}
@@ -120,8 +119,8 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		}
 
 		public int indexOf(@NonNull String ref) {
-			for (ExtendedHashMap bouquet : mItems) {
-				if (ref != null && ref.equals(bouquet.get(Service.KEY_REFERENCE)))
+			for (Service bouquet : mItems) {
+				if (ref != null && ref.equals(bouquet.getReference()))
 					return mItems.indexOf(bouquet);
 			}
 			return -1;
@@ -251,10 +250,10 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 				super.onPageSelected(position);
 				switch(mMode) {
 					case MODE_TV:
-						mCurrentTv = mTvListAdapter.get(position).getString(Service.KEY_REFERENCE, null);
+						mCurrentTv = mTvListAdapter.get(position).getReference();
 						break;
 					case MODE_RADIO:
-						mCurrentRadio = mRadioListAdapter.get(position).getString(Service.KEY_REFERENCE, null);
+						mCurrentRadio = mRadioListAdapter.get(position).getReference();
 						break;
 					case MODE_MOVIES:
 						mCurrentMovie = mMovielistAdapter.get(position);
@@ -353,9 +352,9 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		if (MODE_MOVIES.equals(mMode) && mMovielistAdapter.getItemCount() > position)
 			return mMovielistAdapter.get(position);
 		if (MODE_TV.equals(mMode) && mTvListAdapter.getItemCount() > position)
-			return mTvListAdapter.get(position).getString(Service.KEY_NAME);
+			return mTvListAdapter.get(position).getName();
 		if (MODE_RADIO.equals(mMode) && mRadioListAdapter.getItemCount() > position)
-			return mRadioListAdapter.get(position).getString(Service.KEY_NAME);
+			return mRadioListAdapter.get(position).getName();
 
 		return getString(R.string.not_available);
 	}
@@ -389,14 +388,11 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		int start = 0;
 		if (mBouquets != null && mBouquets.tv.size() > 0) {
 			start = 1;
-			for (ExtendedHashMap bouquet : mBouquets.tv)
+			for (Service bouquet : mBouquets.tv)
 				mTvListAdapter.add(bouquet);
 		}
 		for (int i = start; i < servicelist.length; i++) {
-			ExtendedHashMap bouquet = new ExtendedHashMap();
-			bouquet.put(Event.KEY_SERVICE_NAME, servicelist[i]);
-			bouquet.put(Event.KEY_SERVICE_REFERENCE, servicerefs[i]);
-			mTvListAdapter.add(bouquet);
+			mTvListAdapter.add(new Service(servicerefs[i], servicelist[i]));
 		}
 
 		mTvListAdapter.notifyDataSetChanged();
@@ -423,14 +419,11 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		int start = 0;
 		if (mBouquets != null && mBouquets.radio.size() > 0) {
 			start = 1;
-			for (ExtendedHashMap bouquet : mBouquets.radio)
+			for (Service bouquet : mBouquets.radio)
 				mRadioListAdapter.add(bouquet);
 		}
 		for (int i = start; i < servicelist.length; i++) {
-			ExtendedHashMap bouquet = new ExtendedHashMap();
-			bouquet.put(Event.KEY_SERVICE_NAME, servicelist[i]);
-			bouquet.put(Event.KEY_SERVICE_REFERENCE, servicerefs[i]);
-			mRadioListAdapter.add(bouquet);
+			mRadioListAdapter.add(new Service(servicerefs[i], servicelist[i]));
 		}
 
 		mRadioListAdapter.notifyDataSetChanged();

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -69,7 +69,6 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 
 	@Override
 	public void onGetLocationsAndTagsProgress(String title, String progress) {
-		// skip
 	}
 
 	@Override
@@ -266,7 +265,6 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		mMovielistAdapter = new MovieListAdapter(this);
 		mTimerListAdapter = new TimerListAdapter(this);
 
-		//selectedItemId = mTabLayout.getSelectedTabPosition()
 		if (MODE_MOVIES.equals(mMode)) {
 			mPager.setAdapter(mMovielistAdapter);
 		} else if (MODE_RADIO.equals(mMode)){

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -31,6 +31,8 @@ import net.reichholf.dreamdroid.asynctask.SimpleResultTask;
 import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IHttpBase;
+import net.reichholf.dreamdroid.enigma.EnigmaClient;
+import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Python;
@@ -43,6 +45,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ZapRequestHandler
 import net.reichholf.dreamdroid.loader.LoaderResult;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author sre
@@ -293,6 +296,16 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
 
     public SimpleHttpClient getHttpClient() {
         return mShc;
+    }
+
+    @NonNull
+    public List<Service> fetchServices(@NonNull List<NameValuePair> params) {
+        return fetchServices(mShc, params);
+    }
+
+    @NonNull
+    public static List<Service> fetchServices(@NonNull SimpleHttpClient shc, @NonNull List<NameValuePair> params) {
+        return EnigmaClient.getServicesBlocking(shc, params);
     }
 
     public void onLoadStarted() {

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -47,9 +47,6 @@ import net.reichholf.dreamdroid.loader.LoaderResult;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author sre
- */
 public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHandler, SetVolumeTask.SetVolumeTaskHandler {
     public static final int LOADER_DEFAULT_ID = 0;
     private Fragment mFragment;
@@ -86,7 +83,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         mSwipeRefreshLayout = view.findViewById(R.id.ptr_layout);
         if (mSwipeRefreshLayout != null) {
-            // Now setup the SwipeRefreshLayout
             mSwipeRefreshLayout.setOnRefreshListener((SwipeRefreshLayout.OnRefreshListener) mFragment);
         }
     }
@@ -134,7 +130,7 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
     }
 
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if(getAppCompatActivity() == null) //not attached to activity
+        if(getAppCompatActivity() == null)
             return false;
         if (PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity()).getBoolean("volume_control", false)) {
             switch (keyCode) {
@@ -161,11 +157,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
             mVolumeTask.cancel(true);
     }
 
-    /**
-     * Called after a Button has been clicked
-     *
-     * @param set value to set
-     */
     @SuppressWarnings("unchecked")
     private void onVolumeButtonClicked(String set) {
         ArrayList<NameValuePair> params = new ArrayList<>();
@@ -178,10 +169,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         mVolumeTask.execute(params);
     }
 
-    /**
-     * @param handler
-     * @param params
-     */
     @SuppressWarnings("unchecked")
     public void execSimpleResultTask(SimpleResultRequestHandler handler, ArrayList<NameValuePair> params) {
         if (mSimpleResultTask != null) {
@@ -214,10 +201,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         mShowToastOnSimpleResult = show;
     }
 
-    /**
-     * @param success
-     * @param volume
-     */
     public void onVolumeSet(boolean success, @NonNull ExtendedHashMap volume) {
         if (!mFragment.isAdded())
             return;
@@ -238,9 +221,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         showToast(text);
     }
 
-    /**
-     * @param toastText
-     */
     private void showToast(String toastText) {
         Toast toast = Toast.makeText(getAppCompatActivity(), toastText, Toast.LENGTH_LONG);
         toast.show();
@@ -258,18 +238,12 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         onLoadStarted();
     }
 
-    /**
-     * @param title
-     */
     public void finishProgress(String title) {
         getBaseFragment().setCurrentTitle(title);
         getAppCompatActivity().setTitle(title);
         onLoadFinished();
     }
 
-    /**
-     * @param event
-     */
     public void findSimilarEvents(@NonNull ExtendedHashMap event) {
         EpgSearchFragment f = new EpgSearchFragment();
         Bundle args = new Bundle();
@@ -312,7 +286,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         if (mIsReloading)
             return;
         mIsReloading = true;
-        //The SDK check is a workaround for broken pull-to-refresh with ActionBarCompat
         if (mSwipeRefreshLayout != null) {
             if (!mSwipeRefreshLayout.isRefreshing())
                 mSwipeRefreshLayout.setRefreshing(true);

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
@@ -20,13 +20,6 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.DeviceInfoRequest
 
 import java.util.ArrayList;
 
-/**
- * Check a profile for data-consistency and connectivity. Checks hostname, port,
- * connectivity & webinterface version
- * 
- * @author sre
- * 
- */
 public class CheckProfile {
 	public static final String LOG_TAG = "CheckProfile";
 
@@ -44,10 +37,6 @@ public class CheckProfile {
 	@NonNull
 	public static int[] CURRENT_VERSION = { 0, 0, 0 };
 
-	/**
-	 * @param profile
-	 * @return
-	 */
 	@NonNull
 	public static ExtendedHashMap checkProfile(@NonNull Profile profile, Context context) {
 		CURRENT_VERSION = new int[]{ 0, 0, 0 };
@@ -104,14 +93,16 @@ public class CheckProfile {
 								setError(checkResult, true, true, R.string.version_too_low);
 							}
 						} else {
-							// TODO Parser-Error
+							addEntry(resultList, R.string.connection, true, String.valueOf(host), R.string.get_content_error);
+							setError(checkResult, true, R.string.get_content_error);
 						}
 
 					} else if (shc.hasError()) {
 						addEntry(resultList, R.string.connection, true, String.valueOf(host), R.string.connection_error, shc.getErrorText(context));
 						setError(checkResult, true, R.string.connection_error, shc.getErrorText(context));
 					} else if (xml == null) {
-						// TODO Unexpected Error
+						addEntry(resultList, R.string.connection, true, String.valueOf(host), R.string.get_content_error);
+						setError(checkResult, true, R.string.get_content_error);
 					}
 				} else {
 					addEntry(resultList, R.string.port, true, String.valueOf(port), R.string.port_out_of_range);
@@ -158,13 +149,6 @@ public class CheckProfile {
 		return -1;
 	}
 
-	/**
-	 * @param resultList
-	 * @param checkTypeId
-	 * @param hasError
-	 * @param value
-	 * @param errorTextId
-	 */
 	private static void addEntry(@NonNull ArrayList<ExtendedHashMap> resultList, int checkTypeId, boolean hasError,
 								 String value, int errorTextId){
 		addEntry(resultList, checkTypeId, hasError, value, errorTextId, null);

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
@@ -71,7 +71,7 @@ public class CheckProfile {
 					addEntry(resultList, R.string.port, false, Integer.toString(port));
 					DeviceInfoRequestHandler dirh = new DeviceInfoRequestHandler();
 
-					SimpleHttpClient shc = SimpleHttpClient.getInstance();
+					SimpleHttpClient shc = SimpleHttpClient.getInstance(profile);
 					String xml = profile.getCachedDeviceInfo();
 					if(xml == null)
 						xml = dirh.get(shc);

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/ServiceParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/ServiceParserTest.java
@@ -1,0 +1,34 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ServiceParserTest {
+    @Test
+    public void parsesGetServicesFixtureIntoServiceValues() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/getservices.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        long started = System.nanoTime();
+        List<Service> services = ServiceParser.INSTANCE.parse(xml);
+        long elapsedNanos = System.nanoTime() - started;
+        System.out.println("ServiceParser.parse nanos=" + elapsedNanos);
+
+        assertEquals(3, services.size());
+        assertEquals(
+                "1:7:1:0:0:0:0:0:0:0:FROM BOUQUET \"userbouquet.favourites.tv\" ORDER BY bouquet",
+                services.get(0).getReference()
+        );
+        assertEquals("Favourites (TV)", services.get(0).getName());
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", services.get(1).getReference());
+        assertEquals("Das Erste HD", services.get(1).getName());
+        assertEquals("1:64:1:0:0:0:0:0:0:0:", services.get(2).getReference());
+        assertEquals("--------", services.get(2).getName());
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/ServiceParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/ServiceParserTest.java
@@ -31,4 +31,14 @@ public class ServiceParserTest {
         assertEquals("1:64:1:0:0:0:0:0:0:0:", services.get(2).getReference());
         assertEquals("--------", services.get(2).getName());
     }
+
+    @Test
+    public void emptyXmlYieldsNoServices() {
+        assertEquals(0, ServiceParser.INSTANCE.parse("").size());
+    }
+
+    @Test
+    public void malformedXmlYieldsNoServices() {
+        assertEquals(0, ServiceParser.INSTANCE.parse("<e2servicelist><e2service>").size());
+    }
 }

--- a/app/src/test/resources/web/getservices.xml
+++ b/app/src/test/resources/web/getservices.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2servicelist>
+	<e2service>
+		<e2servicereference>1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet</e2servicereference>
+		<e2servicename>Favourites (TV)</e2servicename>
+	</e2service>
+	<e2service>
+		<e2servicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2servicereference>
+		<e2servicename>Das Erste HD</e2servicename>
+	</e2service>
+	<e2service>
+		<e2servicereference>1:64:1:0:0:0:0:0:0:0:</e2servicereference>
+		<e2servicename>--------</e2servicename>
+	</e2service>
+</e2servicelist>


### PR DESCRIPTION
## Why

TV & Movies still loads bouquet lists as `ExtendedHashMap`. This change adds typed Enigma2 models and a coroutine client that wraps `SimpleHttpClient` and `URIStore`, then parses `/web/getservices` XML into `Service` values at that HTTP boundary.

## Scope

- `net.reichholf.dreamdroid.enigma` data classes for `Service`, `Event`, `Timer`, and `Movie`
- `ServiceParser` and `EnigmaClient.getServices`
- `HttpFragmentHelper.fetchServices` for the bouquet list path
- `GetBouquetListTask` and `ServiceListPager` store `Service` instead of `ExtendedHashMap` on that path
- `CheckProfile.checkProfile` passes the given `Profile` into `SimpleHttpClient.getInstance(profile)`
- Out of scope: OkHttp for `/web/*`, Zap and EPG map loaders, the legacy SQLite file, `versionCode`

## Tradeoffs

Kotlin stays at 1.6.21 with `kotlinx-coroutines-android` 1.6.4. OkHttp stays at 3.14.9. `Event`, `Timer`, and `Movie` types have no parsers yet.

## Blast Radius

Bouquet tabs on TV & Movies go through `EnigmaClient`. A failed fetch still shows the dedicated bouquet rows. Other list screens still use `ExtendedHashMap`. Check now talks to the profile you passed in, not only the current one.

## Verification

`.\gradlew.bat :app:testGoogleDebugUnitTest` parses the checked-in `/web/getservices.xml` fixture into three `Service` values. Live device lanes and review screenshots follow on this PR.
