### PR TITLE
feat(services): show TV, Movies, and Timer rows in Compose

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/MovieListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/MovieListScreenTest.kt
@@ -1,0 +1,48 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class MovieListScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsMovieTitleAndService() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                MovieListScreen(
+                    items = listOf(
+                        MovieListItem(
+                            index = 0,
+                            title = "Recorded film",
+                            serviceName = "ZDF",
+                            fileSize = "1.2 GB",
+                            time = "01.01.2026",
+                            length = "90",
+                        ),
+                    ),
+                    onItemClick = {},
+                    onItemLongClick = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Recorded film").assertIsDisplayed()
+        composeRule.onNodeWithText("ZDF").assertIsDisplayed()
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
@@ -1,0 +1,55 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ServiceListScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsChannelAndNowNext() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                ServiceListScreen(
+                    items = listOf(
+                        ServiceListItem(
+                            index = 0,
+                            reference = "1:0:1:1:1:1:1:0:0:0:",
+                            name = "ARD",
+                            kind = ServiceRowKind.CHANNEL,
+                            nowTitle = "Tagesschau",
+                            nowStart = "20:00",
+                            nowDuration = "15",
+                            nextTitle = "Wetter",
+                            nextStart = "20:15",
+                            nextDuration = "5",
+                            progressMax = 15,
+                            progress = 3,
+                        ),
+                    ),
+                    onItemClick = {},
+                    onItemLongClick = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("ARD").assertIsDisplayed()
+        composeRule.onNodeWithText("20:00  Tagesschau  15").assertIsDisplayed()
+        composeRule.onNodeWithText("20:15  Wetter  5").assertIsDisplayed()
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/TimerListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/TimerListScreenTest.kt
@@ -1,0 +1,51 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TimerListScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsTimerNameAndService() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                TimerListScreen(
+                    items = listOf(
+                        TimerListItem(
+                            index = 0,
+                            name = "Evening news",
+                            serviceName = "ARD",
+                            begin = "20:00",
+                            end = "20:15",
+                            action = "Record",
+                            state = "Waiting",
+                            stateColor = 0xFF888888.toInt(),
+                        ),
+                    ),
+                    onItemClick = {},
+                    onItemLongClick = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Evening news").assertIsDisplayed()
+        composeRule.onNodeWithText("ARD").assertIsDisplayed()
+        composeRule.onNodeWithText("20:00 – 20:15").assertIsDisplayed()
+    }
+}

--- a/app/res/layout/compose_swipe_list.xml
+++ b/app/res/layout/compose_swipe_list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/ptr_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@android:id/list"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:visibility="gone" />
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/compose_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    <TextView
+        android:id="@android:id/empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:visibility="gone"
+        app:drawableTopCompat="@drawable/ic_warning_48dp" />
+</FrameLayout>

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -13,13 +13,16 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -45,6 +48,10 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.MovieListRequestH
 import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.services.MovieListItem;
+import net.reichholf.dreamdroid.ui.services.MovieListMapperKt;
+import net.reichholf.dreamdroid.ui.services.MovieListState;
+import net.reichholf.dreamdroid.ui.services.MovieListStateKt;
 
 import java.util.ArrayList;
 
@@ -62,6 +69,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 	@State public ArrayList<String> mSelectedTags;
 	@State public ArrayList<String> mOldTags;
 	@State public ExtendedHashMap mMovie;
+	private MovieListState mListState;
 
 	@Nullable
 	private ProgressDialog mProgress;
@@ -79,6 +87,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 			mOldTags = new ArrayList<>();
 		}
 		setInitialLocation(savedInstanceState);
+		mListState = new MovieListState();
 	}
 
 	protected void setInitialLocation(@Nullable Bundle savedInstanceState) {
@@ -99,6 +108,30 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 			}
 		}
 		mReload = true;
+	}
+
+	@Nullable
+	@Override
+	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		return inflater.inflate(R.layout.compose_swipe_list, container, false);
+	}
+
+	@Override
+	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		ComposeView compose = view.findViewById(R.id.compose_list);
+		MovieListStateKt.bindMovieListScreen(
+				compose,
+				mListState,
+				item -> {
+					onComposeClick(item, false);
+					return kotlin.Unit.INSTANCE;
+				},
+				item -> {
+					onComposeClick(item, true);
+					return kotlin.Unit.INSTANCE;
+				}
+		);
 	}
 
 	@Override
@@ -241,6 +274,15 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 			return;
 		super.onLoadFinished(loader, result);
 		getAppCompatActivity().setTitle(mCurrentLocation);
+		mListState.replaceAll(MovieListMapperKt.movieListItemsFrom(mMapList));
+	}
+
+	private void onComposeClick(@NonNull MovieListItem item, boolean isLong) {
+		View host = getView();
+		if (host == null) {
+			return;
+		}
+		onMovieItemClick(host, item.getIndex(), isLong);
 	}
 
 	public void setLocation(int index) {

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -7,7 +7,6 @@
 package net.reichholf.dreamdroid.fragment;
 
 import android.content.ActivityNotFoundException;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
@@ -20,6 +19,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -46,7 +46,10 @@ import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
 import net.reichholf.dreamdroid.room.AppDatabase;
-import net.reichholf.dreamdroid.widget.AutofitRecyclerView;
+import net.reichholf.dreamdroid.ui.services.ServiceListItem;
+import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
+import net.reichholf.dreamdroid.ui.services.ServiceListState;
+import net.reichholf.dreamdroid.ui.services.ServiceListStateKt;
 
 import java.util.ArrayList;
 
@@ -76,6 +79,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public String mRef;
 
 	private ArrayList<ExtendedHashMap> mHistory;
+	private ServiceListState mListState;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -100,6 +104,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 			mRef = DreamDroid.getCurrentProfile().getDefaultBouquetTv();
 			mName = DreamDroid.getCurrentProfile().getDefaultBouquetTvName();
 		}
+		mListState = new ServiceListState();
 	}
 
 	@Override
@@ -115,21 +120,25 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	@Nullable
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		return inflater.inflate(R.layout.card_grid_content, container, false);
+		return inflater.inflate(R.layout.compose_swipe_list, container, false);
 	}
 
 	@Override
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity());
-		((AutofitRecyclerView) getRecyclerView()).setMaxSpanCount(
-				Integer.parseInt(
-						prefs.getString(
-								DreamDroid.PREFS_KEY_GRID_MAX_COLS,
-								Integer.toString(AutofitRecyclerView.DEFAULT_MAX_SPAN_COUNT)
-						)
-				)
-		);
 		super.onViewCreated(view, savedInstanceState);
+		ComposeView compose = view.findViewById(R.id.compose_list);
+		ServiceListStateKt.bindServiceListScreen(
+				compose,
+				mListState,
+				item -> {
+					onComposeClick(item, false);
+					return kotlin.Unit.INSTANCE;
+				},
+				item -> {
+					onComposeClick(item, true);
+					return kotlin.Unit.INSTANCE;
+				}
+		);
 	}
 
 	@Override
@@ -147,6 +156,14 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public boolean onItemLongClick(RecyclerView parent, @NonNull View view, int position, long id) {
 		onItemClick(parent, view, position, true);
 		return true;
+	}
+
+	private void onComposeClick(@NonNull ServiceListItem item, boolean isLong) {
+		View host = getView();
+		if (host == null) {
+			return;
+		}
+		onItemClick(host, host, item.getIndex(), isLong);
 	}
 
 	private void onItemClick(View l, @NonNull View v, int position, boolean isLong) {
@@ -265,6 +282,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		if (!isResumed())
 			return;
 		super.onLoadFinished(loader, result);
+		mListState.replaceAll(ServiceListMapperKt.serviceListItemsFrom(mMapList));
 	}
 
 	public void upOrReload() {

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.loader.content.Loader;
 import androidx.appcompat.view.ActionMode;
 import androidx.recyclerview.widget.RecyclerView;
@@ -40,6 +41,10 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerDeleteReques
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerListRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.services.TimerListItem;
+import net.reichholf.dreamdroid.ui.services.TimerListMapperKt;
+import net.reichholf.dreamdroid.ui.services.TimerListState;
+import net.reichholf.dreamdroid.ui.services.TimerListStateKt;
 import net.reichholf.dreamdroid.widget.helper.ItemSelectionSupport;
 
 import java.util.ArrayList;
@@ -99,6 +104,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	@Nullable
 	private ProgressDialog mProgress;
 	protected int mCurrentPos;
+	private TimerListState mListState;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -111,11 +117,12 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		mCurrentPos = -1;
 		mIsActionMode = false;
 		mReload = true;
+		mListState = new TimerListState();
 	}
 
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		View view = inflater.inflate(R.layout.card_recycler_content, container, false);
+		View view = inflater.inflate(R.layout.compose_swipe_list, container, false);
 		registerFab(R.id.fab_main, R.string.new_timer, R.drawable.ic_action_fab_add, v -> onItemSelected(Statics.ITEM_NEW_TIMER));
 		return view;
 	}
@@ -124,6 +131,19 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		setAdapter();
+		ComposeView compose = view.findViewById(R.id.compose_list);
+		TimerListStateKt.bindTimerListScreen(
+				compose,
+				mListState,
+				item -> {
+					onComposeClick(item, false);
+					return kotlin.Unit.INSTANCE;
+				},
+				item -> {
+					onComposeClick(item, true);
+					return kotlin.Unit.INSTANCE;
+				}
+		);
 	}
 
 	protected void startActionMode() {
@@ -197,6 +217,24 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	private void setAdapter() {
 		mAdapter = new TimerAdapter(getAppCompatActivity(), mMapList);
 		getRecyclerView().setAdapter(mAdapter);
+	}
+
+	@Override
+	public void onLoadFinished(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
+							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
+		super.onLoadFinished(loader, result);
+		if (getAppCompatActivity() != null) {
+			mListState.replaceAll(TimerListMapperKt.timerListItemsFrom(getAppCompatActivity(), mMapList));
+		}
+	}
+
+	private void onComposeClick(@NonNull TimerListItem item, boolean isLong) {
+		int position = item.getIndex();
+		if (isLong) {
+			onItemLongClick(getRecyclerView(), getView(), position, position);
+		} else {
+			onItemClick(getRecyclerView(), getView(), position, position);
+		}
 	}
 
 	/**

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListItem.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListItem.kt
@@ -1,0 +1,10 @@
+package net.reichholf.dreamdroid.ui.services
+
+data class MovieListItem(
+    val index: Int,
+    val title: String,
+    val serviceName: String,
+    val fileSize: String,
+    val time: String,
+    val length: String,
+)

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
@@ -1,0 +1,17 @@
+package net.reichholf.dreamdroid.ui.services
+
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.enigma2.Movie
+
+fun movieListItemsFrom(maps: List<ExtendedHashMap>): List<MovieListItem> {
+    return maps.mapIndexed { index, map ->
+        MovieListItem(
+            index = index,
+            title = map.getString(Movie.KEY_TITLE).orEmpty(),
+            serviceName = map.getString(Movie.KEY_SERVICE_NAME).orEmpty(),
+            fileSize = map.getString(Movie.KEY_FILE_SIZE_READABLE).orEmpty(),
+            time = map.getString(Movie.KEY_TIME_READABLE).orEmpty(),
+            length = map.getString(Movie.KEY_LENGTH).orEmpty(),
+        )
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListScreen.kt
@@ -1,0 +1,65 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MovieListScreen(
+    items: List<MovieListItem>,
+    onItemClick: (MovieListItem) -> Unit,
+    onItemLongClick: (MovieListItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 8.dp)) {
+        items(items, key = { it.index }) { item ->
+            MovieRow(item, onClick = { onItemClick(item) }, onLongClick = { onItemLongClick(item) })
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MovieRow(
+    item: MovieListItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = item.serviceName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = listOf(item.time, item.length, item.fileSize).filter { it.isNotEmpty() }.joinToString("  "),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
@@ -1,0 +1,33 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class MovieListState(initial: List<MovieListItem> = emptyList()) {
+    val items: SnapshotStateList<MovieListItem> = initial.toMutableStateList()
+
+    fun replaceAll(next: List<MovieListItem>) {
+        items.clear()
+        items.addAll(next)
+    }
+}
+
+fun ComposeView.bindMovieListScreen(
+    state: MovieListState,
+    onItemClick: (MovieListItem) -> Unit,
+    onItemLongClick: (MovieListItem) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            MovieListScreen(
+                items = state.items,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListItem.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListItem.kt
@@ -1,0 +1,22 @@
+package net.reichholf.dreamdroid.ui.services
+
+enum class ServiceRowKind {
+    CHANNEL,
+    DIRECTORY,
+    MARKER,
+}
+
+data class ServiceListItem(
+    val index: Int,
+    val reference: String,
+    val name: String,
+    val kind: ServiceRowKind,
+    val nowTitle: String = "",
+    val nowStart: String = "",
+    val nowDuration: String = "",
+    val nextTitle: String = "",
+    val nextStart: String = "",
+    val nextDuration: String = "",
+    val progressMax: Int = 0,
+    val progress: Int = 0,
+)

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
@@ -1,0 +1,51 @@
+package net.reichholf.dreamdroid.ui.services
+
+import android.util.Log
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.helpers.DateTime
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.Python
+import net.reichholf.dreamdroid.helpers.enigma2.Event
+import net.reichholf.dreamdroid.helpers.enigma2.Service
+
+fun serviceListItemsFrom(maps: List<ExtendedHashMap>): List<ServiceListItem> {
+    return maps.mapIndexed { index, map ->
+        Event.supplementReadables(map)
+        val ref = map.getString(Service.KEY_REFERENCE) ?: ""
+        val name = map.getString(Event.KEY_SERVICE_NAME) ?: ""
+        when {
+            Service.isMarker(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.MARKER)
+            Service.isDirectory(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.DIRECTORY)
+            else -> {
+                val nextTitle = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_TITLE).orEmpty()
+                var max = 0
+                var cur = 0
+                val nowTime = map.getString(Event.KEY_CURRENT_TIME)
+                val duration = map.getString(Event.KEY_EVENT_DURATION)
+                val start = map.getString(Event.KEY_EVENT_START)
+                if (duration != null && start != null && duration != Python.NONE && start != Python.NONE) {
+                    try {
+                        max = (duration.toDouble() / 60).toLong().toInt()
+                        cur = max - DateTime.getRemaining(duration, start, nowTime)
+                    } catch (e: Exception) {
+                        Log.e(DreamDroid.LOG_TAG, e.toString())
+                    }
+                }
+                ServiceListItem(
+                    index = index,
+                    reference = ref,
+                    name = name,
+                    kind = ServiceRowKind.CHANNEL,
+                    nowTitle = map.getString(Event.KEY_EVENT_TITLE).orEmpty(),
+                    nowStart = map.getString(Event.KEY_EVENT_START_TIME_READABLE).orEmpty(),
+                    nowDuration = map.getString(Event.KEY_EVENT_DURATION_READABLE).orEmpty(),
+                    nextTitle = nextTitle,
+                    nextStart = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_START_TIME_READABLE).orEmpty(),
+                    nextDuration = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_DURATION_READABLE).orEmpty(),
+                    progressMax = max,
+                    progress = cur.coerceAtLeast(0),
+                )
+            }
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -1,0 +1,128 @@
+package net.reichholf.dreamdroid.ui.services
+
+import android.widget.ImageView
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.Statics
+import net.reichholf.dreamdroid.helpers.enigma2.Event
+import net.reichholf.dreamdroid.helpers.enigma2.Picon
+import net.reichholf.dreamdroid.helpers.enigma2.Service
+
+@Composable
+fun ServiceListScreen(
+    items: List<ServiceListItem>,
+    onItemClick: (ServiceListItem) -> Unit,
+    onItemLongClick: (ServiceListItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 8.dp)) {
+        items(items, key = { "${it.index}:${it.reference}" }) { item ->
+            ServiceRow(
+                item = item,
+                onClick = { onItemClick(item) },
+                onLongClick = { onItemLongClick(item) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ServiceRow(
+    item: ServiceListItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    if (item.kind == ServiceRowKind.MARKER) {
+        Text(
+            text = item.name,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+        return
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (item.kind == ServiceRowKind.CHANNEL) {
+                    ServicePicon(item)
+                }
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+            if (item.kind == ServiceRowKind.CHANNEL) {
+                if (item.nowTitle.isNotEmpty()) {
+                    Text(
+                        text = "${item.nowStart}  ${item.nowTitle}  ${item.nowDuration}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+                if (item.progressMax > 0) {
+                    LinearProgressIndicator(
+                        progress = item.progress.toFloat() / item.progressMax.toFloat(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                    )
+                }
+                if (item.nextTitle.isNotEmpty()) {
+                    Text(
+                        text = "${item.nextStart}  ${item.nextTitle}  ${item.nextDuration}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ServicePicon(item: ServiceListItem) {
+    val context = LocalContext.current
+    AndroidView(
+        factory = { ctx -> ImageView(ctx) },
+        modifier = Modifier.size(48.dp),
+        update = { view ->
+            val map = ExtendedHashMap()
+            map.put(Service.KEY_REFERENCE, item.reference)
+            map.put(Event.KEY_SERVICE_REFERENCE, item.reference)
+            map.put(Event.KEY_SERVICE_NAME, item.name)
+            Picon.setPiconForView(context, view, map, Statics.TAG_PICON)
+        },
+    )
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
@@ -1,0 +1,33 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class ServiceListState(initial: List<ServiceListItem> = emptyList()) {
+    val items: SnapshotStateList<ServiceListItem> = initial.toMutableStateList()
+
+    fun replaceAll(next: List<ServiceListItem>) {
+        items.clear()
+        items.addAll(next)
+    }
+}
+
+fun ComposeView.bindServiceListScreen(
+    state: ServiceListState,
+    onItemClick: (ServiceListItem) -> Unit,
+    onItemLongClick: (ServiceListItem) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            ServiceListScreen(
+                items = state.items,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListItem.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListItem.kt
@@ -1,0 +1,12 @@
+package net.reichholf.dreamdroid.ui.services
+
+data class TimerListItem(
+    val index: Int,
+    val name: String,
+    val serviceName: String,
+    val begin: String,
+    val end: String,
+    val action: String,
+    val state: String,
+    val stateColor: Int,
+)

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListMapper.kt
@@ -1,0 +1,42 @@
+package net.reichholf.dreamdroid.ui.services
+
+import android.content.Context
+import android.util.Log
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.enigma2.Timer
+
+fun timerListItemsFrom(context: Context, maps: List<ExtendedHashMap>): List<TimerListItem> {
+    val states = context.resources.getTextArray(R.array.timer_state)
+    val actions = context.resources.getTextArray(R.array.timer_action)
+    val colors = context.resources.getIntArray(R.array.timer_state_color)
+    return maps.mapIndexed { index, map ->
+        var actionId = 0
+        try {
+            actionId = Integer.parseInt(map.getString(Timer.KEY_JUST_PLAY) ?: "0")
+        } catch (e: Exception) {
+            Log.e(DreamDroid.LOG_TAG, e.toString())
+        }
+        var stateId = 0
+        try {
+            stateId = Integer.parseInt(map.getString(Timer.KEY_STATE) ?: "0")
+            stateId += Integer.parseInt(map.getString(Timer.KEY_DISABLED) ?: "0")
+        } catch (e: Exception) {
+            Log.e(DreamDroid.LOG_TAG, e.toString())
+        }
+        val action = if (actionId in actions.indices) actions[actionId].toString() else ""
+        val state = if (stateId in states.indices) states[stateId].toString() else ""
+        val color = if (stateId in colors.indices) colors[stateId] else 0
+        TimerListItem(
+            index = index,
+            name = map.getString(Timer.KEY_NAME).orEmpty(),
+            serviceName = map.getString(Timer.KEY_SERVICE_NAME).orEmpty(),
+            begin = map.getString(Timer.KEY_BEGIN_READEABLE).orEmpty(),
+            end = map.getString(Timer.KEY_END_READABLE).orEmpty(),
+            action = action,
+            state = state,
+            stateColor = color,
+        )
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListScreen.kt
@@ -1,0 +1,86 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TimerListScreen(
+    items: List<TimerListItem>,
+    onItemClick: (TimerListItem) -> Unit,
+    onItemLongClick: (TimerListItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 8.dp)) {
+        items(items, key = { it.index }) { item ->
+            TimerRow(item, onClick = { onItemClick(item) }, onLongClick = { onItemLongClick(item) })
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TimerRow(
+    item: TimerListItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Row(Modifier.height(IntrinsicSize.Min)) {
+            Box(
+                Modifier
+                    .width(4.dp)
+                    .fillMaxHeight()
+                    .background(Color(item.stateColor)),
+            )
+            Column(Modifier.padding(12.dp)) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = item.serviceName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "${item.begin} – ${item.end}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "${item.action}  ${item.state}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListState.kt
@@ -1,0 +1,33 @@
+package net.reichholf.dreamdroid.ui.services
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class TimerListState(initial: List<TimerListItem> = emptyList()) {
+    val items: SnapshotStateList<TimerListItem> = initial.toMutableStateList()
+
+    fun replaceAll(next: List<TimerListItem>) {
+        items.clear()
+        items.addAll(next)
+    }
+}
+
+fun ComposeView.bindTimerListScreen(
+    state: TimerListState,
+    onItemClick: (TimerListItem) -> Unit,
+    onItemLongClick: (TimerListItem) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            TimerListScreen(
+                items = state.items,
+                onItemClick = onItemClick,
+                onItemLongClick = onItemLongClick,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Why
TV & Movies hub chrome was Compose; the channel, movie, and timer pages were still RecyclerView. The product path users actually stare at is those rows.

## Scope
- Compose lists for TV/Radio services, Movies, and Timer.
- Zap, long-press menus, picons, and loaders stay in the existing Java fragments.
- `ServiceAdapter` kept for ShareActivity and the video overlay.

## Blast Radius
Phone TV & Movies pager pages only. Leanback TV untouched. Profile list and About untouched.

## Verification
- [x] `./gradlew.bat :app:connectedGoogleDebugAndroidTest` — 8 tests, BUILD SUCCESSFUL on emulator-5554