### PR TITLE
feat(services): host TV and Movies destinations in Compose

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/TvMoviesScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/TvMoviesScreenTest.kt
@@ -1,0 +1,46 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TvMoviesScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsDestinationsAndFakeBouquets() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                TvMoviesScreen(
+                    selected = TvMoviesDestination.TV,
+                    rows = listOf("Favourites (TV)", "All Services"),
+                    selectedRow = 0,
+                    error = null,
+                    onDestinationSelected = {},
+                    onRowSelected = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("TV").assertIsDisplayed()
+        composeRule.onNodeWithText("Radio").assertIsDisplayed()
+        composeRule.onNodeWithText("Movies").assertIsDisplayed()
+        composeRule.onNodeWithText("Timer").assertIsDisplayed()
+        composeRule.onNodeWithText("Favourites (TV)").assertIsDisplayed()
+        composeRule.onNodeWithText("All Services").assertIsDisplayed()
+    }
+}

--- a/app/res/layout/service_list_pager.xml
+++ b/app/res/layout/service_list_pager.xml
@@ -1,21 +1,22 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.tabs.TabLayout
-        android:background="?attr/colorOnSurfaceInverse"
-        android:id="@+id/tab_layout"
-        app:tabMode="scrollable"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/tv_movies_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1">
-    </androidx.viewpager2.widget.ViewPager2>
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/tv_movies_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -3,21 +3,17 @@ package net.reichholf.dreamdroid.fragment;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.evernote.android.state.State;
-import com.google.android.material.navigation.NavigationBarView;
-import com.google.android.material.navigationrail.NavigationRailView;
-import com.google.android.material.tabs.TabLayout;
-import com.google.android.material.tabs.TabLayoutMediator;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
@@ -26,6 +22,9 @@ import net.reichholf.dreamdroid.asynctask.GetLocationsAndTagsTask;
 import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
 import net.reichholf.dreamdroid.helpers.enigma2.Event;
+import net.reichholf.dreamdroid.ui.services.TvMoviesDestination;
+import net.reichholf.dreamdroid.ui.services.TvMoviesHubState;
+import net.reichholf.dreamdroid.ui.services.TvMoviesHubStateKt;
 
 import java.util.ArrayList;
 
@@ -55,14 +54,9 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 	MovieListAdapter mMovielistAdapter;
 	TimerListAdapter mTimerListAdapter;
 
-	NavigationBarView mNavigation;
-	TabLayout mTabLayout;
-	@Nullable
-	TabLayoutMediator mTabLayoutMediator;
+	TvMoviesHubState mHubState;
 	GetBouquetListTask mBouquetListTask;
 	GetLocationsAndTagsTask mLocationsAndTagsTask;
-
-	int mSelectedItemId;
 
 	@Nullable
 	private GetBouquetListTask.Bouquets mBouquets;
@@ -200,6 +194,7 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		super.onCreate(savedInstanceState);
 		mHasFabReload = false;
 		mBouquets = null;
+		mHubState = new TvMoviesHubState();
 		if (mMode == null)
 			mMode = MODE_TV;
 	}
@@ -214,48 +209,40 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 
-		mNavigation = getAppCompatActivity().findViewById(R.id.bottom_navigation);
-		mNavigation.setVisibility(View.VISIBLE);
-		mNavigation.getMenu().clear();
-		mNavigation.inflateMenu(R.menu.bottom_navigation_services);
-		mNavigation.setOnItemSelectedListener(item -> {
-			onItemSelected(item);
-			return true;
+		View bottomNav = getAppCompatActivity().findViewById(R.id.bottom_navigation);
+		if (bottomNav != null)
+			bottomNav.setVisibility(View.GONE);
+
+		ComposeView header = view.findViewById(R.id.tv_movies_header);
+		ComposeView nav = view.findViewById(R.id.tv_movies_nav);
+		TvMoviesHubStateKt.bindTvMoviesHeader(header, mHubState, index -> {
+			if (mPager.getAdapter() != null && index >= 0 && index < mPager.getAdapter().getItemCount())
+				mPager.setCurrentItem(index, false);
+			return kotlin.Unit.INSTANCE;
+		});
+		TvMoviesHubStateKt.bindTvMoviesDestinationBar(nav, mHubState, dest -> {
+			onDestinationSelected(dest);
+			return kotlin.Unit.INSTANCE;
 		});
 
-		mTabLayout = getView().findViewById(R.id.tab_layout);
-		mTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
-			@Override
-			public void onTabSelected(TabLayout.Tab tab) {
-			}
-
-			@Override
-			public void onTabUnselected(TabLayout.Tab tab) {
-			}
-
-			@Override
-			public void onTabReselected(TabLayout.Tab tab) {
-				if (mMode.equals(MODE_TV) || mMode.equals(MODE_RADIO)) {
-					ServiceListPageFragment f = (ServiceListPageFragment) getChildFragmentManager().findFragmentByTag("f" + mPager.getCurrentItem());
-					f.upOrReload();
-				}
-			}
-		});
-
-		mPager = getView().findViewById(R.id.viewPager);
+		mPager = view.findViewById(R.id.viewPager);
 		mPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
 			@Override
 			public void onPageSelected(int position) {
 				super.onPageSelected(position);
+				mHubState.setSelectedRow(position);
 				switch(mMode) {
 					case MODE_TV:
-						mCurrentTv = mTvListAdapter.get(position).getReference();
+						if (mTvListAdapter.getItemCount() > position)
+							mCurrentTv = mTvListAdapter.get(position).getReference();
 						break;
 					case MODE_RADIO:
-						mCurrentRadio = mRadioListAdapter.get(position).getReference();
+						if (mRadioListAdapter.getItemCount() > position)
+							mCurrentRadio = mRadioListAdapter.get(position).getReference();
 						break;
 					case MODE_MOVIES:
-						mCurrentMovie = mMovielistAdapter.get(position);
+						if (mMovielistAdapter.getItemCount() > position)
+							mCurrentMovie = mMovielistAdapter.get(position);
 						break;
 				}
 			}
@@ -267,16 +254,18 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 
 		if (MODE_MOVIES.equals(mMode)) {
 			mPager.setAdapter(mMovielistAdapter);
+			mHubState.setSelected(TvMoviesDestination.MOVIES);
 		} else if (MODE_RADIO.equals(mMode)){
 			mPager.setAdapter(mRadioListAdapter);
+			mHubState.setSelected(TvMoviesDestination.RADIO);
 		} else if (MODE_TIMER.equals(mMode)) {
 			mPager.setAdapter(mTimerListAdapter);
+			mHubState.setSelected(TvMoviesDestination.TIMER);
 		} else {
 			mPager.setAdapter(mTvListAdapter);
+			mHubState.setSelected(TvMoviesDestination.TV);
 		}
 
-		if (mMode != MODE_TIMER)
-			attachTabLayoutMediator();
 		if (mBouquetListTask != null) {
 			mBouquetListTask.cancel(true);
 		}
@@ -295,7 +284,9 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		super.onPause();
 		if (mMode.equals(MODE_TIMER))
 			mPager.setAdapter(null);
-		mNavigation.setVisibility(View.GONE);
+		View bottomNav = getAppCompatActivity().findViewById(R.id.bottom_navigation);
+		if (bottomNav != null)
+			bottomNav.setVisibility(View.GONE);
 	}
 
 	@Override
@@ -303,7 +294,9 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		super.onResume();
 		if (mMode.equals(MODE_TIMER))
 			mPager.setAdapter(mTimerListAdapter);
-		mNavigation.setVisibility(View.VISIBLE);
+		View bottomNav = getAppCompatActivity().findViewById(R.id.bottom_navigation);
+		if (bottomNav != null)
+			bottomNav.setVisibility(View.GONE);
 	}
 
 	@Override
@@ -319,6 +312,10 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 	@Override
 	public void onBouquetListReady(boolean result, GetBouquetListTask.Bouquets bouquets, String errorText) {
 		mBouquets = bouquets;
+		if (errorText != null && !errorText.isEmpty())
+			mHubState.setError(errorText);
+		else
+			mHubState.setError(null);
 		if (mMode.equals(MODE_TV))
 			onTvSelected();
 		else if (mMode.equals(MODE_RADIO))
@@ -329,20 +326,20 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			onTimerSelected();
 	}
 
-	protected void attachTabLayoutMediator() {
-		if (mTabLayout.getVisibility() != View.VISIBLE)
-			mTabLayout.setVisibility(View.VISIBLE);
-		detachTabLayoutMediator();
-		mTabLayoutMediator = new TabLayoutMediator(mTabLayout, mPager,
-				(tab, position) -> tab.setText(getTabText(position))
-		);
-		mTabLayoutMediator.attach();
-	}
-
-	protected void detachTabLayoutMediator() {
-		if (mTabLayoutMediator != null)
-			mTabLayoutMediator.detach();
-		mTabLayoutMediator = null;
+	protected void publishHubRows() {
+		ArrayList<String> rows = new ArrayList<>();
+		int count = 0;
+		if (MODE_MOVIES.equals(mMode))
+			count = mMovielistAdapter.getItemCount();
+		else if (MODE_TV.equals(mMode))
+			count = mTvListAdapter.getItemCount();
+		else if (MODE_RADIO.equals(mMode))
+			count = mRadioListAdapter.getItemCount();
+		for (int i = 0; i < count; i++)
+			rows.add(getTabText(i));
+		mHubState.setRows(rows);
+		if (mPager.getAdapter() != null)
+			mHubState.setSelectedRow(mPager.getCurrentItem());
 	}
 
 	@Nullable
@@ -353,25 +350,21 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			return mTvListAdapter.get(position).getName();
 		if (MODE_RADIO.equals(mMode) && mRadioListAdapter.getItemCount() > position)
 			return mRadioListAdapter.get(position).getName();
-
 		return getString(R.string.not_available);
 	}
 
-	public void onItemSelected(@NonNull MenuItem item) {
-		if (item.getItemId() == mSelectedItemId)
-			return;
-		mSelectedItemId = item.getItemId();
-		switch (item.getItemId()) {
-			case R.id.menu_tv:
+	public void onDestinationSelected(@NonNull TvMoviesDestination dest) {
+		switch (dest) {
+			case TV:
 				onTvSelected();
 				break;
-			case R.id.menu_radio:
+			case RADIO:
 				onRadioSelected();
 				break;
-			case R.id.menu_movie:
+			case MOVIES:
 				onMoviesSelected();
 				break;
-			case R.id.menu_timer:
+			case TIMER:
 				onTimerSelected();
 				break;
 		}
@@ -379,8 +372,8 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 
 	public void onTvSelected() {
 		mMode = MODE_TV;
+		mHubState.setSelected(TvMoviesDestination.TV);
 		mTvListAdapter.clear();
-		detachTabLayoutMediator();
 		String[] servicelist = getResources().getStringArray(R.array.servicelist_dedicated);
 		String[] servicerefs = getResources().getStringArray(R.array.servicerefstv);
 		int start = 0;
@@ -404,14 +397,13 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			mPager.setCurrentItem(idx);
 		else
 			mPager.setCurrentItem(0);
-
-		attachTabLayoutMediator();
+		publishHubRows();
 	}
 
 	public void onRadioSelected() {
 		mMode = MODE_RADIO;
+		mHubState.setSelected(TvMoviesDestination.RADIO);
 		mRadioListAdapter.clear();
-		detachTabLayoutMediator();
 		String[] servicelist = getResources().getStringArray(R.array.servicelist_dedicated);
 		String[] servicerefs = getResources().getStringArray(R.array.servicerefsradio);
 		int start = 0;
@@ -437,16 +429,15 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 		} else {
 			mPager.setCurrentItem(0);
 		}
-
-		attachTabLayoutMediator();
+		publishHubRows();
 	}
 
 	public void onMoviesSelected() {
 		mMode = MODE_MOVIES;
-		detachTabLayoutMediator();
+		mHubState.setSelected(TvMoviesDestination.MOVIES);
 		if (DreamDroid.getLocations().size() == 0) {
 			showToast(getString(R.string.loading));
-			attachTabLayoutMediator();
+			publishHubRows();
 			return;
 		}
 		mMovielistAdapter.clear();
@@ -464,18 +455,13 @@ public class ServiceListPager extends BaseHttpFragment implements GetBouquetList
 			mPager.setCurrentItem(idx);
 		else
 			mPager.setCurrentItem(0);
-
-		attachTabLayoutMediator();
+		publishHubRows();
 	}
 
 	public void onTimerSelected() {
 		mMode = MODE_TIMER;
-		detachTabLayoutMediator();
-		if (mNavigation instanceof NavigationRailView)
-			mTabLayout.removeAllTabs();
-		else
-			mTabLayout.setVisibility(View.GONE);
-
+		mHubState.setSelected(TvMoviesDestination.TIMER);
+		mHubState.setRows(new ArrayList<>());
 		mPager.setAdapter(mTimerListAdapter);
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesDestination.kt
@@ -1,0 +1,8 @@
+package net.reichholf.dreamdroid.ui.services
+
+enum class TvMoviesDestination {
+    TV,
+    RADIO,
+    MOVIES,
+    TIMER,
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesHubState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesHubState.kt
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class TvMoviesHubState {
+    var selected by mutableStateOf(TvMoviesDestination.TV)
+    var rows by mutableStateOf(listOf<String>())
+    var selectedRow by mutableIntStateOf(0)
+    var error by mutableStateOf<String?>(null)
+}
+
+fun ComposeView.bindTvMoviesHeader(state: TvMoviesHubState, onRowSelected: (Int) -> Unit) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            TvMoviesHeader(
+                rows = state.rows,
+                selectedRow = state.selectedRow,
+                error = state.error,
+                onRowSelected = onRowSelected,
+            )
+        }
+    }
+}
+
+fun ComposeView.bindTvMoviesDestinationBar(
+    state: TvMoviesHubState,
+    onDestinationSelected: (TvMoviesDestination) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            TvMoviesDestinationBar(
+                selected = state.selected,
+                onDestinationSelected = onDestinationSelected,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesScreen.kt
@@ -1,0 +1,117 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import net.reichholf.dreamdroid.R
+
+@Composable
+fun TvMoviesScreen(
+    selected: TvMoviesDestination,
+    rows: List<String>,
+    selectedRow: Int,
+    error: String?,
+    onDestinationSelected: (TvMoviesDestination) -> Unit,
+    onRowSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.fillMaxWidth()) {
+        TvMoviesHeader(
+            rows = rows,
+            selectedRow = selectedRow,
+            error = error,
+            onRowSelected = onRowSelected,
+        )
+        TvMoviesDestinationBar(
+            selected = selected,
+            onDestinationSelected = onDestinationSelected,
+        )
+    }
+}
+
+@Composable
+fun TvMoviesHeader(
+    rows: List<String>,
+    selectedRow: Int,
+    error: String?,
+    onRowSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.fillMaxWidth()) {
+        if (!error.isNullOrBlank()) {
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        if (rows.isNotEmpty()) {
+            val tabIndex = selectedRow.coerceIn(0, rows.lastIndex)
+            ScrollableTabRow(selectedTabIndex = tabIndex) {
+                rows.forEachIndexed { index, title ->
+                    Tab(
+                        selected = index == tabIndex,
+                        onClick = { onRowSelected(index) },
+                        text = { Text(title) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TvMoviesDestinationBar(
+    selected: TvMoviesDestination,
+    onDestinationSelected: (TvMoviesDestination) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    NavigationBar(modifier = modifier.fillMaxWidth()) {
+        TvMoviesDestination.entries.forEach { dest ->
+            NavigationBarItem(
+                selected = dest == selected,
+                onClick = { onDestinationSelected(dest) },
+                icon = {
+                    Icon(
+                        painter = painterResource(destinationIcon(dest)),
+                        contentDescription = destinationLabel(dest),
+                    )
+                },
+                label = { Text(destinationLabel(dest)) },
+            )
+        }
+    }
+}
+
+private fun destinationIcon(dest: TvMoviesDestination): Int {
+    return when (dest) {
+        TvMoviesDestination.TV -> R.drawable.ic_menu_tv
+        TvMoviesDestination.RADIO -> R.drawable.ic_menu_radio
+        TvMoviesDestination.MOVIES -> R.drawable.ic_menu_movie
+        TvMoviesDestination.TIMER -> R.drawable.ic_menu_timer
+    }
+}
+
+@Composable
+private fun destinationLabel(dest: TvMoviesDestination): String {
+    val id = when (dest) {
+        TvMoviesDestination.TV -> R.string.tv
+        TvMoviesDestination.RADIO -> R.string.radio
+        TvMoviesDestination.MOVIES -> R.string.movies
+        TvMoviesDestination.TIMER -> R.string.timer
+    }
+    return stringResource(id)
+}


### PR DESCRIPTION
## Summary
- TV & Movies hub chrome is Compose: destinations `TV`, `Radio`, `Movies`, `Timer`, plus bouquet/location tabs.
- Connection errors from the typed bouquet fetch show in the hub instead of a blank strip.
- ViewPager pages (service list, movies, timers) stay; lists still come from `EnigmaClient`.

## Test plan
- [x] `./gradlew.bat :app:connectedGoogleDebugAndroidTest` (5 tests, BUILD SUCCESSFUL)
- [ ] Drawer TV & Movies shows Compose TV/Radio/Movies/Timer
- [ ] With a box, a bouquet or row is visible; without, error text is visible
- [ ] Profiles and About still open from the drawer