### PR TITLE
feat(profiles): show the profile list in Compose

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/profiles/ProfilesScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/profiles/ProfilesScreenTest.kt
@@ -1,0 +1,50 @@
+package net.reichholf.dreamdroid.ui.profiles
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ProfilesScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsDemoRowAndAddProfileFab() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                ProfilesScreen(
+                    profiles = listOf(
+                        ProfileListItem(
+                            id = 1,
+                            name = "Demo",
+                            host = "dreamdroid.org",
+                            active = true,
+                        ),
+                    ),
+                    addLabel = "Add Profile",
+                    onProfileClick = {},
+                    onProfileLongClick = {},
+                    onAddClick = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Demo").assertIsDisplayed()
+        composeRule.onNodeWithText("dreamdroid.org").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Add Profile").assertIsDisplayed()
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -144,7 +144,9 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 				setConnectionState(getString(R.string.ok), true);
 			}
 			mNavigationHelper.setAvailableFeatures();
-			if (getCurrentDetailFragment() == null) {
+			// First-start already navigated to Profiles. The fragment commit is still pending, so
+			// mDetailFragment can still be null here; do not overwrite Profiles with services.
+			if (!isFirstStart && getCurrentDetailFragment() == null) {
 				mNavigationHelper.navigateTo(R.id.menu_navigation_services);
 			}
 		}

--- a/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
@@ -1,5 +1,5 @@
 /* © 2010 Stephan Reichholf <stephan at reichholf dot net>
- * 
+ *
  * Licensed under the Create-Commons Attribution-Noncommercial-Share Alike 3.0 Unported
  * http://creativecommons.org/licenses/by-nc-sa/3.0/
  */
@@ -18,119 +18,101 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
-import androidx.recyclerview.widget.RecyclerView;
+import androidx.compose.ui.platform.ComposeView;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import net.reichholf.dreamdroid.DatabaseHelper;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
-import net.reichholf.dreamdroid.adapter.recyclerview.ProfileAdapter;
 import net.reichholf.dreamdroid.asynctask.DetectDevicesTask;
-import net.reichholf.dreamdroid.fragment.abs.BaseRecyclerFragment;
+import net.reichholf.dreamdroid.fragment.abs.BaseFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.IndeterminateProgress;
 import net.reichholf.dreamdroid.fragment.dialogs.PositiveNegativeDialog;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.room.AppDatabase;
-import net.reichholf.dreamdroid.widget.helper.ItemSelectionSupport;
+import net.reichholf.dreamdroid.ui.profiles.ProfileListItem;
+import net.reichholf.dreamdroid.ui.profiles.ProfilesListState;
+import net.reichholf.dreamdroid.ui.profiles.ProfilesListStateKt;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Shows a list of all connection profiles
  *
  * @author sre
  */
-public class ProfileListFragment extends BaseRecyclerFragment implements DetectDevicesTask.DetectDevicesTaskHandler {
+public class ProfileListFragment extends BaseFragment implements DetectDevicesTask.DetectDevicesTaskHandler {
 
 	private boolean mIsActionMode;
 	private boolean mIsActionModeRequired;
+	@Nullable
+	private ActionMode mActionMode;
 
 	private Profile mProfile;
 	private ArrayList<Profile> mProfiles;
-	private ArrayList<ExtendedHashMap> mProfileMapList;
+
 	@Nullable
 	private ArrayList<Profile> mDetectedProfiles;
 
-	@Nullable
-	private RecyclerView.Adapter mAdapter;
 	@Nullable
 	private DetectDevicesTask mDetectDevicesTask;
 
 	@Nullable
 	private IndeterminateProgress mProgress;
 
-	private int mCurrentPos;
+	private ProfilesListState mListState;
 
 	public static final String KEY_ACTIVE_PROFILE = "active_profile";
 
-	@Override
-	public void onDialogAction(int action, Object details, String dialogTag) {
-		switch (action) {
-			case Statics.ACTION_DELETE_CONFIRMED:
-				Profile.ProfileDao dao = AppDatabase.profiles(getContext());
-				dao.deleteProfile(mProfile);
-				showToast(getString(R.string.profile_deleted) + " '" + mProfile.getName() + "'");
-
-				// TODO Add error handling
-				reloadProfiles();
-				mProfile = Profile.getDefault();
-				mAdapter.notifyDataSetChanged();
-				break;
-		}
-	}
-
 	@NonNull
-	private ActionMode.Callback mActionModeCallback = new ActionMode.Callback() {
-
-		// Called when the action mode is created; startActionMode() was called
+	private final ActionMode.Callback mActionModeCallback = new ActionMode.Callback() {
 		@Override
 		public boolean onCreateActionMode(@NonNull ActionMode mode, Menu menu) {
-			// Inflate a menu resource providing context menu items
 			MenuInflater inflater = mode.getMenuInflater();
 			inflater.inflate(R.menu.profilelist_context, menu);
 			mIsActionMode = true;
 			mIsActionModeRequired = false;
-			mSelectionSupport.setChoiceMode(ItemSelectionSupport.ChoiceMode.SINGLE);
 			return true;
 		}
 
-		// Called each time the action mode is shown. Always called after onCreateActionMode, but
-		// may be called multiple times if the mode is invalidated.
 		@Override
 		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
 			return true;
 		}
 
-		// Called when the user selects a contextual menu item
 		@Override
 		public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
-			mode.finish(); // Action picked, so close the CAB
+			mode.finish();
 			return onItemClicked(item.getItemId());
 		}
 
-		// Called when the user exits the action mode
 		@Override
 		public void onDestroyActionMode(ActionMode mode) {
 			mIsActionMode = false;
+			mActionMode = null;
 			if (mIsActionModeRequired)
 				return;
-			final RecyclerView rv = getRecyclerView();
-			mSelectionSupport.setItemChecked(mSelectionSupport.getCheckedItemPosition(), false);
-			rv.post(() -> mSelectionSupport.setChoiceMode(ItemSelectionSupport.ChoiceMode.NONE)
-
-			);
 		}
 	};
+
+	@Override
+	public void onDialogAction(int action, Object details, String dialogTag) {
+		if (action == Statics.ACTION_DELETE_CONFIRMED) {
+			Profile.ProfileDao dao = AppDatabase.profiles(getContext());
+			dao.deleteProfile(mProfile);
+			showToast(getString(R.string.profile_deleted) + " '" + mProfile.getName() + "'");
+			reloadProfiles();
+			mProfile = Profile.getDefault();
+		}
+	}
 
 	private void detectDevices() {
 		if (mDetectedProfiles == null) {
@@ -162,15 +144,12 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 	private void addAllDetectedDevices() {
 		Profile.ProfileDao dao = AppDatabase.profiles(getContext());
 		for (Profile p : mDetectedProfiles) {
-			p.setId ( dao.addProfile(p) );
+			p.setId(dao.addProfile(p));
 			showToast(getText(R.string.profile_added) + " '" + p.getName() + "'");
 		}
 		reloadProfiles();
 	}
 
-	/**
-	 * @param profiles A list of profiles for auto-discovered dreamboxes
-	 */
 	@Override
 	public void onDevicesDetected(@NonNull ArrayList<Profile> profiles) {
 		mProgress = (IndeterminateProgress) getFragmentManager().findFragmentByTag("dialog_devicesearch_indeterminate");
@@ -199,14 +178,11 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 					mDetectedProfiles = null;
 					detectDevices();
 				})
-				.setNegativeButton(R.string.add_all, (dialog, which) -> {
-					addAllDetectedDevices();
-				});
+				.setNegativeButton(R.string.add_all, (dialog, which) -> addAllDetectedDevices());
 
 		} else {
 			builder.setMessage(R.string.autodiscovery_failed);
 			builder.setNeutralButton(android.R.string.ok, (dialog, which) -> {
-
 			});
 		}
 		builder.show();
@@ -214,32 +190,40 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		mCardListStyle = true;
-		mHasFabMain = true;
-		mEnableReload = false;
+		mHasFabMain = false;
 		super.onCreate(savedInstanceState);
 		setHasOptionsMenu(true);
-		initTitle(getString(R.string.profiles));
-
-		mCurrentPos = -1;
-
+		initTitles(getString(R.string.profiles));
 		mProfiles = new ArrayList<>();
-		mProfileMapList = new ArrayList<>();
 		mProfile = Profile.getDefault();
+		mListState = new ProfilesListState();
 	}
 
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		View view = inflater.inflate(R.layout.card_recycler_content, container, false);
-		registerFab(R.id.fab_main, R.string.profile_add, R.drawable.ic_action_fab_add, v -> createProfile());
-		return view;
-	}
-
-	@Override
-	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
-		mAdapter = new ProfileAdapter(getActivity(), mProfileMapList);
-		getRecyclerView().setAdapter(mAdapter);
+		ComposeView composeView = new ComposeView(requireContext());
+		composeView.setLayoutParams(new ViewGroup.LayoutParams(
+			ViewGroup.LayoutParams.MATCH_PARENT,
+			ViewGroup.LayoutParams.MATCH_PARENT
+		));
+		ProfilesListStateKt.bindProfilesScreen(
+			composeView,
+			mListState,
+			getString(R.string.profile_add),
+			item -> {
+				onProfileRowClick(item);
+				return kotlin.Unit.INSTANCE;
+			},
+			item -> {
+				onProfileRowLongClick(item);
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				createProfile();
+				return kotlin.Unit.INSTANCE;
+			}
+		);
+		return composeView;
 	}
 
 	@Override
@@ -262,63 +246,42 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 		super.onPause();
 	}
 
-	@Override
-	public void onItemClick(RecyclerView parent, View view, int position, long id) {
-		mProfile = mProfiles.get(position);
+	private void onProfileRowClick(ProfileListItem item) {
+		selectProfile(item);
 		if (mIsActionMode) {
-			mSelectionSupport.setItemChecked(position, true);
 			return;
 		}
 		activateProfile();
 	}
 
-	@Override
-	public boolean onItemLongClick(RecyclerView parent, View view, int position, long id) {
-		mProfile = mProfiles.get(position);
-		getAppCompatActivity().startSupportActionMode(mActionModeCallback);
-		mSelectionSupport.setItemChecked(position, true);
-		return true;
+	private void onProfileRowLongClick(ProfileListItem item) {
+		selectProfile(item);
+		mActionMode = getAppCompatActivity().startSupportActionMode(mActionModeCallback);
 	}
 
-	@Override
-	public void onRefresh() {
-		reloadProfiles();
+	private void selectProfile(ProfileListItem item) {
+		for (Profile p : mProfiles) {
+			if (p.getId() != null && p.getId() == item.getId()) {
+				mProfile = p;
+				return;
+			}
+		}
 	}
 
 	private void reloadProfiles() {
 		Profile.ProfileDao dao = AppDatabase.profiles(getContext());
 		mProfiles.clear();
-		mProfileMapList.clear();
 		mProfiles.addAll(dao.getProfiles());
 
 		SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity());
-
+		int activeProfileId = sp.getInt(DreamDroid.CURRENT_PROFILE, -1);
+		List<ProfileListItem> rows = new ArrayList<>();
 		for (Profile m : mProfiles) {
-			boolean isActive = false;
-			int activeProfileId = sp.getInt(DreamDroid.CURRENT_PROFILE, -1);
-			if (activeProfileId > -1 && activeProfileId == m.getId()) {
-				isActive = true;
-			}
-			ExtendedHashMap map = new ExtendedHashMap();
-			map.put(DatabaseHelper.KEY_PROFILE_PROFILE, m.getName());
-			map.put(DatabaseHelper.KEY_PROFILE_HOST, m.getHost());
-			map.put(KEY_ACTIVE_PROFILE, isActive);
-			mProfileMapList.add(map);
+			boolean isActive = activeProfileId > -1 && m.getId() != null && activeProfileId == m.getId();
+			int id = m.getId() == null ? 0 : m.getId();
+			rows.add(new ProfileListItem(id, m.getName(), m.getHost(), isActive));
 		}
-		mAdapter.notifyDataSetChanged();
-		mSwipeRefreshLayout.setRefreshing(false);
-	}
-
-	protected boolean onListItemLongClick(AdapterView<?> a, View v, int position, long id) {
-		mCurrentPos = position;
-		startActionMode();
-		return true;
-	}
-
-	protected void startActionMode() {
-		mProfile = mProfiles.get(mCurrentPos);
-		mActionMode = getAppCompatActivity().startSupportActionMode(mActionModeCallback);
-		mSelectionSupport.setItemChecked(mCurrentPos, true);
+		mListState.replaceAll(rows);
 	}
 
 	@Override
@@ -328,43 +291,34 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 
 	@Override
 	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-		return onItemClicked(item.getItemId());
+		if (onItemClicked(item.getItemId())) {
+			return true;
+		}
+		return super.onOptionsItemSelected(item);
 	}
 
-	/**
-	 * @param id The id of the selected menu item (<code>MENU_*</code> statics)
-	 * @return true if click was handled, false otherwise
-	 */
 	protected boolean onItemClicked(int id) {
 		switch (id) {
 			case (Statics.ITEM_ADD_PROFILE):
 				createProfile();
-				break;
+				return true;
 			case Statics.ITEM_DETECT_DEVICES:
 				detectDevices();
-				break;
+				return true;
 			case Statics.ITEM_EDIT:
 				editProfile();
-				break;
+				return true;
 			case Statics.ITEM_DELETE:
 				getMultiPaneHandler().showDialogFragment(
-						PositiveNegativeDialog.newInstance(mProfile.getName(), R.string.confirm_delete_profile,
-								android.R.string.yes, Statics.ACTION_DELETE_CONFIRMED, android.R.string.no,
-								Statics.ACTION_NONE), "dialog_delete_profile_confirm");
-				break;
+					PositiveNegativeDialog.newInstance(mProfile.getName(), R.string.confirm_delete_profile,
+						android.R.string.yes, Statics.ACTION_DELETE_CONFIRMED, android.R.string.no,
+						Statics.ACTION_NONE), "dialog_delete_profile_confirm");
+				return true;
 			default:
 				return false;
 		}
-
-		return true;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see android.support.v4.app.Fragment#onActivityResult(int, int,
-	 * android.content.Intent)
-	 */
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
 		if (requestCode == Statics.REQUEST_EDIT_PROFILE) {
@@ -374,9 +328,6 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 		}
 	}
 
-	/**
-	 * Activates the selected profile
-	 */
 	private void activateProfile() {
 		if (DreamDroid.setCurrentProfile(getAppCompatActivity(), mProfile.getId(), true)) {
 			showToast(getText(R.string.profile_activated) + " '" + mProfile.getName() + "'");
@@ -386,25 +337,14 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 		reloadProfiles();
 	}
 
-	/**
-	 * Opens a <code>ProfileEditActivity</code> for the selected profile
-	 */
 	private void editProfile() {
 		openProfileEditActivity(getActivity(), mProfile);
 	}
 
-	/**
-	 * Opens a <code>ProfileEditActivity</code> for creating a new profile
-	 */
 	private void createProfile() {
 		openProfileEditActivity(getActivity(), null);
 	}
 
-	/**
-	 * Opens a <code>ProfileEditActivity</code>.
-	 * @param activity The calling activity
-	 * @param profile The selected profile that should be edited, null if a new one should be created instead.
-	 */
 	public static void openProfileEditActivity(@NonNull Activity activity, @Nullable Profile profile) {
 		ExtendedHashMap data = new ExtendedHashMap();
 		data.put("action", Intent.ACTION_EDIT);
@@ -418,16 +358,6 @@ public class ProfileListFragment extends BaseRecyclerFragment implements DetectD
 		intent.putExtra("titleResource", profile == null ? R.string.profile_add : R.string.edit_profile);
 		intent.putExtra("serializableData", data);
 		activity.startActivityForResult(intent, Statics.REQUEST_EDIT_PROFILE);
-	}
-
-	/**
-	 * Shows a toast
-	 *
-	 * @param text The text to show as toast
-	 */
-	protected void showToast(String text) {
-		Toast toast = Toast.makeText(getAppCompatActivity(), text, Toast.LENGTH_LONG);
-		toast.show();
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileListItem.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileListItem.kt
@@ -1,0 +1,8 @@
+package net.reichholf.dreamdroid.ui.profiles
+
+data class ProfileListItem(
+    val id: Int,
+    val name: String,
+    val host: String,
+    val active: Boolean,
+)

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesListState.kt
@@ -1,0 +1,37 @@
+package net.reichholf.dreamdroid.ui.profiles
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class ProfilesListState(initial: List<ProfileListItem> = emptyList()) {
+    val items: SnapshotStateList<ProfileListItem> = initial.toMutableStateList()
+
+    fun replaceAll(next: List<ProfileListItem>) {
+        items.clear()
+        items.addAll(next)
+    }
+}
+
+fun ComposeView.bindProfilesScreen(
+    state: ProfilesListState,
+    addLabel: String,
+    onProfileClick: (ProfileListItem) -> Unit,
+    onProfileLongClick: (ProfileListItem) -> Unit,
+    onAddClick: () -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            ProfilesScreen(
+                profiles = state.items,
+                addLabel = addLabel,
+                onProfileClick = onProfileClick,
+                onProfileLongClick = onProfileLongClick,
+                onAddClick = onAddClick,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
@@ -1,0 +1,110 @@
+package net.reichholf.dreamdroid.ui.profiles
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import net.reichholf.dreamdroid.R
+
+@Composable
+fun ProfilesScreen(
+    profiles: List<ProfileListItem>,
+    addLabel: String,
+    onProfileClick: (ProfileListItem) -> Unit,
+    onProfileLongClick: (ProfileListItem) -> Unit,
+    onAddClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddClick) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_action_fab_add),
+                    contentDescription = addLabel,
+                )
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+        ) {
+            items(profiles, key = { it.id }) { profile ->
+                ProfileRow(
+                    profile = profile,
+                    onClick = { onProfileClick(profile) },
+                    onLongClick = { onProfileLongClick(profile) },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ProfileRow(
+    profile: ProfileListItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (profile.active) {
+                Box(
+                    Modifier
+                        .width(4.dp)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.colorScheme.primary),
+                )
+            }
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                    text = profile.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = profile.host,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Phone Profiles is Compose: list from Room (`Demo` row, active marker) plus an Add Profile FAB. Autodiscovery, edit, and delete stay on the fragment.
- First-start no longer races `navigateTo(Profiles)` then `navigateTo(services)` while `mDetailFragment` is still null after `commit()`.
- `ProfilesScreenTest` covers the Demo row and Add Profile FAB.

## Test plan
- [x] `./gradlew.bat :app:connectedGoogleDebugAndroidTest` (4 tests, BUILD SUCCESSFUL)
- [ ] Clear debug data, dismiss Changelog, confirm Profiles shows `Demo` and Add Profile (not TV & Movies)
- [ ] FAB opens add-profile form (`Profile name`, `Hostname or IP`)
- [ ] Drawer profile header still opens Profiles
- [ ] Overflow still has Dreambox Autodiscovery