### PR TITLE
Add modernization plan and verify-dreamdroid skill

### DIFF
--- a/.cursor/skills/verify-dreamdroid/SKILL.md
+++ b/.cursor/skills/verify-dreamdroid/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: verify-dreamdroid
+description: Prove dreamDroid phone UI. Prefer instrumented Compose tests. Use adb dumps only for a single look or a shell path that has no test yet.
+---
+
+# Verify dreamDroid
+
+dreamDroid is a phone/tablet Enigma2 remote (`net.reichholf.dreamdroid`). **Default proof is instrumented tests**, not tapping the emulator. See `AGENTS.md`.
+
+```bash
+./gradlew.bat :app:connectedGoogleDebugAndroidTest
+```
+
+Use **JDK 17** (`JAVA_HOME`). AGP 8.2's `jlink` transform fails on JDK 21. Do not pass `-Pandroid.testInstrumentationRunnerArguments...` — that sets Gradle property `android` to a String and breaks `android.applicationVariants`. Filter a class with:
+
+```bash
+adb shell am instrument -w -e class net.reichholf.dreamdroid.ui.about.AboutScreenTest net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+Tests live in `app/androidTest/java`. Add Compose UI tests next to each new screen. If the UI is Compose inside an XML dialog or `ComposeView`, host it that way in the test.
+
+`verify-dreamdroid.py` is for a **single look** (screenshot) or a shell-only path that has no instrumented test yet. It is not the verification loop.
+
+Helper (from repo root):
+
+```bash
+python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py <command>
+```
+
+On Windows use the same command. The script finds `adb` on `PATH`, in `ADB`, or in `sdk.dir` from `local.properties`.
+
+Default package: `net.reichholf.dreamdroid.debug` (googleDebug `applicationIdSuffix`). Never drive `net.reichholf.dreamdroid` (Play/F-Droid release) or the Amazon id.
+
+Set `ANDROID_SERIAL` when more than one device is attached. Two googleDebug instances cannot run side by side on one device; debug vs release can.
+
+Read [features/README.md](features/README.md) before driving. Exercise the mapped user path, not internal setters or HTTP clients.
+
+## Launch (optional look)
+
+1. `JAVA_HOME` at JDK 17. `gradle.properties` must not pass `-XX:MaxPermSize` or CMS flags.
+2. Install if needed: `./gradlew.bat :app:installGoogleDebug`
+3. Disposable session: `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch --clear-data`
+
+Ready when `pidof net.reichholf.dreamdroid.debug` returns a pid and the helper prints `started ... pid=...`. First start opens the Profiles screen and the navigation drawer. Seeded profile name is `Demo` (host `dreamdroid.org`). That host is not an offline mock: bouquets, EPG, zap, and remote still need a reachable Enigma2 WebInterface unless the recipe says otherwise.
+
+Teardown is `cleanup` below. Do not `am force-stop` or `pm uninstall` by the release package name.
+
+## Doctor
+
+```bash
+python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py doctor
+```
+
+Pass only when an adb device is in `device` state, `net.reichholf.dreamdroid.debug` is installed and in the foreground, and it has a pid. If doctor fails, relaunch the debug package; do not tap a user-owned release install.
+
+## Drive (optional look)
+
+Prefer resource ids and visible text over coordinates. `tap --text About` matches **Settings & About** first; scroll the drawer and match text exactly `About`.
+
+| User control | Handle |
+| --- | --- |
+| Open drawer | content-desc `Open navigation drawer` (English) |
+| Drawer profile row | `net.reichholf.dreamdroid.debug:id/drawer_profile` |
+| Profile name / status | `...:id/drawer_profile_name`, `...:id/drawer_profile_status` |
+| TV & Movies | text `TV & Movies` |
+| EPG / Virtual Remote / Zap / Current event | text `EPG`, `Virtual Remote`, `Zap`, `Current event` |
+| About | text `About` (opens a dialog) |
+| Add Profile FAB | `...:id/fab_main` content-desc `Add Profile` |
+| Autodiscovery | text `Dreambox Autodiscovery` |
+| TV/Radio/Movies/Timer tabs | text `TV`, `Radio`, `Movies`, `Timer` |
+
+- First-start after `--clear-data` shows Changelog. Dismiss with `back` before driving Profiles or the drawer. The changelog text contains the word `Profiles`, so `wait-text "Profiles"` is a false positive until the dialog is gone.
+
+Receiver-backed screens (TV & Movies, Zap, EPG, remote keypresses) are unverified when the profile host does not answer. Report the unmet precondition; do not call a connection-error snackbar a successful zap.
+
+## Evidence
+
+Instrumented test output is the proof for Compose screens. Optional look artifacts live in `.cursor/skills/verify-dreamdroid/artifacts/` (gitignored). Cleanup must not delete them.
+
+```bash
+python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py dump --path .cursor/skills/verify-dreamdroid/artifacts/<feature>/ui.xml
+python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py screenshot --path .cursor/skills/verify-dreamdroid/artifacts/<feature>/screen.png
+```
+
+## Cleanup
+
+```bash
+python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py cleanup
+```
+
+Stops the debug package started by `launch` (`kill` of the recorded pid, then `am force-stop` of `net.reichholf.dreamdroid.debug` only). Removes the device-side dump file. Leaves `artifacts/` on disk.
+
+## Helpers
+
+`scripts/verify-dreamdroid.py` subcommands: `doctor`, `launch [--clear-data]`, `dump [--path]`, `screenshot --path`, `tap (--text|--desc|--resource-id)`, `wait-text TEXT`, `contains TEXT`, `back`, `cleanup`.

--- a/.cursor/skills/verify-dreamdroid/features/README.md
+++ b/.cursor/skills/verify-dreamdroid/features/README.md
@@ -1,0 +1,48 @@
+# dreamDroid verification map
+
+This directory is the maintained source for verifying the user-facing behavior of dreamDroid. Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Prove Compose screens with `./gradlew.bat :app:connectedGoogleDebugAndroidTest` (see `AGENTS.md`). Do not tap the emulator in a loop.
+- googleDebug is installed: `./gradlew.bat :app:installGoogleDebug`.
+- For an optional look, launch with `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch --clear-data`. Dismiss the first-install Changelog with `back` before driving other screens.
+- Package `net.reichholf.dreamdroid.debug` is in the foreground. `doctor` must pass.
+- Device language English unless a recipe says to match a dump instead.
+- Never drive a release install (`net.reichholf.dreamdroid`).
+- Receiver-backed features need a reachable Enigma2 WebInterface on the active profile. First-start seeds profile `Demo` at `dreamdroid.org`; that is not an offline bouquet/EPG mock.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer resource-id and visible text over bounds.
+- Treat every command as literal.
+- Restore debug app data with `--clear-data` on the next launch after a mutation. Do not remove proof artifacts during cleanup.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes a UI dump and a screenshot with the debug app identity visible (`dreamDroid DBG`).
+- Mutation proof includes a second user-visible view of the stored value.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition (including `Connection error` when the box is down).
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with verify-dreamdroid` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [Profiles](./profiles.md) covers first-start Profiles, the Demo row, Add Profile, and the drawer profile header.
+- [About](./about.md) covers the About dialog from the drawer (no receiver required).
+- [TV and Movies](./tv-and-movies.md) covers drawer TV & Movies and the TV/Radio/Movies/Timer bar.
+- [Zap](./zap.md) covers the Zap screen and changing channel.
+- [Virtual Remote](./virtual-remote.md) covers opening the on-screen remote.

--- a/.cursor/skills/verify-dreamdroid/features/about.md
+++ b/.cursor/skills/verify-dreamdroid/features/about.md
@@ -1,0 +1,28 @@
+# About
+
+About shows the installed version, the GPL notice, and the source link in a dialog, without talking to a receiver.
+
+## Sub-features
+
+- `about-open` opens the About dialog from the drawer.
+- `about-identity` shows a version string and `About` as the dialog title.
+
+## How to get to it (user POV)
+
+- Open the navigation drawer and choose `About`.
+
+## Driving it with verify-dreamdroid
+
+Preconditions:
+
+- A device or emulator in `device` state.
+- No Enigma2 box is required.
+
+- **Proof.** Run `./gradlew.bat :app:connectedGoogleDebugAndroidTest`. `AboutScreenTest` and `AboutDialogHostTest` must pass. Night `LocalContentColor` is asserted equal to `onSurface` (light) inside `DreamDroidTheme`, including when hosted in a Material night `AlertDialog`.
+- **Look (optional).** `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch`, open the drawer, tap text exactly `About` (not `Settings & About`), then `screenshot --path .cursor/skills/verify-dreamdroid/artifacts/about/screen.png`.
+
+## Gotchas
+
+- Instrumented tests are the pass criteria. A screenshot is not a substitute.
+- `tap --text About` matches **Settings & About** first. Scroll the drawer and match `About` exactly.
+- Licenses is a separate button inside the dialog and is not this feature's pass criteria.

--- a/.cursor/skills/verify-dreamdroid/features/profiles.md
+++ b/.cursor/skills/verify-dreamdroid/features/profiles.md
@@ -1,0 +1,37 @@
+# Profiles
+
+Profiles lets a user see connection profiles, open the seeded Demo profile, add a new profile, and jump to the list from the navigation drawer header.
+
+## Sub-features
+
+- `profiles-first-start` shows the Profiles screen after a clear-data launch.
+- `profiles-demo` lists the seeded `Demo` profile.
+- `profiles-add-open` opens the add-profile form from the FAB.
+- `profiles-drawer` reaches Profiles from the drawer profile header.
+
+## How to get to it (user POV)
+
+- Cold-start the app after clearing debug data (first start).
+- Open the navigation drawer and choose the profile header.
+- Choose `Add Profile` on the Profiles screen.
+
+## Driving it with verify-dreamdroid
+
+Preconditions:
+
+- `doctor` passes on `net.reichholf.dreamdroid.debug`.
+- Launch used `--clear-data`.
+- No Enigma2 box is required for these steps.
+
+- **First start.** After launch, a Changelog dialog appears on a fresh install. Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py wait-text "Changelog"` then `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py back`. Then wait for the seeded profile, not the word Profiles: `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py wait-text "Demo"`. The Profiles list shows `Demo`.
+- **Demo row.** Confirm the seeded profile. Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py contains "Demo"`. The list shows `Demo`.
+- **Add Profile.** Choose the add FAB. Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --resource-id "net.reichholf.dreamdroid.debug:id/fab_main"`. The form shows `Profile name` and `Hostname or IP`.
+- **Drawer entry.** Return to Profiles if needed, open the drawer, and choose the profile header. Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --desc "Open navigation drawer"` then `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --resource-id "net.reichholf.dreamdroid.debug:id/drawer_profile"`. Profiles is visible again with `Demo`.
+- **Proof.** Capture the list with Demo visible. Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py dump --path .cursor/skills/verify-dreamdroid/artifacts/profiles/ui.xml` and `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py screenshot --path .cursor/skills/verify-dreamdroid/artifacts/profiles/screen.png`. Both artifacts show `Profiles` and `Demo`.
+
+## Gotchas
+
+- A fresh `--clear-data` launch shows Changelog before Profiles. Dismiss it with `back`. Do not `wait-text "Profiles"` while Changelog is open: the changelog body contains the word Profiles.
+- Autodiscovery needs LAN multicast and is not part of this feature's pass criteria.
+- Saving a new profile against a dead host still creates the row; proving connectivity is a different feature.
+- Do not treat a connection-error snackbar as a failed Profiles list. The list can be valid while the box is down.

--- a/.cursor/skills/verify-dreamdroid/features/tv-and-movies.md
+++ b/.cursor/skills/verify-dreamdroid/features/tv-and-movies.md
@@ -1,0 +1,33 @@
+# TV and Movies
+
+TV and Movies is the bouquet/recordings/timers hub: bouquet tabs on TV or Radio, plus Movies and Timer lists.
+
+## Sub-features
+
+- `services-open` opens TV & Movies from the drawer.
+- `services-tv-bar` shows the TV, Radio, Movies, and Timer destinations.
+- `services-list` shows bouquet or service rows when the receiver answers.
+
+## How to get to it (user POV)
+
+- Open the navigation drawer and choose `TV & Movies`.
+- After a successful profile check, the app may land here instead of Profiles.
+
+## Driving it with verify-dreamdroid
+
+Preconditions:
+
+- `doctor` passes.
+- For `services-list`, the active profile's host must accept Enigma2 WebInterface requests. If it does not, record the error dump and skip `services-list` only.
+
+- **Open drawer.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --desc "Open navigation drawer"`.
+- **Open TV & Movies.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --text "TV & Movies"`. The bottom bar includes `TV`, `Radio`, `Movies`, and `Timer`.
+- **Bar destinations.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --text "Radio"` then `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --text "TV"`. The selected destination changes; the screen stays in TV & Movies.
+- **List (receiver).** If no connection error is shown, the list or tabs contain bouquet or service names. If a connection error is shown, dump it and skip this sub-feature.
+- **Proof.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py dump --path .cursor/skills/verify-dreamdroid/artifacts/tv-and-movies/ui.xml` and `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py screenshot --path .cursor/skills/verify-dreamdroid/artifacts/tv-and-movies/screen.png`. Artifacts show `TV`, `Radio`, `Movies`, and `Timer`.
+
+## Gotchas
+
+- A hard connection error blocks this screen from loading lists. That is a skip, not a pass.
+- Bottom bar items are hidden until TV & Movies is the current destination.
+- `TV & Movies` is the drawer label; do not search for `Services`.

--- a/.cursor/skills/verify-dreamdroid/features/virtual-remote.md
+++ b/.cursor/skills/verify-dreamdroid/features/virtual-remote.md
@@ -1,0 +1,30 @@
+# Virtual Remote
+
+Virtual Remote is the on-screen Dreambox remote: number keys, OK, power, and color keys.
+
+## Sub-features
+
+- `remote-open` opens Virtual Remote from the drawer.
+- `remote-ok` shows the `OK` key (and typically `Power`).
+
+## How to get to it (user POV)
+
+- Open the navigation drawer and choose `Virtual Remote`.
+
+## Driving it with verify-dreamdroid
+
+Preconditions:
+
+- `doctor` passes.
+- Opening the remote does not require a receiver. A keypress that should control the box does.
+
+- **Open drawer.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --desc "Open navigation drawer"`.
+- **Open remote.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --text "Virtual Remote"`. Keys such as `OK` are visible.
+- **OK visible.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py contains "OK"`.
+- **Proof.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py dump --path .cursor/skills/verify-dreamdroid/artifacts/virtual-remote/ui.xml` and `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py screenshot --path .cursor/skills/verify-dreamdroid/artifacts/virtual-remote/screen.png`. Artifacts show the remote keypad.
+
+## Gotchas
+
+- On phone, Virtual Remote may open in a separate no-title activity. `doctor` must still see `net.reichholf.dreamdroid.debug`.
+- Pressing `Power` or other keys against a dead host is not a pass for this feature; visibility of the keypad is.
+- Do not kill `net.reichholf.dreamdroid` (release) if this activity is mistaken for a second app.

--- a/.cursor/skills/verify-dreamdroid/features/zap.md
+++ b/.cursor/skills/verify-dreamdroid/features/zap.md
@@ -1,0 +1,32 @@
+# Zap
+
+Zap lists channels the user can switch the receiver to.
+
+## Sub-features
+
+- `zap-open` opens Zap from the drawer.
+- `zap-channel` taps a channel and the receiver changes service.
+
+## How to get to it (user POV)
+
+- Open the navigation drawer and choose `Zap`.
+- From a service row overflow, choose zap (popup `Zap`) when that menu is offered.
+
+## Driving it with verify-dreamdroid
+
+Preconditions:
+
+- `doctor` passes.
+- `zap-open` can be attempted without a box; an empty or error state is not a channel change.
+- `zap-channel` requires a reachable receiver and at least one channel row.
+
+- **Open drawer.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --desc "Open navigation drawer"`.
+- **Open Zap.** Run `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py tap --text "Zap"`. The destination is Zap (toolbar or heading includes `Zap`).
+- **Change channel (receiver).** Tap a visible channel name with `tap --text "<channel>"`. Then open `Current event` from the drawer. The current service name is the channel just chosen.
+- **Proof.** Dump and screenshot Zap before the tap and Current event after: `.cursor/skills/verify-dreamdroid/artifacts/zap/`.
+
+## Gotchas
+
+- Opening Zap is not proof of a zap. A second view (`Current event`) must show the new service.
+- Demo host `dreamdroid.org` usually cannot zap. Skip `zap-channel` with the error dump.
+- Instant-zap settings can change whether a tap zaps immediately; still confirm Current event.

--- a/.cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py
+++ b/.cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Drive the dreamDroid googleDebug APK on a connected Android device via adb."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+PACKAGE = "net.reichholf.dreamdroid.debug"
+LAUNCHER = f"{PACKAGE}/net.reichholf.dreamdroid.activities.TabbedNavigationActivity"
+STATE_DIR = Path(__file__).resolve().parents[1] / "artifacts"
+PID_FILE = STATE_DIR / "session.pid"
+DUMP_REMOTE = "/sdcard/dreamdroid-verify-dump.xml"
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def find_adb() -> str:
+    env = os.environ.get("ADB")
+    if env:
+        return env
+    local = REPO_ROOT / "local.properties"
+    if local.exists():
+        for line in local.read_text(encoding="utf-8").splitlines():
+            if line.startswith("sdk.dir="):
+                sdk = line.split("=", 1)[1].replace("\\\\", "\\").replace("\\:", ":")
+                candidate = Path(sdk) / "platform-tools" / ("adb.exe" if os.name == "nt" else "adb")
+                if candidate.exists():
+                    return str(candidate)
+    return "adb.exe" if os.name == "nt" else "adb"
+
+
+ADB = find_adb()
+
+
+def run_adb(args: list[str], check: bool = True, capture: bool = True) -> subprocess.CompletedProcess[str]:
+    serial = os.environ.get("ANDROID_SERIAL")
+    cmd = [ADB]
+    if serial:
+        cmd.extend(["-s", serial])
+    cmd.extend(args)
+    return subprocess.run(
+        cmd,
+        check=check,
+        capture_output=capture,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def require_device() -> str:
+    out = run_adb(["devices"]).stdout
+    ready = []
+    for line in out.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "device":
+            ready.append(parts[0])
+    if not ready:
+        print("doctor: no adb device in 'device' state", file=sys.stderr)
+        print(out, file=sys.stderr)
+        sys.exit(1)
+    serial = os.environ.get("ANDROID_SERIAL")
+    if serial and serial not in ready:
+        print(f"doctor: ANDROID_SERIAL={serial} is not connected", file=sys.stderr)
+        sys.exit(1)
+    return serial or ready[0]
+
+
+def parse_dump(xml_text: str) -> list[dict[str, str]]:
+    nodes = []
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise SystemExit(f"ui dump is not valid XML: {exc}") from exc
+    for el in root.iter("node"):
+        nodes.append(dict(el.attrib))
+    return nodes
+
+
+def bounds_center(bounds: str) -> tuple[int, int]:
+    m = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds)
+    if not m:
+        raise SystemExit(f"unparseable bounds: {bounds}")
+    l, t, r, b = map(int, m.groups())
+    return (l + r) // 2, (t + b) // 2
+
+
+def dump_ui() -> list[dict[str, str]]:
+    run_adb(["shell", "uiautomator", "dump", DUMP_REMOTE], check=False)
+    pulled = run_adb(["exec-out", "cat", DUMP_REMOTE], check=False)
+    if pulled.returncode != 0 or not pulled.stdout.strip():
+        raise SystemExit("failed to dump UI hierarchy")
+    return parse_dump(pulled.stdout)
+
+
+def match_node(nodes: list[dict[str, str]], text=None, desc=None, resource_id=None) -> dict[str, str]:
+    for n in nodes:
+        if text is not None and text not in (n.get("text") or ""):
+            continue
+        if desc is not None and desc not in (n.get("content-desc") or ""):
+            continue
+        if resource_id is not None and n.get("resource-id") != resource_id:
+            continue
+        return n
+    raise SystemExit(
+        f"no node matched text={text!r} desc={desc!r} resource-id={resource_id!r}"
+    )
+
+
+def cmd_doctor(_: argparse.Namespace) -> None:
+    serial = require_device()
+    pkg = run_adb(["shell", "pm", "path", PACKAGE], check=False)
+    if pkg.returncode != 0 or not pkg.stdout.strip():
+        print(f"doctor: {PACKAGE} is not installed (install googleDebug first)", file=sys.stderr)
+        sys.exit(1)
+    pid = run_adb(["shell", "pidof", PACKAGE], check=False).stdout.strip()
+    focus = run_adb(["shell", "dumpsys", "window"], check=False).stdout
+    focused = ""
+    for line in focus.splitlines():
+        if "mCurrentFocus" in line or "mFocusedApp" in line:
+            focused = line.strip()
+            if PACKAGE in focused:
+                break
+    version = run_adb(
+        ["shell", "dumpsys", "package", PACKAGE],
+        check=False,
+    ).stdout
+    version_name = ""
+    for line in version.splitlines():
+        if "versionName=" in line:
+            version_name = line.strip()
+            break
+    print(f"serial={serial}")
+    print(f"package={PACKAGE}")
+    print(version_name or "versionName=unknown")
+    print(f"pid={pid or 'not running'}")
+    print(focused or "focus=unknown")
+    if PACKAGE not in (focused or ""):
+        print("doctor: debug package is not in the foreground", file=sys.stderr)
+        sys.exit(1)
+    if not pid:
+        print("doctor: debug package has no pid", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_launch(args: argparse.Namespace) -> None:
+    require_device()
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    if args.clear_data:
+        run_adb(["shell", "pm", "clear", PACKAGE], check=False)
+    started = run_adb(
+        ["shell", "am", "start", "-W", "-n", LAUNCHER, "-a", "android.intent.action.MAIN"],
+        check=False,
+    )
+    if started.returncode != 0:
+        print(started.stdout + started.stderr, file=sys.stderr)
+        raise SystemExit("am start failed")
+    deadline = time.time() + args.timeout
+    pid = ""
+    while time.time() < deadline:
+        pid = run_adb(["shell", "pidof", PACKAGE], check=False).stdout.strip().split()
+        pid = pid[0] if pid else ""
+        if pid:
+            break
+        time.sleep(0.4)
+    if not pid:
+        raise SystemExit("app did not start")
+    PID_FILE.write_text(pid, encoding="utf-8")
+    print(f"started {LAUNCHER} pid={pid}")
+
+
+def cmd_dump(args: argparse.Namespace) -> None:
+    nodes = dump_ui()
+    xml_text = run_adb(["exec-out", "cat", DUMP_REMOTE]).stdout
+    if args.path:
+        path = Path(args.path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(xml_text, encoding="utf-8")
+        print(str(path))
+    else:
+        for n in nodes:
+            print(
+                f"{n.get('class','')} text={n.get('text')!r} desc={n.get('content-desc')!r} id={n.get('resource-id')!r} bounds={n.get('bounds')}"
+            )
+
+
+def cmd_screenshot(args: argparse.Namespace) -> None:
+    path = Path(args.path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = subprocess.run(
+        [ADB] + (["-s", os.environ["ANDROID_SERIAL"]] if os.environ.get("ANDROID_SERIAL") else []) + ["exec-out", "screencap", "-p"],
+        check=True,
+        capture_output=True,
+    )
+    path.write_bytes(raw.stdout)
+    print(str(path))
+
+
+def cmd_tap(args: argparse.Namespace) -> None:
+    node = match_node(dump_ui(), text=args.text, desc=args.desc, resource_id=args.resource_id)
+    x, y = bounds_center(node["bounds"])
+    run_adb(["shell", "input", "tap", str(x), str(y)])
+    print(f"tapped {x},{y} text={node.get('text')!r} id={node.get('resource-id')!r}")
+
+
+def cmd_wait_text(args: argparse.Namespace) -> None:
+    deadline = time.time() + args.timeout
+    last = ""
+    while time.time() < deadline:
+        nodes = dump_ui()
+        last = " | ".join((n.get("text") or n.get("content-desc") or "") for n in nodes if n.get("text") or n.get("content-desc"))
+        for n in nodes:
+            hay = f"{n.get('text','')} {n.get('content-desc','')}"
+            if args.text in hay:
+                print(f"found {args.text!r}")
+                return
+        time.sleep(0.6)
+    print(last, file=sys.stderr)
+    raise SystemExit(f"timed out waiting for {args.text!r}")
+
+
+def cmd_contains(args: argparse.Namespace) -> None:
+    nodes = dump_ui()
+    for n in nodes:
+        hay = f"{n.get('text','')} {n.get('content-desc','')}"
+        if args.text in hay:
+            print(f"contains {args.text!r}")
+            return
+    raise SystemExit(f"UI dump does not contain {args.text!r}")
+
+
+def cmd_back(_: argparse.Namespace) -> None:
+    run_adb(["shell", "input", "keyevent", "KEYCODE_BACK"])
+    print("KEYCODE_BACK")
+
+
+def cmd_cleanup(_: argparse.Namespace) -> None:
+    pid = PID_FILE.read_text(encoding="utf-8").strip() if PID_FILE.exists() else ""
+    current = run_adb(["shell", "pidof", PACKAGE], check=False).stdout.strip().split()
+    if pid and pid in current:
+        run_adb(["shell", "kill", pid], check=False)
+    run_adb(["shell", "am", "force-stop", PACKAGE], check=False)
+    run_adb(["shell", "rm", "-f", DUMP_REMOTE], check=False)
+    if PID_FILE.exists():
+        PID_FILE.unlink()
+    print(f"stopped {PACKAGE}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("doctor")
+    p_launch = sub.add_parser("launch")
+    p_launch.add_argument("--clear-data", action="store_true")
+    p_launch.add_argument("--timeout", type=float, default=30)
+    p_dump = sub.add_parser("dump")
+    p_dump.add_argument("--path")
+    p_shot = sub.add_parser("screenshot")
+    p_shot.add_argument("--path", required=True)
+    p_tap = sub.add_parser("tap")
+    p_tap.add_argument("--text")
+    p_tap.add_argument("--desc")
+    p_tap.add_argument("--resource-id")
+    p_wait = sub.add_parser("wait-text")
+    p_wait.add_argument("text")
+    p_wait.add_argument("--timeout", type=float, default=20)
+    p_has = sub.add_parser("contains")
+    p_has.add_argument("text")
+    sub.add_parser("back")
+    sub.add_parser("cleanup")
+
+    args = parser.parse_args()
+    if args.cmd == "tap" and not (args.text or args.desc or args.resource_id):
+        parser.error("tap requires --text, --desc, or --resource-id")
+    {
+        "doctor": cmd_doctor,
+        "launch": cmd_launch,
+        "dump": cmd_dump,
+        "screenshot": cmd_screenshot,
+        "tap": cmd_tap,
+        "wait-text": cmd_wait_text,
+        "contains": cmd_contains,
+        "back": cmd_back,
+        "cleanup": cmd_cleanup,
+    }[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ gen/
 build/
 *.iml
 local.properties
+.cursor/skills/verify-dreamdroid/artifacts/
 app/manifest-merger-release-report.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Phone Enigma2 remote. Rewrite trunk is `main`. Sources live in `app/src` and `app/res`, not `src/main`. Debug package is `net.reichholf.dreamdroid.debug`. Build with **JDK 17**.
 
+Modernization plan: [`docs/modernize-dreamdroid.md`](docs/modernize-dreamdroid.md). UI look helper: [`.cursor/skills/verify-dreamdroid/SKILL.md`](.cursor/skills/verify-dreamdroid/SKILL.md).
+
 ## Verify UI with instrumented tests
 
 Do not prove phone UI by tapping the emulator through `adb` / `verify-dreamdroid.py` in a loop. That path is slow and brittle (`About` matches `Settings & About`, Changelog contains `Profiles`, dumps miss color).

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -1,0 +1,302 @@
+# Modernize dreamDroid phone app
+
+Phone users get a Compose Material 3 remote. TV stays Leanback until a later program. minSdk is 26. Dead deps went first, then the typed Enigma2 client, then phone screens.
+
+Rewrite trunk is **`main`**. `master` is last 1.15 stable. Do not merge `master` or branches cut from `master` into `main`.
+
+Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap loops. See [`AGENTS.md`](../AGENTS.md). AVD `dreamdroid-verify`. JDK 17. Debug package `net.reichholf.dreamdroid.debug`.
+
+## Status as of 2026-09-08
+
+| Unit | GitHub | State | Head / merge |
+| --- | --- | --- | --- |
+| pr-floor | #163 closed without squash-merge | on `main` as direct commits | `60e59f72` minSdk 26 / drop jcenter. `0c769e8f` OkHttp 4.12.0. `e7b43a7c` back to OkHttp 3.14.9 so Kotlin 1.6.21 still compiled. |
+| pr-about | [#164](https://github.com/sreichholf/dreamDroid/pull/164) | merged | `7372a21d` |
+| About night | [#166](https://github.com/sreichholf/dreamDroid/pull/166) | merged | `17042aa0` `LocalContentColor` / `onSurface` |
+| About tests | [#167](https://github.com/sreichholf/dreamDroid/pull/167) | merged | `d725ee9b` `AGENTS.md`, `AboutScreenTest`, `AboutDialogHostTest` |
+| pr-client | [#165](https://github.com/sreichholf/dreamDroid/pull/165) | merged | `de010cb4` |
+| pr-profiles | [#168](https://github.com/sreichholf/dreamDroid/pull/168) | merged | `e7563787` |
+| pr-services | [#169](https://github.com/sreichholf/dreamDroid/pull/169) | merged | squash `f125c117` |
+| TV/Movies/Timer rows | [#170](https://github.com/sreichholf/dreamDroid/pull/170) | open on `pr-service-lists` | Compose lists hosted in the existing Java fragments. Not on `main` yet. |
+
+Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
+
+Wave 2 (operator choice): finish TV & Movies lists, then delete dead weight. Lists are #170. Dead-weight deletes are next and must not drop ButterKnife (still used by frozen Leanback TV).
+
+### Operator overrides (this program)
+
+- **Land** when the operator says land. That waives "owners do not merge" for that PR.
+- **Proof** is `./gradlew.bat :app:connectedGoogleDebugAndroidTest`. Do not prove phone UI by tapping the emulator through `adb` / `verify-dreamdroid.py` in a loop. That script is a single look, or a shell path that has no test yet.
+- Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
+- Theme follows `DreamDroid.getThemeType()`. Default `"1"` is always night. Do not reopen `colorSchemeFromViewTheme`. Version/license `Text` uses `onSurface`. Dialog-hosted Compose must be tested in a dialog/`ComposeView`, not only `setContent { }`.
+- `captureToImage` on this AVD returns black pixels even for light content. Do not use pixel-luminance tests.
+- Java calling Kotlin `(T) -> Unit` must `return kotlin.Unit.INSTANCE`. `DisposeOnViewTreeLifecycleDestroyed` is set from Kotlin, not Java.
+- Two googleDebug processes cannot share one device. AGP 8.2 `jlink` fails on JDK 21.
+
+### Not done, recorded so it is not pretended done
+
+- Swarm live lanes, perf probes, and `media/pr-*-review.*` videos were **not** run. The operator accepted connectedAndroidTest and landed.
+- On `main`, phone channel lists are still `ServiceListPageFragment` + `ServiceAdapter`. Hub chrome is Compose. Compose rows live in #170.
+- `ProfileAdapter` remains for `ShareActivity`.
+- `app/res/service_list_pager.xml` (not under `layout/`) is a leftover stub. Inflater uses `R.layout.service_list_pager`.
+
+## How to read this
+
+One box is one unit of work. Check a box only when its evidence exists: a SHA, a PR URL, a test run, a file. Nested boxes are sub-steps.
+
+The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf ratio per PR. That protocol is superseded by the overrides above. Live/perf boxes below stay unchecked unless a later run actually produces those files.
+
+## Program checklist
+
+### Arm the program
+
+- [x] Protocol and plan stated. Operator go given. Later holds (reboot) and "land" orders override the playbook in chat.
+- [ ] Original `/goal` text still says `master` and `verify-dreamdroid`. Do not re-arm that string. Wave 1 done is #169 on `main` plus hub Compose tests green.
+- [x] Forge resolved to `gh` as `sreichholf`. Origin/`gt` not used.
+
+### Spawn owners
+
+- [x] Work ran serially in one worktree, not one cloud owner per PR.
+- [x] Order held: floor, then About and client in parallel in time, Profiles after About, services after Profiles + client.
+- [x] No PR edited `app/src/net/reichholf/dreamdroid/tv/` except compile-safe leftovers.
+- [x] Review gate waived per operator "land" for #164–#169.
+
+### PR mechanics, for every PR
+
+- [x] PRs opened ready, never draft, `--base main`.
+- [x] JDK 17 assemble / connected tests before push where UI changed.
+- [x] Cursor git wrapper injects `--trailer`; Git 2.23 rejects it. Commit via Python calling `git.exe` with `-F`.
+
+## Raise the device floor (pr-floor)
+
+**Depends on.** None. **On `main`.**
+
+**Files.**
+
+- [x] [`app/build.gradle`](../app/build.gradle) `minSdkVersion` 26, Java 17, no `jcenter()`, no unused Navigation.
+- [x] [`gradle.properties`](../gradle.properties).
+- [x] Wrapper left unless AGP required it.
+- [x] OkHttp ended at **3.14.9** (`e7b43a7c`) after 4.12.0 failed Kotlin 1.6.21. Still Picasso-only. Enigma2 stays `HttpURLConnection`.
+
+**Build.**
+
+- [x] `./gradlew.bat :app:assembleGoogleDebug` `BUILD SUCCESSFUL`. Manifest minSdk 26.
+
+**You see.**
+
+- [x] Debug package still `net.reichholf.dreamdroid.debug`.
+
+**Verify, unit.**
+
+- [x] `app/src/test/java/net/reichholf/dreamdroid/MinSdkSmokeTest.java`.
+
+**Verify, live / perf / swarm.** Not run. Operator landed the floor as commits; #163 was closed without merge.
+
+## Show About in Compose (pr-about)
+
+**Depends on.** pr-floor. **On `main` as #164, #166, #167.**
+
+**Files.**
+
+- [x] Compose BOM, `compose` buildFeatures, Kotlin plugin kept (later 1.9.24).
+- [x] `app/src/net/reichholf/dreamdroid/ui/about/AboutScreen.kt`.
+- [x] `NavigationHelper` opens Compose About.
+- [x] `AboutDialog.java` deleted.
+- [x] Unused `app/res/layout/navigation_layout.xml` gone.
+- [x] Night: `DreamDroidTheme` provides `LocalContentColor` from scheme `onSurface` (#166).
+- [x] `AGENTS.md` plus `AboutScreenTest` / `AboutDialogHostTest` (#167). Test APK strings `app_name_debug` / `app_name_tv_debug` so AAPT links.
+
+**Build.**
+
+- [x] About shows `DreamDroid.VERSION_STRING`, GPLv3, source URL.
+
+**You see.**
+
+- [x] Drawer About is a Compose dialog titled About.
+
+**Verify, unit.**
+
+- [x] `AboutScreenTest` version + licenses. `AboutDialogHostTest` night `LocalContentColor` inside an `AlertDialog` host. `connectedGoogleDebugAndroidTest`.
+
+**Verify, live / perf / review media.** Not run. Operator landed on tests.
+
+## Rebuild Profiles in Compose (pr-profiles)
+
+**Depends on.** pr-about. **On `main` as #168 (`e7563787`).**
+
+**Files.**
+
+- [x] `app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt`, `ProfileListItem.kt`, `ProfilesListState.kt`.
+- [x] `ProfileListFragment` hosts `ComposeView`. XML `fab_main` hidden. Compose FAB uses `R.string.profile_add`.
+- [x] `MainActivity.onProfileChecked`: after `navigateTo(Profiles)`, skip `navigateTo(services)` when `isFirstStart` even if `mDetailFragment` is still null after `commit()`.
+- [x] Room `AppDatabase.profiles()` kept.
+- [ ] `ProfileAdapter` **not** deleted. `ShareActivity` still uses it.
+
+**Build.**
+
+- [x] Seeded `Demo` row and Add Profile FAB. Autodiscovery, edit, delete kept.
+
+**You see.**
+
+- [x] Profiles list is Compose.
+
+**Verify, unit.**
+
+- [x] `ProfilesScreenTest` Demo row + Add Profile content description. `connectedGoogleDebugAndroidTest`.
+
+**Verify, live / perf / review media.** Not run. Operator landed #168.
+
+## Type the Enigma2 client (pr-client)
+
+**Depends on.** pr-floor. **On `main` as #165 (`de010cb4`).**
+
+**Files.**
+
+- [x] `app/src/net/reichholf/dreamdroid/enigma/` Kotlin types and coroutine client wrapping `SimpleHttpClient` + `URIStore`.
+- [x] Bouquet fetch for the hub goes through `EnigmaClient.getServicesBlocking`.
+- [ ] `ExtendedHashMap` still used on unmigrated list rows (`ServiceListPageFragment` and others).
+
+**Build.**
+
+- [x] Models for Service, Event, Timer, Movie. Parse at the HTTP boundary. Not OkHttp.
+
+**You see.**
+
+- [x] JVM test parses fixture `/web/getservices` XML into `Service`.
+
+**Verify, unit.**
+
+- [x] `ServiceParserTest`. `./gradlew.bat :app:testGoogleDebugUnitTest`.
+
+**Verify, live / perf / review media.** Not run. Operator landed #165.
+
+## Rebuild TV and Movies hub (pr-services)
+
+**Depends on.** pr-profiles, pr-client. **On `main` as [#169](https://github.com/sreichholf/dreamDroid/pull/169) (`f125c117`).**
+
+**Files.**
+
+- [x] `app/src/net/reichholf/dreamdroid/ui/services/TvMoviesScreen.kt`, `TvMoviesDestination.kt`, `TvMoviesHubState.kt`.
+- [x] `ServiceListPager.java` hosts Compose header + destination bar. XML `TabLayout` / activity bottom nav gone (`GONE` leftover id ok).
+- [ ] Phone Recycler adapters **not** deleted on `main`. That is [#170](https://github.com/sreichholf/dreamDroid/pull/170).
+
+**Build.**
+
+- [x] Destinations TV, Radio, Movies, Timer. Bouquet/location names in Compose tabs. Lists still pager fragments on `main`. Errors from typed bouquet fetch in hub state.
+
+**You see.**
+
+- [x] Instrumented: fake bouquets `Favourites (TV)` and `All Services` plus four destinations.
+
+**Verify, unit.**
+
+- [x] `TvMoviesScreenTest`. `:app:connectedGoogleDebugAndroidTest` before push.
+
+**Merge.**
+
+- [x] Squash-merged. `origin/main` is `f125c117` after #169.
+
+## Close wave 1
+
+- [x] #169 on `main`.
+- [x] Operator chose wave 2: (1) finish TV & Movies lists, then (4) dead weight. See Appendix E.
+
+## Appendix A. Prototype evidence
+
+Compose versus XML Views was not prototyped in-repo. Plan mode blocked a throwaway sketch. The choice is Compose because minSdk 26 allows the current BOM, and Material 3 in [`app/res/values/themes.xml`](../app/res/values/themes.xml) already parents `Theme.Material3`.
+
+minSdk 17 versus 26 was a product call. The operator picked 26.
+
+TV in the first wave was a product call. The operator picked phone only.
+
+## Appendix B. Alternatives rejected
+
+A greenfield second app was rejected. The Enigma2 XML API and Room profiles are the product.
+
+Keeping minSdk 17 was rejected. Shipping phone and TV together was rejected. Leanback stays frozen.
+
+Keeping `ExtendedHashMap` as the list row type was rejected for new screens. Unmigrated fragments still use it.
+
+## Appendix C. Risks and traps (current)
+
+Play users below API 26 lose install. Floor is on `main`.
+
+No Enigma2 box in CI. Connection error is a valid pass for list content. Crash is not.
+
+ButterKnife remains on a few files. Do not drop it as a drive-by. Leanback TV still uses it.
+
+Two HTTP stacks. Box XML is `HttpURLConnection`. Picons are Picasso plus OkHttp 3.14.9.
+
+Two database files. Room `dreambox` holds `profile`. Legacy SQLite `dreamdroid` still feeds first-run migration and backup. Do not delete the old file until backup points at Room.
+
+First-start skip-Profiles race is fixed on `main` in #168. Still wait for `Demo` after Changelog, not the word Profiles inside changelog text.
+
+Evernote `@State` plus Livefront Bridge is load-bearing on rotation. Do not migrate it in this program.
+
+VLC `VideoActivity` is out of this program.
+
+Kotlin plugin is 1.9.24 with Compose compiler 1.5.14. OkHttp stays 3.14.9. Do not bump OkHttp to 4 as a drive-by.
+
+Test APK must define `app_name_debug` / `app_name_tv_debug` or AAPT fails.
+
+Do not merge `cursor/verify-dreamdroid-skill` (or any other `master`-based branch) into `main`. Port files.
+
+## Appendix E. What wave 1 did not cover
+
+Wave 1 was a beachhead: minSdk 26, Compose BOM, About, Profiles list, a typed client used by bouquet fetch, and Compose hub chrome. Counts on `main` after #169: **14 Kotlin files, 219 Java files** under `app/src` (12 of those Java files are Leanback TV).
+
+This was never "replace the phone app with Compose." The original boxes named five PRs. Everything else stayed on purpose or by omission.
+
+### Still Java/XML phone screens (drawer and related)
+
+Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies **tabs/bar**. The pager pages behind those tabs are still fragments until #170 lands.
+
+| Surface | Code | Notes |
+| --- | --- | --- |
+| Channel / bouquet rows | `ServiceListPageFragment`, `ServiceAdapter` | Hub leftover on `main`. Zap, long-press, picons, popup menu. Compose in #170. |
+| Movies list | `MovieListFragment` | Hub Movies destination. Compose in #170. |
+| Timer list / edit | `TimerListFragment`, `TimerEditFragment` | Hub Timer destination. List Compose in #170; edit stays XML. |
+| Profile add/edit | `ProfileEditFragment` | List is Compose; form is XML. Autodiscovery stays Java. |
+| Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
+| Zap | `ZapFragment`, `ZapAdapter` | |
+| EPG bouquet / search / timeline | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgTimelineFragment`, `ServiceEpgListFragment`, `EpgAdapter` | |
+| EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
+| Current event | `CurrentServiceFragment` | |
+| Virtual remote | `VirtualRemoteFragment`, `VirtualRemotePagerFragment` | |
+| Device info | `DeviceInfoFragment` | |
+| Signal | `SignalFragment` + vendored gauge lib | |
+| Screenshot | `ScreenShotFragment` + PhotoView | |
+| Settings | `MyPreferenceFragment`, `legacy-preference-v14` | |
+| Backup | `BackupFragment`, `DreamDroidBackupAgent` | Still talks to legacy SQLite. |
+| Sleep timer / send message / power / changelog | dialogs | |
+| Mediaplayer | `MediaPlayerFragment` | Drawer entry commented out; code remains. |
+| Streaming | `VideoActivity`, `VideoOverlayFragment`, VLC | Explicitly out of wave 1. |
+| Widget | `appwidget/` | |
+| Shell | `MainActivity`, `NavigationHelper`, drawer XML, `BaseFragment` tree, Evernote `@State` + Bridge | |
+
+### Still the old data stack
+
+- Typed `EnigmaClient` exists. Almost every list still loads `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
+- Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
+- `android-retrostreams`, ButterKnife (5 files), `legacy-support-v4`, `legacy-preference-v14`, multidex.
+
+### Explicitly frozen
+
+- `app/src/.../tv/` Leanback. Operator picked phone first.
+- Rotation via Evernote State + Livefront Bridge.
+- VLC playback.
+
+### Sensible wave-2 shapes (pick one, do not do all at once)
+
+1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **In progress as #170.**
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting.
+3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
+4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), retrostreams, preference-v14, unused MediaPlayer entry, leftover `res/service_list_pager.xml`. Small PRs, high delete ratio. **Next after #170.**
+5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
+
+Recommended default if the operator just says go: (1) then (4), keep (3) and (5) as later programs.
+
+## Appendix F. Links
+
+[`AGENTS.md`](../AGENTS.md), [`.cursor/skills/verify-dreamdroid/SKILL.md`](../.cursor/skills/verify-dreamdroid/SKILL.md), [`app/build.gradle`](../app/build.gradle), [`NavigationHelper.java`](../app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java), [`MainActivity.java`](../app/src/net/reichholf/dreamdroid/activities/MainActivity.java), [`URIStore.java`](../app/src/net/reichholf/dreamdroid/helpers/enigma2/URIStore.java), [`themes.xml`](../app/res/values/themes.xml).


### PR DESCRIPTION
## Summary
- Ports the Cursor verify-dreamdroid skill and the modernization plan onto `main` so they are not stuck on `cursor/verify-dreamdroid-skill` (that branch was cut from `master` / last 1.15).
- Adds `AGENTS.md` pointers and ignores skill artifacts. Does **not** merge `cursor/verify-dreamdroid-skill`.

## Test plan
- [ ] Docs-only: confirm `AGENTS.md` links, `docs/modernize-dreamdroid.md`, and `.cursor/skills/verify-dreamdroid/` on `main`.
- [ ] Confirm no app/src or dead-weight Java/gradle changes landed.