### PR TITLE
test(about): prove night dialog colors on device

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# dreamDroid agent notes
+
+Phone Enigma2 remote. Rewrite trunk is `main`. Sources live in `app/src` and `app/res`, not `src/main`. Debug package is `net.reichholf.dreamdroid.debug`. Build with **JDK 17**.
+
+## Verify UI with instrumented tests
+
+Do not prove phone UI by tapping the emulator through `adb` / `verify-dreamdroid.py` in a loop. That path is slow and brittle (`About` matches `Settings & About`, Changelog contains `Profiles`, dumps miss color).
+
+Default proof for Compose and in-app UI:
+
+```bash
+./gradlew.bat :app:connectedGoogleDebugAndroidTest
+```
+
+Use `JAVA_HOME` pointing at JDK 17. Tests live in `app/androidTest/java`. Add Compose UI tests next to each new screen (`createComposeRule` / `createAndroidComposeRule`). If the UI is Compose inside an XML dialog or `ComposeView`, the test must host it that way — a naked `setContent { }` will not catch `LocalContentColor` leaks from the View theme.
+
+Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
+
+`verify-dreamdroid.py` is for a single look when you need a screenshot or a shell-only path that has no test yet. It is not the verification loop.
+
+## Other traps
+
+- `main` is the rewrite. Do not merge rewrite work into `master`.
+- AGP 8.2 `jlink` fails on JDK 21.
+- Two googleDebug processes cannot share one device.

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutDialogHostTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutDialogHostTest.kt
@@ -1,0 +1,81 @@
+package net.reichholf.dreamdroid.ui.about
+
+import android.view.ContextThemeWrapper
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.preference.PreferenceManager
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AboutDialogHostTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun contentColorIsOnSurfaceInsideNightAlertDialog() {
+        var localContent = Color.Unspecified
+        var onSurface = Color.Unspecified
+        val activity = composeRule.activity
+        composeRule.runOnUiThread {
+            val themed = ContextThemeWrapper(activity, R.style.Theme_DreamDroid_Night)
+            val composeView = ComposeView(themed).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+                setViewTreeLifecycleOwner(activity)
+                setViewTreeViewModelStoreOwner(activity)
+                setViewTreeSavedStateRegistryOwner(activity)
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                setContent {
+                    DreamDroidTheme {
+                        localContent = LocalContentColor.current
+                        onSurface = MaterialTheme.colorScheme.onSurface
+                        AboutScreen(content = sampleAboutContent(), onLicensesClick = {})
+                    }
+                }
+            }
+            MaterialAlertDialogBuilder(themed)
+                .setTitle(R.string.about)
+                .setView(composeView)
+                .show()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("1.15.460", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Licenses").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertEquals(onSurface, localContent)
+            assertTrue(
+                "night onSurface should be light, luminance=${onSurface.luminance()}",
+                onSurface.luminance() > 0.5f,
+            )
+        }
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutScreenTest.kt
@@ -1,9 +1,19 @@
 package net.reichholf.dreamdroid.ui.about
 
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -11,23 +21,49 @@ class AboutScreenTest {
     @get:Rule
     val composeRule = createComposeRule()
 
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
     @Test
     fun showsVersionSubstringAndLicensesButton() {
         composeRule.setContent {
             DreamDroidTheme {
-                AboutScreen(
-                    content = AboutContent(
-                        title = "About",
-                        version = "dreamDroid 1.15.460-debug",
-                        license = "GPLv3",
-                        sourceLink = "Source code available at: http://github.com/sreichholf/dreamDroid",
-                        licensesLabel = "Licenses",
-                    ),
-                    onLicensesClick = {},
-                )
+                AboutScreen(content = sampleAboutContent(), onLicensesClick = {})
             }
         }
         composeRule.onNodeWithText("1.15.460", substring = true).assertIsDisplayed()
         composeRule.onNodeWithText("Licenses").assertIsDisplayed()
     }
+
+    @Test
+    fun localContentColorMatchesOnSurfaceInNight() {
+        var localContent = Color.Unspecified
+        var onSurface = Color.Unspecified
+        composeRule.setContent {
+            DreamDroidTheme {
+                localContent = LocalContentColor.current
+                onSurface = MaterialTheme.colorScheme.onSurface
+                AboutScreen(content = sampleAboutContent(), onLicensesClick = {})
+            }
+        }
+        composeRule.runOnIdle {
+            assertEquals(onSurface, localContent)
+            assertTrue(
+                "night onSurface should be light, luminance=${onSurface.luminance()}",
+                onSurface.luminance() > 0.5f,
+            )
+        }
+    }
 }
+
+internal fun sampleAboutContent() = AboutContent(
+    title = "About",
+    version = "dreamDroid 1.15.460-debug",
+    license = "GPLv3",
+    sourceLink = "Source code available at: http://github.com/sreichholf/dreamDroid",
+    licensesLabel = "Licenses",
+)

--- a/app/androidTest/res/values/strings.xml
+++ b/app/androidTest/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name_debug">dreamDroid DBG</string>
+    <string name="app_name_tv_debug">dreamDroidTV DBG</string>
+</resources>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
     testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
## Summary
- Add `AGENTS.md`: prove phone UI with instrumented tests, not adb tap loops.
- About night colors: `AboutScreenTest` and `AboutDialogHostTest` assert `LocalContentColor` is light `onSurface` inside `DreamDroidTheme`, including a Material night AlertDialog host.
- Test APK needs `app_name_debug` strings so `connectedGoogleDebugAndroidTest` can link.

## Test plan
- [x] `./gradlew.bat :app:connectedGoogleDebugAndroidTest` on emulator-5554 (3 tests, BUILD SUCCESSFUL)