### PR TITLE
Add Cloud Agent development environment for dreamDroid

### DIFF
--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -66,7 +66,8 @@ else
 fi
 
 # `am instrument` exits 0 even when tests fail, so inspect the summary.
-if grep -qaE "^OK \([0-9]+ test" "$INSTR_LOG" && ! grep -qaE "^FAILURES!!!" "$INSTR_LOG"; then
+# Require a non-zero test count so mistyped -e class filters cannot pass empty.
+if grep -qaE '^OK \([1-9][0-9]* tests?\)' "$INSTR_LOG" && ! grep -qaE "^FAILURES!!!" "$INSTR_LOG"; then
   echo "== connected-test: PASSED =="
   exit 0
 fi

--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Reliable instrumented-test runner for the Cloud Agent (software/TCG) emulator.
+#
+# The stock `:app:connectedGoogleDebugAndroidTest` pushes the ~196 MB universal
+# debug APK over ddmlib's sync protocol; under TCG that read times out inside
+# UTP's device controller (which ignores adbOptions.timeOutInMs). This helper
+# uses a streamed `adb install` of the standalone x86_64 APK plus `am instrument`
+# (the path AGENTS.md sanctions) so tests run green on the slow emulator.
+#
+# Usage: bash .cursor/cloud/connected-test.sh [testClassOrPackage]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT/.cursor/cloud"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/emulator.sh"
+
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+APP_APK="$REPO_ROOT/app/build/outputs/apk/google/debug/app-google-x86_64-debug.apk"
+TEST_APK="$REPO_ROOT/app/build/outputs/apk/androidTest/google/debug/app-google-debug-androidTest.apk"
+TEST_RUNNER="net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner"
+FILTER="${1:-}"
+
+if [ ! -f "$APP_APK" ] || [ ! -f "$TEST_APK" ]; then
+  echo "== connected-test: building debug + androidTest APKs =="
+  (cd "$REPO_ROOT" && ./gradlew --no-daemon :app:assembleGoogleDebug :app:assembleGoogleDebugAndroidTest)
+fi
+
+emu_launch quickboot
+emu_wait_boot
+
+echo "== connected-test: installing app + test APKs (streamed) =="
+# The TCG emulator occasionally drops the package-service socket mid-install
+# ("Broken pipe"); retry rather than fail the whole run.
+adb_install() {
+  local apk="$1" attempt
+  for attempt in 1 2 3; do
+    if "$ADB" -s "$SERIAL" install -r -t "$apk"; then
+      return 0
+    fi
+    echo "connected-test: install attempt $attempt failed, retrying..." >&2
+    "$ADB" -s "$SERIAL" wait-for-device || true
+    sleep 10
+  done
+  echo "connected-test: failed to install $apk after 3 attempts" >&2
+  return 1
+}
+adb_install "$APP_APK"
+adb_install "$TEST_APK"
+
+echo "== connected-test: running instrumentation =="
+INSTR_LOG="$LOG_DIR/instrumentation.log"
+if [ -n "$FILTER" ]; then
+  "$ADB" -s "$SERIAL" shell am instrument -w -r -e class "$FILTER" "$TEST_RUNNER" | tee "$INSTR_LOG"
+else
+  "$ADB" -s "$SERIAL" shell am instrument -w -r "$TEST_RUNNER" | tee "$INSTR_LOG"
+fi
+
+# `am instrument` exits 0 even when tests fail, so inspect the summary.
+if grep -qaE "^OK \([0-9]+ test" "$INSTR_LOG" && ! grep -qaE "^FAILURES!!!" "$INSTR_LOG"; then
+  echo "== connected-test: PASSED =="
+  exit 0
+fi
+echo "== connected-test: FAILED (see $INSTR_LOG) ==" >&2
+exit 1

--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -26,8 +26,11 @@ APP_APK="$REPO_ROOT/app/build/outputs/apk/google/debug/app-google-x86_64-debug.a
 TEST_APK="$REPO_ROOT/app/build/outputs/apk/androidTest/google/debug/app-google-debug-androidTest.apk"
 TEST_RUNNER="net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner"
 FILTER="${1:-}"
-
-if [ ! -f "$APP_APK" ] || [ ! -f "$TEST_APK" ]; then
+# Always assemble so snapshot-warmed APKs cannot mask a newer checkout.
+# Set DREAMDROID_SKIP_ASSEMBLE=1 only when you intentionally reuse existing APKs.
+if [ "${DREAMDROID_SKIP_ASSEMBLE:-0}" = "1" ] && [ -f "$APP_APK" ] && [ -f "$TEST_APK" ]; then
+  echo "== connected-test: reusing existing APKs (DREAMDROID_SKIP_ASSEMBLE=1) =="
+else
   echo "== connected-test: building debug + androidTest APKs =="
   (cd "$REPO_ROOT" && ./gradlew --no-daemon :app:assembleGoogleDebug :app:assembleGoogleDebugAndroidTest)
 fi

--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -12,10 +12,16 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT_DIR="$REPO_ROOT/.cursor/cloud"
+ENV_FILE="$HOME/.cursor/dreamdroid/env.sh"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+fi
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/emulator.sh"
 
 export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export PATH="$JAVA_HOME/bin:$PATH"
 APP_APK="$REPO_ROOT/app/build/outputs/apk/google/debug/app-google-x86_64-debug.apk"
 TEST_APK="$REPO_ROOT/app/build/outputs/apk/androidTest/google/debug/app-google-debug-androidTest.apk"
 TEST_RUNNER="net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner"

--- a/.cursor/cloud/emulator.sh
+++ b/.cursor/cloud/emulator.sh
@@ -15,13 +15,18 @@ ADB="$ANDROID_SDK_ROOT/platform-tools/adb"
 SERIAL="emulator-5554"
 LOG_DIR="$HOME/.cursor/dreamdroid"
 EMU_LOG="$LOG_DIR/emulator.log"
-BOOT_TIMEOUT_SECS="${DREAMDROID_BOOT_TIMEOUT:-900}"
+# Whole wait (device online + boot_completed) must finish within this budget.
+BOOT_TIMEOUT_SECS="${DREAMDROID_BOOT_TIMEOUT:-600}"
 mkdir -p "$LOG_DIR"
 
 emu_kvm_perms() {
   if [ -e /dev/kvm ] && [ ! -w /dev/kvm ]; then
     sudo chmod 666 /dev/kvm 2>/dev/null || true
   fi
+}
+
+emu_is_online() {
+  "$ADB" devices 2>/dev/null | grep -q "^${SERIAL}[[:space:]]\+device$"
 }
 
 emu_is_booted() {
@@ -54,14 +59,13 @@ emu_launch() {
     > "$EMU_LOG" 2>&1 &
 }
 
-# Wait until the device reports boot completed.
+# Wait until the device reports boot completed. Never blocks forever:
+# polls for device online and boot_completed under BOOT_TIMEOUT_SECS.
 emu_wait_boot() {
-  echo "emulator: waiting for device"
-  "$ADB" wait-for-device
-  echo "emulator: waiting for boot (timeout ${BOOT_TIMEOUT_SECS}s)"
+  echo "emulator: waiting for device + boot (timeout ${BOOT_TIMEOUT_SECS}s)"
   local deadline=$(( $(date +%s) + BOOT_TIMEOUT_SECS ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if emu_is_booted; then
+    if emu_is_online && emu_is_booted; then
       "$ADB" -s "$SERIAL" shell input keyevent 82 >/dev/null 2>&1 || true
       echo "emulator: boot completed"
       "$ADB" devices

--- a/.cursor/cloud/emulator.sh
+++ b/.cursor/cloud/emulator.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Shared emulator helpers for the dreamDroid Cloud Agent environment.
+#
+# Nested KVM guest execution hangs on Cursor Cloud VMs (the vCPU never runs even
+# though /dev/kvm exists and kvm-ok passes), so the emulator is launched under
+# software (TCG) emulation by default. Override with DREAMDROID_EMU_ACCEL=auto on
+# a host with working nested virtualization.
+set -euo pipefail
+
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+AVD_NAME="${DREAMDROID_AVD:-dreamdroid-verify}"
+EMU_ACCEL="${DREAMDROID_EMU_ACCEL:-off}"
+EMULATOR="$ANDROID_SDK_ROOT/emulator/emulator"
+ADB="$ANDROID_SDK_ROOT/platform-tools/adb"
+SERIAL="emulator-5554"
+LOG_DIR="$HOME/.cursor/dreamdroid"
+EMU_LOG="$LOG_DIR/emulator.log"
+BOOT_TIMEOUT_SECS="${DREAMDROID_BOOT_TIMEOUT:-900}"
+mkdir -p "$LOG_DIR"
+
+emu_kvm_perms() {
+  if [ -e /dev/kvm ] && [ ! -w /dev/kvm ]; then
+    sudo chmod 666 /dev/kvm 2>/dev/null || true
+  fi
+}
+
+emu_is_booted() {
+  [ "$("$ADB" -s "$SERIAL" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]
+}
+
+# Launch the emulator in the background unless one is already booted.
+# $1 (optional): "cold" to force a full boot ignoring any saved quickboot snapshot.
+emu_launch() {
+  local mode="${1:-quickboot}"
+  emu_kvm_perms
+  "$ADB" start-server >/dev/null 2>&1 || true
+  if emu_is_booted; then
+    echo "emulator: already booted"
+    return 0
+  fi
+
+  local snap_flag="-no-snapshot-save"
+  if [ "$mode" = "cold" ]; then
+    snap_flag="-no-snapshot"
+  fi
+
+  local accel_flags="-accel off"
+  [ "$EMU_ACCEL" = "auto" ] && accel_flags="-accel auto"
+
+  echo "emulator: launching '$AVD_NAME' (accel=$EMU_ACCEL, mode=$mode)"
+  nohup "$EMULATOR" -avd "$AVD_NAME" \
+    -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect \
+    $accel_flags $snap_flag \
+    > "$EMU_LOG" 2>&1 &
+}
+
+# Wait until the device reports boot completed.
+emu_wait_boot() {
+  echo "emulator: waiting for device"
+  "$ADB" wait-for-device
+  echo "emulator: waiting for boot (timeout ${BOOT_TIMEOUT_SECS}s)"
+  local deadline=$(( $(date +%s) + BOOT_TIMEOUT_SECS ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if emu_is_booted; then
+      "$ADB" -s "$SERIAL" shell input keyevent 82 >/dev/null 2>&1 || true
+      echo "emulator: boot completed"
+      "$ADB" devices
+      return 0
+    fi
+    sleep 5
+  done
+  echo "emulator: boot did not complete in ${BOOT_TIMEOUT_SECS}s; see $EMU_LOG" >&2
+  return 1
+}

--- a/.cursor/cloud/install.sh
+++ b/.cursor/cloud/install.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+JAVA_HOME_17="/usr/lib/jvm/java-17-openjdk-amd64"
 CMDLINE_TOOLS_VERSION="11076708"
 AVD_NAME="dreamdroid-verify"
 SYSTEM_IMAGE="system-images;android-34;google_apis;x86_64"
@@ -16,17 +17,37 @@ SDK_PACKAGES=(
   "emulator"
   "$SYSTEM_IMAGE"
 )
+ENV_FILE="$HOME/.cursor/dreamdroid/env.sh"
 
 echo "== install: system packages (JDK 17, KVM, tools) =="
 sudo apt-get update -qq
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
   openjdk-17-jdk qemu-kvm unzip curl
 
-# AGP 8.2's jlink transform fails on JDK 21, so pin the JVM default to 17.
-sudo update-java-alternatives -s java-1.17.0-openjdk-amd64 >/dev/null 2>&1 || true
-export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+# AGP 8.2's jlink transform fails on JDK 21, so pin the JVM to 17 and fail if
+# that JDK is missing. Also write env.sh so later shells (start/tests) inherit it.
+if [ ! -x "$JAVA_HOME_17/bin/java" ]; then
+  echo "install: JDK 17 missing at $JAVA_HOME_17" >&2
+  exit 1
+fi
+sudo update-java-alternatives -s java-1.17.0-openjdk-amd64 >/dev/null 2>&1 || \
+  echo "install: update-java-alternatives failed; relying on JAVA_HOME=$JAVA_HOME_17" >&2
+export JAVA_HOME="$JAVA_HOME_17"
+export PATH="$JAVA_HOME/bin:$PATH"
+mkdir -p "$(dirname "$ENV_FILE")"
+cat > "$ENV_FILE" <<EOF
+export JAVA_HOME="$JAVA_HOME_17"
+export PATH="\$JAVA_HOME/bin:\$PATH"
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_SDK_ROOT"
+EOF
 echo "JAVA_HOME=$JAVA_HOME"
 java -version
+java -version 2>&1 | grep -q 'version "17\.' || {
+  echo "install: expected JDK 17 on PATH, got:" >&2
+  java -version >&2
+  exit 1
+}
 
 echo "== install: Android command-line tools =="
 mkdir -p "$ANDROID_SDK_ROOT"
@@ -70,6 +91,7 @@ JAVA_HOME="$JAVA_HOME" ./gradlew --no-daemon \
 echo "== install: bake a booted quickboot snapshot into the base image =="
 # Boot the emulator once now so a fresh agent's start.sh loads a warm snapshot
 # instead of a ~10 min cold TCG boot. Best effort: never fail install on this.
+# emu_wait_boot has a hard timeout so a stuck emulator cannot hang install forever.
 if [ -w /dev/kvm ] || sudo chmod 666 /dev/kvm 2>/dev/null; then :; fi
 # shellcheck source=/dev/null
 source "$REPO_ROOT/.cursor/cloud/emulator.sh"

--- a/.cursor/cloud/install.sh
+++ b/.cursor/cloud/install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Cloud Agent install phase for dreamDroid.
+# Idempotent: installs JDK 17, the Android SDK, an emulator AVD, and warms the
+# Gradle build. Safe to re-run. Heavy stable state that a build snapshot keeps.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+CMDLINE_TOOLS_VERSION="11076708"
+AVD_NAME="dreamdroid-verify"
+SYSTEM_IMAGE="system-images;android-34;google_apis;x86_64"
+SDK_PACKAGES=(
+  "platform-tools"
+  "platforms;android-34"
+  "build-tools;34.0.0"
+  "emulator"
+  "$SYSTEM_IMAGE"
+)
+
+echo "== install: system packages (JDK 17, KVM, tools) =="
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+  openjdk-17-jdk qemu-kvm unzip curl
+
+# AGP 8.2's jlink transform fails on JDK 21, so pin the JVM default to 17.
+sudo update-java-alternatives -s java-1.17.0-openjdk-amd64 >/dev/null 2>&1 || true
+export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+echo "JAVA_HOME=$JAVA_HOME"
+java -version
+
+echo "== install: Android command-line tools =="
+mkdir -p "$ANDROID_SDK_ROOT"
+if [ ! -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+  tmp_zip="$(mktemp /tmp/cmdline-tools.XXXXXX.zip)"
+  curl -fsSL -o "$tmp_zip" \
+    "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+  rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/tmp"
+  mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools/tmp"
+  unzip -q "$tmp_zip" -d "$ANDROID_SDK_ROOT/cmdline-tools/tmp"
+  rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+  mv "$ANDROID_SDK_ROOT/cmdline-tools/tmp/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+  rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/tmp" "$tmp_zip"
+fi
+
+export ANDROID_SDK_ROOT ANDROID_HOME="$ANDROID_SDK_ROOT"
+SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+AVDMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
+
+echo "== install: accept licenses and install SDK packages =="
+yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
+"$SDKMANAGER" --install "${SDK_PACKAGES[@]}"
+
+echo "== install: create AVD '$AVD_NAME' =="
+if ! "$AVDMANAGER" list avd 2>/dev/null | grep -q "Name: $AVD_NAME"; then
+  echo "no" | "$AVDMANAGER" create avd \
+    --name "$AVD_NAME" \
+    --package "$SYSTEM_IMAGE" \
+    --device "pixel" \
+    --force
+fi
+
+echo "== install: point Gradle at the SDK (local.properties) =="
+printf 'sdk.dir=%s\n' "$ANDROID_SDK_ROOT" > "$REPO_ROOT/local.properties"
+
+echo "== install: raise adb install timeout for connected tests (TCG is slow) =="
+mkdir -p "$HOME/.gradle"
+cat > "$HOME/.gradle/init.gradle" <<'GRADLE'
+// Cloud Agent: the dreamDroid emulator runs under software (TCG) emulation
+// because nested KVM guest execution hangs on Cursor Cloud VMs. APK installs
+// are therefore slow, so raise the adb install/exec timeout for connected tests.
+allprojects {
+    plugins.withId("com.android.application") {
+        try {
+            def android = extensions.getByName("android")
+            android.adbOptions.timeOutInMs = 1_200_000
+        } catch (Throwable t) {
+            logger.lifecycle("init.gradle: could not set adbOptions.timeOutInMs: " + t)
+        }
+    }
+}
+GRADLE
+
+echo "== install: warm Gradle build (assembleGoogleDebug + test APK) =="
+cd "$REPO_ROOT"
+JAVA_HOME="$JAVA_HOME" ./gradlew --no-daemon \
+  :app:assembleGoogleDebug :app:assembleGoogleDebugAndroidTest
+
+echo "== install: bake a booted quickboot snapshot into the base image =="
+# Boot the emulator once now so a fresh agent's start.sh loads a warm snapshot
+# instead of a ~10 min cold TCG boot. Best effort: never fail install on this.
+if [ -w /dev/kvm ] || sudo chmod 666 /dev/kvm 2>/dev/null; then :; fi
+# shellcheck source=/dev/null
+source "$REPO_ROOT/.cursor/cloud/emulator.sh"
+if emu_launch cold && emu_wait_boot; then
+  echo "== install: saving quickboot snapshot 'default_boot' =="
+  "$ANDROID_SDK_ROOT/platform-tools/adb" -s emulator-5554 emu avd snapshot save default_boot || true
+  "$ANDROID_SDK_ROOT/platform-tools/adb" -s emulator-5554 emu kill || true
+  sleep 3
+else
+  echo "install: emulator did not boot during install; start.sh will cold boot" >&2
+fi
+
+echo "== install: done =="

--- a/.cursor/cloud/install.sh
+++ b/.cursor/cloud/install.sh
@@ -62,24 +62,6 @@ fi
 echo "== install: point Gradle at the SDK (local.properties) =="
 printf 'sdk.dir=%s\n' "$ANDROID_SDK_ROOT" > "$REPO_ROOT/local.properties"
 
-echo "== install: raise adb install timeout for connected tests (TCG is slow) =="
-mkdir -p "$HOME/.gradle"
-cat > "$HOME/.gradle/init.gradle" <<'GRADLE'
-// Cloud Agent: the dreamDroid emulator runs under software (TCG) emulation
-// because nested KVM guest execution hangs on Cursor Cloud VMs. APK installs
-// are therefore slow, so raise the adb install/exec timeout for connected tests.
-allprojects {
-    plugins.withId("com.android.application") {
-        try {
-            def android = extensions.getByName("android")
-            android.adbOptions.timeOutInMs = 1_200_000
-        } catch (Throwable t) {
-            logger.lifecycle("init.gradle: could not set adbOptions.timeOutInMs: " + t)
-        }
-    }
-}
-GRADLE
-
 echo "== install: warm Gradle build (assembleGoogleDebug + test APK) =="
 cd "$REPO_ROOT"
 JAVA_HOME="$JAVA_HOME" ./gradlew --no-daemon \

--- a/.cursor/cloud/start.sh
+++ b/.cursor/cloud/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Cloud Agent start phase for dreamDroid.
+# Per-boot: bring up the emulator that the instrumented Compose tests
+# (:app:connectedGoogleDebugAndroidTest) require. Loads the quickboot snapshot
+# baked in by install.sh so boot is fast. Idempotent: a booted device returns
+# immediately. Reaches readiness, then returns.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/emulator.sh"
+
+emu_launch quickboot
+emu_wait_boot

--- a/.cursor/cloud/start.sh
+++ b/.cursor/cloud/start.sh
@@ -7,6 +7,16 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$HOME/.cursor/dreamdroid/env.sh"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+fi
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export PATH="$JAVA_HOME/bin:$PATH"
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+export ANDROID_HOME="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
+
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/emulator.sh"
 

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "name": "dreamDroid",
+  "user": "ubuntu",
+  "install": "bash .cursor/cloud/install.sh",
+  "start": "bash .cursor/cloud/start.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,14 @@ Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets 
 
 Setup lives in [`.cursor/environment.json`](.cursor/environment.json) with scripts under `.cursor/cloud/`. `install.sh` installs JDK 17 + the Android SDK (build-tools 34, platform 34, `google_apis;x86_64` image), creates the `dreamdroid-verify` AVD, warms the Gradle build, and bakes a booted quickboot snapshot. `start.sh` boots that emulator each session.
 
-Nested KVM guest execution hangs on Cursor Cloud VMs: `/dev/kvm` exists and `kvm-ok` passes, but under `-enable-kvm` the guest vCPU never runs (0% CPU, no kernel output). The emulator therefore runs under software (`-accel off`, TCG). It works but is slow, so APK installs need a raised adb timeout (`~/.gradle/init.gradle` sets `adbOptions.timeOutInMs`). Set `DREAMDROID_EMU_ACCEL=auto` to try KVM on a host that supports nested virt.
+Nested KVM guest execution hangs on Cursor Cloud VMs: `/dev/kvm` exists and `kvm-ok` passes, but under `-enable-kvm` the guest vCPU never runs (0% CPU, no kernel output). The emulator therefore runs under software (`-accel off`, TCG). It works but is slow. Set `DREAMDROID_EMU_ACCEL=auto` to try KVM on a host that supports nested virt.
+
+Because of the slow emulator, the stock `:app:connectedGoogleDebugAndroidTest` task fails: UTP pushes the ~196 MB universal debug APK over ddmlib's sync protocol and the per-read socket timeout fires (it ignores `adbOptions.timeOutInMs`). On the Cloud VM, verify with the helper instead, which streams the standalone x86_64 APK and runs `am instrument`:
+
+```bash
+bash .cursor/cloud/connected-test.sh            # whole suite
+bash .cursor/cloud/connected-test.sh net.reichholf.dreamdroid.ui.about.AboutScreenTest
+```
 
 ## Other traps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets 
 
 `verify-dreamdroid.py` is for a single look when you need a screenshot or a shell-only path that has no test yet. It is not the verification loop.
 
+## Cloud Agent environment
+
+Setup lives in [`.cursor/environment.json`](.cursor/environment.json) with scripts under `.cursor/cloud/`. `install.sh` installs JDK 17 + the Android SDK (build-tools 34, platform 34, `google_apis;x86_64` image), creates the `dreamdroid-verify` AVD, warms the Gradle build, and bakes a booted quickboot snapshot. `start.sh` boots that emulator each session.
+
+Nested KVM guest execution hangs on Cursor Cloud VMs: `/dev/kvm` exists and `kvm-ok` passes, but under `-enable-kvm` the guest vCPU never runs (0% CPU, no kernel output). The emulator therefore runs under software (`-accel off`, TCG). It works but is slow, so APK installs need a raised adb timeout (`~/.gradle/init.gradle` sets `adbOptions.timeOutInMs`). Set `DREAMDROID_EMU_ACCEL=auto` to try KVM on a host that supports nested virt.
+
 ## Other traps
 
 - `main` is the rewrite. Do not merge rewrite work into `master`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up a reproducible Cloud Agent development environment for dreamDroid so agents can build the app and run the mandated instrumented Compose test suite end to end.

Adds:
- `.cursor/environment.json` — repo-managed environment wiring `install`/`start`.
- `.cursor/cloud/install.sh` — installs JDK 17, the Android SDK, creates the `dreamdroid-verify` AVD, warms Gradle, bakes a quickboot snapshot.
- `.cursor/cloud/start.sh` + `.cursor/cloud/emulator.sh` — per-boot emulator startup under a hard timeout.
- `.cursor/cloud/connected-test.sh` — streamed `adb install` + `am instrument` path for TCG emulator (always assembles unless `DREAMDROID_SKIP_ASSEMBLE=1`).
- `AGENTS.md` — Cloud Agent / nested-KVM notes.

## Review fixes

- Fail install if JDK 17 is missing; persist `JAVA_HOME` in `~/.cursor/dreamdroid/env.sh`.
- Deadline poll instead of unbounded `adb wait-for-device` (`DREAMDROID_BOOT_TIMEOUT`, default 600s).
- Always assemble before connected-test so snapshot-warmed APKs cannot mask a newer checkout.

## Validation

Rebased onto `main` after #175. App sources unchanged.

Do not pass `-Pandroid.testInstrumentationRunnerArguments...`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-358671ec-b743-4f6b-8ce5-29fd1dd614a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-358671ec-b743-4f6b-8ce5-29fd1dd614a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

