### PR TITLE
feat(zap): type Zap list rows off ExtendedHashMap

### DIFF
--- a/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ZapAdapter.java
+++ b/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ZapAdapter.java
@@ -14,24 +14,24 @@ import android.widget.TextView;
 import com.squareup.picasso.Callback;
 
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.helpers.enigma2.Picon;
-import net.reichholf.dreamdroid.helpers.enigma2.Service;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Stephan on 03.02.2016.
  */
-public class ZapAdapter extends BaseAdapter<ZapAdapter.ZapViewHolder> {
+public class ZapAdapter extends RecyclerView.Adapter<ZapAdapter.ZapViewHolder> {
 	@NonNull
 	private static String TAG = ZapAdapter.class.getSimpleName();
 	private Context mContext;
+	private List<Service> mData;
 
-	public ZapAdapter(Context context, ArrayList<ExtendedHashMap> data) {
-		super(data);
+	public ZapAdapter(Context context, List<Service> data) {
 		mContext = context;
+		mData = data;
 	}
 
 	@NonNull
@@ -46,12 +46,17 @@ public class ZapAdapter extends BaseAdapter<ZapAdapter.ZapViewHolder> {
 
 	@Override
 	public void onBindViewHolder(@NonNull ZapViewHolder holder, int position) {
-		ExtendedHashMap service = mData.get(position);
+		Service service = mData.get(position);
 		if (service != null) {
 			holder.serviceName.setVisibility(View.VISIBLE);
-			holder.serviceName.setText(service.getString(Service.KEY_NAME));
-			Picon.setPiconForView(mContext, holder.picon, service, Statics.TAG_PICON, holder.piconCallback);
+			holder.serviceName.setText(service.getName());
+			Picon.setPiconForView(mContext, holder.picon, service.getReference(), service.getName(), Statics.TAG_PICON, holder.piconCallback);
 		}
+	}
+
+	@Override
+	public int getItemCount() {
+		return mData.size();
 	}
 
 	static class ZapViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetServiceListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetServiceListTask.java
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.Service;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+import net.reichholf.dreamdroid.helpers.NameValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetServiceListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	private ArrayList<Service> mServices;
+
+	public GetServiceListTask(GetServiceListTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(ArrayList<NameValuePair> params) {
+		mServices = new ArrayList<>();
+		if (isCancelled()) {
+			return false;
+		}
+		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
+		mServices.addAll(HttpFragmentHelper.fetchServices(getHttpClient(), requestParams));
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetServiceListTaskHandler handler = (GetServiceListTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onServiceListReady(success, mServices, success ? null : getErrorText());
+	}
+
+	public interface GetServiceListTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onServiceListReady(boolean success, @NonNull List<Service> services, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
@@ -20,19 +20,23 @@ import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.adapter.recyclerview.ZapAdapter;
+import net.reichholf.dreamdroid.asynctask.GetServiceListTask;
+import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.RecyclerViewPauseOnScrollListener;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ServiceListRequestHandler;
 import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.zap.ZapListMapper;
 import net.reichholf.dreamdroid.widget.AutofitRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -41,12 +45,17 @@ import java.util.ArrayList;
  * As a GridView is also using a ListAdapter, this avoids having to copy existing code
  */
 
-public class ZapFragment extends BaseHttpRecyclerFragment {
+public class ZapFragment extends BaseHttpRecyclerFragment implements GetServiceListTask.GetServiceListTaskHandler {
 	@NonNull
-	public static String BUNDLE_KEY_CURRENT_BOUQUET = "currentBouquet";
+	public static String BUNDLE_KEY_CURRENT_BOUQUET_REFERENCE = "currentBouquetReference";
+	@NonNull
+	public static String BUNDLE_KEY_CURRENT_BOUQUET_NAME = "currentBouquetName";
 
-	private ExtendedHashMap mCurrentBouquet;
+	private Service mCurrentBouquet;
+	private final ArrayList<Service> mServices = new ArrayList<>();
 	private boolean mWaitingForPicker;
+	@Nullable
+	private GetServiceListTask mServiceListTask;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -55,9 +64,16 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 		if (mCurrentBouquet == null) {
 			mReload = true;
 			initTitle("");
-			mCurrentBouquet = new ExtendedHashMap();
-			mCurrentBouquet.put(Service.KEY_REFERENCE, DreamDroid.getCurrentProfile().getDefaultBouquetTv());
-			mCurrentBouquet.put(Service.KEY_NAME, DreamDroid.getCurrentProfile().getDefaultBouquetTvName());
+			if (savedInstanceState != null && savedInstanceState.containsKey(BUNDLE_KEY_CURRENT_BOUQUET_REFERENCE)) {
+				mCurrentBouquet = new Service(
+						savedInstanceState.getString(BUNDLE_KEY_CURRENT_BOUQUET_REFERENCE, ""),
+						savedInstanceState.getString(BUNDLE_KEY_CURRENT_BOUQUET_NAME, "")
+				);
+			} else {
+				String ref = DreamDroid.getCurrentProfile().getDefaultBouquetTv();
+				String name = DreamDroid.getCurrentProfile().getDefaultBouquetTvName();
+				mCurrentBouquet = new Service(ref != null ? ref : "", name != null ? name : "");
+			}
 			mWaitingForPicker = false;
 		}
 	}
@@ -77,15 +93,26 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-		mAdapter = new ZapAdapter(getContext(), mMapList);
+		mAdapter = new ZapAdapter(getContext(), mServices);
 		getRecyclerView().setAdapter(mAdapter);
+		super.onActivityCreated(savedInstanceState);
 	}
 
 	@Override
 	public void onSaveInstanceState(@NonNull Bundle outState) {
-		outState.putSerializable(BUNDLE_KEY_CURRENT_BOUQUET, mCurrentBouquet);
+		if (mCurrentBouquet != null) {
+			outState.putString(BUNDLE_KEY_CURRENT_BOUQUET_REFERENCE, mCurrentBouquet.getReference());
+			outState.putString(BUNDLE_KEY_CURRENT_BOUQUET_NAME, mCurrentBouquet.getName());
+		}
 		super.onSaveInstanceState(outState);
+	}
+
+	@Override
+	public void onDestroy() {
+		if (mServiceListTask != null) {
+			mServiceListTask.cancel(true);
+		}
+		super.onDestroy();
 	}
 
 	@Override
@@ -97,16 +124,15 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 
 	@Override
 	public void onItemClick(RecyclerView rv, View v, int position, long id) {
-		String ref = mMapList.get(position).getString(Service.KEY_REFERENCE);
+		String ref = mServices.get(position).getReference();
 		zapTo(ref);
 	}
 
 	@Override
 	public boolean onItemLongClick(RecyclerView rv, View v, int position, long id) {
-		String ref = mMapList.get(position).getString(Service.KEY_REFERENCE);
-		String name = mMapList.get(position).getString(Service.KEY_NAME);
+		Service service = mServices.get(position);
 		try {
-			startActivity(IntentFactory.getStreamServiceIntent(getAppCompatActivity(), ref, name));
+			startActivity(IntentFactory.getStreamServiceIntent(getAppCompatActivity(), service.getReference(), service.getName()));
 		} catch (ActivityNotFoundException e) {
 			showToast(getText(R.string.missing_stream_player));
 		}
@@ -116,60 +142,88 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int i, Bundle bundle) {
+		// Zap no longer starts this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
 		return new AsyncListLoader(getAppCompatActivity(), new ServiceListRequestHandler(), false, bundle);
+	}
+
+	@Override
+	public void onLoadFinished(Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
+							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
+		// Unused: channel rows come from GetServiceListTask / EnigmaClient.
 	}
 
 	@NonNull
 	@Override
 	public ArrayList<NameValuePair> getHttpParams(int loader) {
 		ArrayList<NameValuePair> params = new ArrayList<>();
-		params.add(new NameValuePair("sRef", mCurrentBouquet.getString(Service.KEY_REFERENCE)));
+		String ref = mCurrentBouquet != null ? mCurrentBouquet.getReference() : "";
+		params.add(new NameValuePair("sRef", ref));
 
 		return params;
 	}
 
 	@Override
 	protected void reload() {
-		if (mCurrentBouquet != null && !mCurrentBouquet.isEmpty())
-			super.reload();
-		else if (!mWaitingForPicker)
+		if (mCurrentBouquet != null) {
+			mReload = false;
+			if (mServices.isEmpty())
+				setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+			else
+				setEmptyText(null);
+			loadServices();
+		} else if (!mWaitingForPicker)
 			pickBouquet();
+	}
+
+	private void loadServices() {
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (mServiceListTask != null) {
+			mServiceListTask.cancel(true);
+		}
+		mServiceListTask = new GetServiceListTask(this);
+		mServiceListTask.execute(getHttpParams(HttpFragmentHelper.LOADER_DEFAULT_ID));
+	}
+
+	@Override
+	public void onServiceListReady(boolean success, @NonNull List<Service> services, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		mServices.clear();
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
+		if (!success) {
+			setEmptyText(errorText);
+			return;
+		}
+		setEmptyText(null);
+		List<Service> rows = ZapListMapper.rowsFrom(services);
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+
+		if (rows.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mServices.addAll(rows);
+		}
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
 	}
 
 	@Nullable
 	@Override
 	public String getLoadFinishedTitle() {
-		if (mCurrentBouquet != null)
-			return mCurrentBouquet.getString(Service.KEY_NAME, super.getLoadFinishedTitle());
+		if (mCurrentBouquet != null && mCurrentBouquet.getName() != null && !mCurrentBouquet.getName().isEmpty())
+			return mCurrentBouquet.getName();
 		return super.getLoadFinishedTitle();
-	}
-
-	@Override
-	public void onLoadFinished(Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
-							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
-
-		mMapList.clear();
-		mAdapter.notifyDataSetChanged();
-		if (result.isError()) {
-			setEmptyText(result.getErrorText());
-			return;
-		}
-		setEmptyText(null);
-
-		ArrayList<ExtendedHashMap> list = result.getResult();
-		setCurrentTitle(getLoadFinishedTitle());
-		getAppCompatActivity().setTitle(getCurrentTitle());
-
-		if (list.size() == 0) {
-			setEmptyText(getText(R.string.no_list_item));
-		} else {
-			for (ExtendedHashMap service : list) {
-				if (!Service.isMarker(service.getString(Service.KEY_REFERENCE)))
-					mMapList.add(service);
-			}
-		}
-		mAdapter.notifyDataSetChanged();
-		mHttpHelper.onLoadFinished();
 	}
 
 	@Override
@@ -188,9 +242,9 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 			return;
 		switch (requestCode) {
 			case Statics.REQUEST_PICK_BOUQUET:
-				ExtendedHashMap bouquet = (ExtendedHashMap) data.getSerializableExtra(PickServiceFragment.KEY_BOUQUET);
-				String reference = bouquet.getString(Service.KEY_REFERENCE, "");
-				if (!reference.equals(mCurrentBouquet.getString(Service.KEY_REFERENCE))) {
+				ExtendedHashMap bouquetMap = (ExtendedHashMap) data.getSerializableExtra(PickServiceFragment.KEY_BOUQUET);
+				Service bouquet = ZapListMapper.bouquetFrom(bouquetMap);
+				if (!bouquet.getReference().equals(mCurrentBouquet.getReference())) {
 					mCurrentBouquet = bouquet;
 					getRecyclerView().smoothScrollToPosition(0);
 				}
@@ -207,7 +261,7 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 		Bundle args = new Bundle();
 
 		ExtendedHashMap data = new ExtendedHashMap();
-		data.put(Service.KEY_REFERENCE, "default");
+		data.put(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_REFERENCE, "default");
 
 		args.putSerializable(sData, data);
 		args.putString("action", Statics.INTENT_ACTION_PICK_BOUQUET);

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/Picon.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/Picon.java
@@ -48,15 +48,19 @@ public class Picon {
 	}
 
 	public static String getPiconFileName(@NonNull Context context, @NonNull ExtendedHashMap service, boolean useName) {
+		return getPiconFileName(context, service.getString(Event.KEY_SERVICE_REFERENCE), service.getString(Event.KEY_SERVICE_NAME), useName);
+	}
+
+	public static String getPiconFileName(@NonNull Context context, @Nullable String reference, @Nullable String name, boolean useName) {
 		String root = getBasepath(context);
 		if(PreferenceManager.getDefaultSharedPreferences(context).getBoolean(DreamDroid.PREFS_KEY_FAKE_PICON, false))
 			return  String.format("%spicon_default.png", root);
 
 		String fileName;
 		if(useName){
-			fileName = service.getString(Event.KEY_SERVICE_NAME);
+			fileName = name;
 		} else {
-			fileName = service.getString(Event.KEY_SERVICE_REFERENCE);
+			fileName = reference;
 			if (fileName == null || !fileName.contains(":"))
 				return fileName;
 
@@ -76,6 +80,10 @@ public class Picon {
 	}
 
 	public static void setPiconForView(@NonNull Context context, @Nullable ImageView piconView, @NonNull ExtendedHashMap service, @NonNull String tag, Callback callback) {
+		setPiconForView(context, piconView, service.getString(Event.KEY_SERVICE_REFERENCE), service.getString(Event.KEY_SERVICE_NAME), tag, callback);
+	}
+
+	public static void setPiconForView(@NonNull Context context, @Nullable ImageView piconView, @Nullable String reference, @Nullable String name, @NonNull String tag, Callback callback) {
 		if (piconView == null) {
 			return;
 		}
@@ -86,7 +94,7 @@ public class Picon {
 			return;
 		}
 		boolean useName = sp.getBoolean(DreamDroid.PREFS_KEY_PICONS_USE_NAME, false);
-		String fileName = getPiconFileName(context, service, useName);
+		String fileName = getPiconFileName(context, reference, name, useName);
 		if (fileName == null) {
 			piconView.setVisibility(View.GONE);
 			return;

--- a/app/src/net/reichholf/dreamdroid/ui/zap/ZapListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/zap/ZapListMapper.kt
@@ -1,0 +1,29 @@
+package net.reichholf.dreamdroid.ui.zap
+
+import net.reichholf.dreamdroid.enigma.Service
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+
+/**
+ * Zap keeps XML rows. This mapper is the typed boundary: bouquet picker maps still
+ * arrive as [ExtendedHashMap], and [net.reichholf.dreamdroid.enigma.EnigmaClient]
+ * already returns [Service] from `/web/getservices`.
+ */
+object ZapListMapper {
+    @JvmStatic
+    fun rowsFrom(services: List<Service>): List<Service> {
+        return services.filter { service ->
+            !net.reichholf.dreamdroid.helpers.enigma2.Service.isMarker(service.reference)
+        }
+    }
+
+    @JvmStatic
+    fun bouquetFrom(map: ExtendedHashMap?): Service {
+        if (map == null) {
+            return Service("", "")
+        }
+        return Service(
+            map.getString(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_REFERENCE) ?: "",
+            map.getString(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_NAME) ?: ""
+        )
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/zap/ZapListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/zap/ZapListMapperTest.java
@@ -1,0 +1,58 @@
+package net.reichholf.dreamdroid.ui.zap;
+
+import net.reichholf.dreamdroid.enigma.Service;
+import net.reichholf.dreamdroid.enigma.ServiceParser;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ZapListMapperTest {
+    @Test
+    public void rowsFromDropsMarkersAndKeepsChannels() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/getservices.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Service> parsed = ServiceParser.INSTANCE.parse(xml);
+        assertEquals(3, parsed.size());
+
+        List<Service> rows = ZapListMapper.rowsFrom(parsed);
+        assertEquals(2, rows.size());
+        assertEquals("Favourites (TV)", rows.get(0).getName());
+        assertEquals("Das Erste HD", rows.get(1).getName());
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", rows.get(1).getReference());
+        for (Service row : rows) {
+            assertTrue(!net.reichholf.dreamdroid.helpers.enigma2.Service.isMarker(row.getReference()));
+        }
+    }
+
+    @Test
+    public void rowsFromEmptyListIsEmpty() {
+        assertEquals(0, ZapListMapper.rowsFrom(Collections.emptyList()).size());
+    }
+
+    @Test
+    public void bouquetFromReadsReferenceAndName() {
+        ExtendedHashMap map = new ExtendedHashMap();
+        map.put(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_REFERENCE, "1:7:1:0:0:0:0:0:0:0:");
+        map.put(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_NAME, "Favourites (TV)");
+        Service bouquet = ZapListMapper.bouquetFrom(map);
+        assertEquals("1:7:1:0:0:0:0:0:0:0:", bouquet.getReference());
+        assertEquals("Favourites (TV)", bouquet.getName());
+    }
+
+    @Test
+    public void bouquetFromNullMapIsEmptyService() {
+        Service bouquet = ZapListMapper.bouquetFrom(null);
+        assertEquals("", bouquet.getReference());
+        assertEquals("", bouquet.getName());
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -19,10 +19,12 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | pr-services | [#169](https://github.com/sreichholf/dreamDroid/pull/169) | merged | squash `f125c117` |
 | TV/Movies/Timer rows | [#170](https://github.com/sreichholf/dreamDroid/pull/170) | merged | `dbd20628` |
 | skill+plan | [#171](https://github.com/sreichholf/dreamDroid/pull/171) | merged | `b98ac193` |
+| dead-weight | [#172](https://github.com/sreichholf/dreamDroid/pull/172) | merged | `970ad4bc` drop android-retrostreams + leftover `app/res/service_list_pager.xml` |
+| Zap typed rows | this PR | open on `cursor/zap-typed-list-36ce` | Feed typed `enigma.Service` into Zap. XML grid stays. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
-Wave 2 (operator choice): finish TV & Movies lists, then delete dead weight. Lists #170 are on `main`. This PR is dead-weight (4). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170) and (4) dead-weight (#172) are on `main`. This PR is shape (2): retire `ExtendedHashMap` on the Zap list path. Do not drop ButterKnife (still used by frozen Leanback TV).
 
 ### Operator overrides (this program)
 
@@ -39,7 +41,7 @@ Wave 2 (operator choice): finish TV & Movies lists, then delete dead weight. Lis
 - Swarm live lanes, perf probes, and `media/pr-*-review.*` videos were **not** run. The operator accepted connectedAndroidTest and landed.
 - Hub + rows are Compose on `main` (#169/#170). `ServiceAdapter` remains for `ShareActivity` / video overlay; a hidden RecyclerView may remain for `BaseRecyclerFragment`.
 - `ProfileAdapter` remains for `ShareActivity`.
-- `app/res/service_list_pager.xml` (not under `layout/`) is a leftover stub. Inflater uses `R.layout.service_list_pager`.
+- Zap still XML. Rows are typed `enigma.Service` in this PR. Bouquet picker still returns `ExtendedHashMap`; Zap converts at the fragment boundary.
 
 ## How to read this
 
@@ -155,7 +157,7 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 
 - [x] `app/src/net/reichholf/dreamdroid/enigma/` Kotlin types and coroutine client wrapping `SimpleHttpClient` + `URIStore`.
 - [x] Bouquet fetch for the hub goes through `EnigmaClient.getServicesBlocking`.
-- [ ] `ExtendedHashMap` still used on unmigrated list rows (`ServiceListPageFragment` and others).
+- [x] Zap list fetch goes through `EnigmaClient.getServicesBlocking` (this PR). `ExtendedHashMap` remains on unmigrated list rows (EPG, current event, `ServiceListPageFragment` hash maps into Compose items).
 
 **Build.**
 
@@ -201,6 +203,23 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 
 - [x] #169 on `main`.
 - [x] Operator chose wave 2: (1) finish TV & Movies lists, then (4) dead weight. See Appendix E.
+- [x] #170 and #172 on `main`. Next: shape (2) Zap typing (this PR).
+
+## Type Zap list rows (pr-zap)
+
+**Depends on.** pr-client. **This PR, `--base main`.**
+
+**Files.**
+
+- [x] `ZapFragment` / `ZapAdapter` hold `enigma.Service`. XML `zap_grid_item` stays.
+- [x] Fetch via `GetServiceListTask` → `HttpFragmentHelper.fetchServices` → `EnigmaClient`.
+- [x] `ZapListMapper` drops markers and converts the bouquet-picker `ExtendedHashMap` at the fragment boundary.
+- [x] `Picon` accepts reference + name so Zap does not rebuild hashes for picons.
+- [ ] Drawer shell, EPG, current event, Compose Navigation **not** in this PR.
+
+**Verify, unit.**
+
+- [x] `ZapListMapperTest` plus `ServiceParserTest`. `:app:testGoogleDebugUnitTest`. Assemble googleDebug. Connected tests when a device exists.
 
 ## Appendix A. Prototype evidence
 
@@ -254,12 +273,12 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 | Surface | Code | Notes |
 | --- | --- | --- |
-| Channel / bouquet rows | Compose on `main` via #170 | Zap, long-press, picons, popup menu. |
+| Channel / bouquet rows | Compose on `main` via #170 | Long-press, picons, popup menu. |
 | Movies list | Compose on `main` via #170 | Hub Movies destination. |
 | Timer list / edit | Compose list on `main` via #170; `TimerEditFragment` | List Compose; edit stays XML. |
 | Profile add/edit | `ProfileEditFragment` | List is Compose; form is XML. Autodiscovery stays Java. |
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
-| Zap | `ZapFragment`, `ZapAdapter` | |
+| Zap | `ZapFragment`, `ZapAdapter` | XML grid. Rows are typed `enigma.Service` (this PR). Picker still `ExtendedHashMap`. |
 | EPG bouquet / search / timeline | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgTimelineFragment`, `ServiceEpgListFragment`, `EpgAdapter` | |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
 | Current event | `CurrentServiceFragment` | |
@@ -277,7 +296,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Almost every list still loads `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (5 files), `legacy-support-v4`, `legacy-preference-v14`, multidex.
@@ -290,13 +309,13 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
-1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main`.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting.
+1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **This PR types Zap.** EPG and current event remain.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
-4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), retrostreams, preference-v14, unused MediaPlayer entry, leftover `res/service_list_pager.xml`. Small PRs, high delete ratio. **This PR.**
+4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), preference-v14, unused MediaPlayer entry. `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. Small PRs, high delete ratio.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
 
-Recommended default if the operator just says go: (1) then (4), keep (3) and (5) as later programs.
+Recommended default if the operator just says go: (1) then (4), then (2), keep (3) and (5) as later programs.
 
 ## Appendix F. Links
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -20,7 +20,7 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | TV/Movies/Timer rows | [#170](https://github.com/sreichholf/dreamDroid/pull/170) | merged | `dbd20628` |
 | skill+plan | [#171](https://github.com/sreichholf/dreamDroid/pull/171) | merged | `b98ac193` |
 | dead-weight | [#172](https://github.com/sreichholf/dreamDroid/pull/172) | merged | `970ad4bc` drop android-retrostreams + leftover `app/res/service_list_pager.xml` |
-| Zap typed rows | this PR | open on `cursor/zap-typed-list-36ce` | Feed typed `enigma.Service` into Zap. XML grid stays. |
+| Zap typed rows | [#173](https://github.com/sreichholf/dreamDroid/pull/173) | open on `cursor/zap-typed-list-36ce` | Feed typed `enigma.Service` into Zap. XML grid stays. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
@@ -207,7 +207,7 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 
 ## Type Zap list rows (pr-zap)
 
-**Depends on.** pr-client. **This PR, `--base main`.**
+**Depends on.** pr-client. **[#173](https://github.com/sreichholf/dreamDroid/pull/173), `--base main`.**
 
 **Files.**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Wave 2 shape (2): stop feeding Zap from `ExtendedHashMap` so the typed Enigma2 client is the list-row type on this path, not a second unused model.

#170 (Compose TV/Movies/Timer rows) and #172 (dead-weight) are already on `main`. This PR does not recreate #172.

## Scope

- `ZapFragment` / `ZapAdapter` hold `enigma.Service`.
- Fetch `/web/getservices` via `GetServiceListTask` → `HttpFragmentHelper.fetchServices` → `EnigmaClient` / `ServiceParser`.
- `ZapListMapper` drops marker rows and converts the bouquet-picker `ExtendedHashMap` at the fragment boundary.
- `Picon` accepts reference + name so Zap does not rebuild hashes for picons.
- Plan file status table matches GitHub: #170 merged, #171 merged, #172 merged, this Zap PR listed as #173.

XML grid stays. Drawer shell, EPG, current event, and Compose Navigation are out of this PR.

## Blast radius

- Zap drawer destination only.
- Bouquet picker (`PickServiceFragment`) still returns hashes; Zap maps them on result.
- `BaseHttpRecyclerFragment` loader callbacks remain for the base class; Zap does not start `AsyncListLoader`.
- Leanback TV, ButterKnife, OkHttp 3.14.9, Evernote `@State` untouched.

## Verification

Cloud VM has **no emulator / no adb device**. Did not hang waiting for an AVD. JDK 17 (`JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64`).

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL, 8 tests, 0 failures (`ZapListMapperTest` 4, `ServiceParserTest` 3, `MinSdkSmokeTest` 1)
- `./gradlew :app:connectedGoogleDebugAndroidTest` — not run (no device)

Do not pass `-Pandroid.testInstrumentationRunnerArguments...`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baeda158-9645-4dc6-b897-0dd3296b36ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baeda158-9645-4dc6-b897-0dd3296b36ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

