### PR TITLE
fix(about): keep dialog body onSurface in night

### DIFF
--- a/app/src/net/reichholf/dreamdroid/ui/about/AboutScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/about/AboutScreen.kt
@@ -54,8 +54,16 @@ fun AboutScreen(
             .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Text(text = content.version, style = MaterialTheme.typography.bodyLarge)
-        Text(text = content.license, style = MaterialTheme.typography.bodyMedium)
+        Text(
+            text = content.version,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = content.license,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         SourceLinkText(sourceLink = content.sourceLink)
         TextButton(onClick = onLicensesClick) {
             Text(content.licensesLabel)

--- a/app/src/net/reichholf/dreamdroid/ui/theme/Theme.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/theme/Theme.kt
@@ -2,10 +2,12 @@ package net.reichholf.dreamdroid.ui.theme
 
 import android.content.Context
 import android.content.res.Configuration
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import net.reichholf.dreamdroid.DreamDroid
@@ -14,10 +16,12 @@ import net.reichholf.dreamdroid.R
 @Composable
 fun DreamDroidTheme(content: @Composable () -> Unit) {
     val dark = isDreamDroidDark(LocalContext.current)
-    MaterialTheme(
-        colorScheme = if (dark) dreamDroidDarkColorScheme() else dreamDroidLightColorScheme(),
-        content = content,
-    )
+    val scheme = if (dark) dreamDroidDarkColorScheme() else dreamDroidLightColorScheme()
+    MaterialTheme(colorScheme = scheme) {
+        // Dialog-hosted ComposeView inherits View contentColor (black in night). Override so
+        // Text() without an explicit color uses the DreamDroid scheme, not the XML dialog.
+        CompositionLocalProvider(LocalContentColor provides scheme.onSurface, content = content)
+    }
 }
 
 fun isDreamDroidDark(context: Context): Boolean {


### PR DESCRIPTION
## Summary
- About is Compose inside a Material night dialog. The dialog View injects black `contentColor`, so version and license `Text()` were black on the dark surface.
- `DreamDroidTheme` now provides `LocalContentColor` from the DreamDroid scheme, and About paints version/license with `onSurface`.

## Test plan
- [ ] Install googleDebug, open drawer, tap About (not Settings & About)
- [ ] Night theme: version, copyright, and GPL body are light on the dark dialog; source URL stays primary
- [ ] Day theme: body stays dark on the light dialog