### PR TITLE
feat(epg): type ServiceEpgListFragment rows as enigma.Event

### DIFF
--- a/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ServiceEpgAdapter.java
+++ b/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ServiceEpgAdapter.java
@@ -1,0 +1,60 @@
+package net.reichholf.dreamdroid.adapter.recyclerview;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.enigma.Event;
+
+import java.util.List;
+
+/**
+ * XML EPG rows bound to typed Event. Detail sheet still receives ExtendedHashMap at the edge.
+ */
+public class ServiceEpgAdapter extends RecyclerView.Adapter<ServiceEpgAdapter.EventViewHolder> {
+	private final List<Event> mData;
+
+	public ServiceEpgAdapter(List<Event> data) {
+		mData = data;
+	}
+
+	@NonNull
+	@Override
+	public EventViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+		View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.epg_list_item, parent, false);
+		return new EventViewHolder(itemView);
+	}
+
+	@Override
+	public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
+		Event event = mData.get(position);
+		holder.title.setText(event.getTitle());
+		holder.description.setText(event.getDescriptionExtended());
+		holder.start.setText(event.getStartReadable());
+		holder.duration.setText(event.getDurationReadable());
+	}
+
+	@Override
+	public int getItemCount() {
+		return mData.size();
+	}
+
+	static class EventViewHolder extends RecyclerView.ViewHolder {
+		final TextView title;
+		final TextView description;
+		final TextView start;
+		final TextView duration;
+
+		EventViewHolder(@NonNull View itemView) {
+			super(itemView);
+			title = itemView.findViewById(R.id.event_title);
+			description = itemView.findViewById(R.id.event_short);
+			start = itemView.findViewById(R.id.event_start);
+			duration = itemView.findViewById(R.id.event_duration);
+		}
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetEventListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetEventListTask.java
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+import net.reichholf.dreamdroid.helpers.NameValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetEventListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	private ArrayList<Event> mEvents;
+
+	public GetEventListTask(GetEventListTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(ArrayList<NameValuePair> params) {
+		mEvents = new ArrayList<>();
+		if (isCancelled()) {
+			return false;
+		}
+		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
+		mEvents.addAll(HttpFragmentHelper.fetchEvents(getHttpClient(), requestParams));
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetEventListTaskHandler handler = (GetEventListTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onEventListReady(success, mEvents, success ? null : getErrorText());
+	}
+
+	public interface GetEventListTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onEventListReady(boolean success, @NonNull List<Event> events, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -20,11 +20,37 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getEvents(
+        params: List<NameValuePair> = emptyList(),
+        uri: String = URIStore.EPG_SERVICE
+    ): List<Event> {
+        return withContext(Dispatchers.IO) {
+            val requestParams = ArrayList(params)
+            if (!http.fetchPageContent(uri, requestParams)) {
+                emptyList()
+            } else {
+                EventParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
             return runBlocking {
                 EnigmaClient(http).getServices(params)
+            }
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun getEventsBlocking(
+            http: SimpleHttpClient,
+            params: List<NameValuePair>,
+            uri: String = URIStore.EPG_SERVICE
+        ): List<Event> {
+            return runBlocking {
+                EnigmaClient(http).getEvents(params, uri)
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/Event.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Event.kt
@@ -9,5 +9,8 @@ data class Event(
     val description: String = "",
     val descriptionExtended: String = "",
     val serviceReference: String = "",
-    val serviceName: String = ""
+    val serviceName: String = "",
+    val startReadable: String = "",
+    val startTimeReadable: String = "",
+    val durationReadable: String = ""
 )

--- a/app/src/net/reichholf/dreamdroid/enigma/EventParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EventParser.kt
@@ -13,16 +13,22 @@ object EventParser {
         if (xml.isEmpty()) {
             return emptyList()
         }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+            ?: emptyList()
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): List<Event>? {
         return try {
             val handler = EventListHandler()
             val factory = SAXParserFactory.newInstance()
             factory.isValidating = false
             val reader = factory.newSAXParser().xmlReader
             reader.contentHandler = handler
-            reader.parse(InputSource(StringReader(xml)))
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
             handler.events
         } catch (e: Exception) {
-            emptyList()
+            null
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/enigma/EventParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EventParser.kt
@@ -1,0 +1,157 @@
+package net.reichholf.dreamdroid.enigma
+
+import net.reichholf.dreamdroid.helpers.DateTime
+import net.reichholf.dreamdroid.helpers.Python
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object EventParser {
+    fun parse(xml: String): List<Event> {
+        if (xml.isEmpty()) {
+            return emptyList()
+        }
+        return try {
+            val handler = EventListHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(xml)))
+            handler.events
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+}
+
+private class EventListHandler : DefaultHandler() {
+    val events = ArrayList<Event>()
+    private var inEvent = false
+    private var inId = false
+    private var inStart = false
+    private var inDuration = false
+    private var inCurrentTime = false
+    private var inTitle = false
+    private var inDescription = false
+    private var inDescriptionEx = false
+    private var inServiceRef = false
+    private var inServiceName = false
+
+    private val eventId = StringBuilder()
+    private val title = StringBuilder()
+    private val start = StringBuilder()
+    private val duration = StringBuilder()
+    private val currentTime = StringBuilder()
+    private val description = StringBuilder()
+    private val descriptionExtended = StringBuilder()
+    private val serviceReference = StringBuilder()
+    private val serviceName = StringBuilder()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2event" -> {
+                inEvent = true
+                eventId.setLength(0)
+                title.setLength(0)
+                start.setLength(0)
+                duration.setLength(0)
+                currentTime.setLength(0)
+                description.setLength(0)
+                descriptionExtended.setLength(0)
+                serviceReference.setLength(0)
+                serviceName.setLength(0)
+            }
+            "e2eventid" -> inId = true
+            "e2eventstart" -> inStart = true
+            "e2eventduration" -> inDuration = true
+            "e2eventcurrenttime" -> inCurrentTime = true
+            "e2eventtitle" -> inTitle = true
+            "e2eventdescription" -> inDescription = true
+            "e2eventdescriptionextended" -> inDescriptionEx = true
+            "e2eventservicereference" -> inServiceRef = true
+            "e2eventservicename" -> inServiceName = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2event" -> {
+                inEvent = false
+                events.add(buildEvent())
+            }
+            "e2eventid" -> inId = false
+            "e2eventstart" -> inStart = false
+            "e2eventduration" -> inDuration = false
+            "e2eventcurrenttime" -> inCurrentTime = false
+            "e2eventtitle" -> inTitle = false
+            "e2eventdescription" -> inDescription = false
+            "e2eventdescriptionextended" -> inDescriptionEx = false
+            "e2eventservicereference" -> inServiceRef = false
+            "e2eventservicename" -> inServiceName = false
+        }
+    }
+
+    override fun characters(ch: CharArray, startIdx: Int, length: Int) {
+        if (!inEvent) {
+            return
+        }
+        when {
+            inId -> eventId.append(ch, startIdx, length)
+            inStart -> start.append(ch, startIdx, length)
+            inDuration -> duration.append(ch, startIdx, length)
+            inCurrentTime -> currentTime.append(ch, startIdx, length)
+            inTitle -> title.append(ch, startIdx, length)
+            inDescription -> description.append(ch, startIdx, length)
+            inDescriptionEx -> descriptionExtended.append(ch, startIdx, length)
+            inServiceRef -> serviceReference.append(ch, startIdx, length)
+            inServiceName -> serviceName.append(ch, startIdx, length)
+        }
+    }
+
+    private fun buildEvent(): Event {
+        val startRaw = start.toString().trim()
+        val durationRaw = duration.toString().trim()
+        var titleRaw = title.toString().trim()
+        if (titleRaw.isEmpty() || Python.NONE == titleRaw) {
+            titleRaw = "N/A"
+        }
+        val extDesc = descriptionExtended.toString().replace("\u008A", "\n")
+
+        var startReadable = ""
+        var startTimeReadable = ""
+        var durationReadable = ""
+        if (startRaw.isNotEmpty() && Python.NONE != startRaw) {
+            startReadable = DateTime.getDateTimeString(startRaw)
+            startTimeReadable = DateTime.getTimeString(startRaw)
+            durationReadable = try {
+                DateTime.getDurationString(durationRaw, startRaw) ?: durationRaw
+            } catch (e: NumberFormatException) {
+                durationRaw
+            }
+        }
+
+        return Event(
+            eventId = eventId.toString().trim(),
+            title = titleRaw,
+            start = startRaw,
+            duration = durationRaw,
+            currentTime = currentTime.toString().trim(),
+            description = description.toString(),
+            descriptionExtended = extDesc,
+            serviceReference = serviceReference.toString().trim(),
+            serviceName = serviceName.toString().replace("\\p{Cntrl}".toRegex(), "").trim(),
+            startReadable = startReadable,
+            startTimeReadable = startTimeReadable,
+            durationReadable = durationReadable
+        )
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/XmlInput.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/XmlInput.kt
@@ -1,0 +1,41 @@
+package net.reichholf.dreamdroid.enigma
+
+/**
+ * Mirrors [net.reichholf.dreamdroid.parsers.GenericSaxParser] control-character
+ * stripping so typed parsers survive the same messy Enigma2 XML payloads.
+ */
+internal object XmlInput {
+    private val aggressiveControl = Regex("\\p{C}")
+
+    fun sanitize(input: String, aggressive: Boolean): String {
+        return if (aggressive) {
+            aggressiveControl.replace(input, "").replace("&nbsp;", " ")
+        } else {
+            stripControlCharacters(input).replace("\u008A", "\n").replace("&nbsp;", " ")
+        }
+    }
+
+    private fun stripControlCharacters(s: String): String {
+        val length = s.length
+        val oldChars = CharArray(length + 1)
+        s.toCharArray(oldChars, 0, 0, length)
+        oldChars[length] = '\u0000'
+
+        var newLen = 0
+        while (true) {
+            newLen++
+            val ch = oldChars[newLen]
+            if (!(ch > ' ' || Character.isWhitespace(ch))) {
+                break
+            }
+        }
+        for (j in newLen until length) {
+            val ch = oldChars[j]
+            if (ch > ' ' || Character.isWhitespace(ch)) {
+                oldChars[newLen] = ch
+                newLen++
+            }
+        }
+        return String(oldChars, 0, newLen)
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
@@ -7,29 +7,42 @@
 package net.reichholf.dreamdroid.fragment;
 
 import android.os.Bundle;
+import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.loader.content.Loader;
+import androidx.recyclerview.widget.RecyclerView;
 
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.adapter.recyclerview.SimpleTextAdapter;
+import net.reichholf.dreamdroid.adapter.recyclerview.ServiceEpgAdapter;
+import net.reichholf.dreamdroid.asynctask.GetEventListTask;
+import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerEventFragment;
+import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailBottomSheet;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EventListRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Shows the EPG of a service. Timers can be set via integrated detail dialog
- * 
+ * Shows the EPG of a service. Timers can be set via integrated detail dialog.
+ * Rows are typed {@link Event}; detail/timer still take ExtendedHashMap at the edge.
+ *
  * @author sreichholf
- * 
  */
-public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
+public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment
+		implements GetEventListTask.GetEventListTaskHandler {
+	private final ArrayList<Event> mEvents = new ArrayList<>();
+	@Nullable
+	private GetEventListTask mEventListTask;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		mCardListStyle = true;
@@ -37,32 +50,38 @@ public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 		super.onCreate(savedInstanceState);
 		initTitle(getString(R.string.epg));
 
-		mReference = getDataForKey(Event.KEY_SERVICE_REFERENCE);
-		mName = getDataForKey(Event.KEY_SERVICE_NAME);
+		mReference = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE);
+		mName = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME);
 	}
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
+		mAdapter = new ServiceEpgAdapter(mEvents);
+		getRecyclerView().setAdapter(mAdapter);
 		super.onActivityCreated(savedInstanceState);
 
 		if (mReference != null) {
-			setAdapter();
-			if (mMapList.size() <= 0)
+			if (mEvents.isEmpty())
 				reload();
 		} else {
 			finish();
 		}
 	}
 
-	/**
-	 * Initializes the <code>SimpleTextAdapter</code>
-	 */
-	private void setAdapter() {
-		mAdapter = new SimpleTextAdapter(mMapList, R.layout.epg_list_item, new String[] {
-				Event.KEY_EVENT_TITLE, Event.KEY_EVENT_DESCRIPTION_EXTENDED, Event.KEY_EVENT_START_READABLE,
-				Event.KEY_EVENT_DURATION_READABLE }, new int[] { R.id.event_title, R.id.event_short, R.id.event_start,
-				R.id.event_duration });
-		getRecyclerView().setAdapter(mAdapter);
+	@Override
+	public void onDestroy() {
+		if (mEventListTask != null) {
+			mEventListTask.cancel(true);
+		}
+		super.onDestroy();
+	}
+
+	@Override
+	public void onItemClick(RecyclerView parent, View view, int position, long id) {
+		Event event = mEvents.get(position);
+		mCurrentItem = EpgListMapper.toExtendedHashMap(event);
+		EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(mCurrentItem);
+		getMultiPaneHandler().showDialogFragment(epgDetailBottomSheet, "epg_detail_dialog");
 	}
 
 	@NonNull
@@ -82,6 +101,69 @@ public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
+		// Service EPG no longer starts this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
 		return new AsyncListLoader(getAppCompatActivity(), new EventListRequestHandler(), false, args);
+	}
+
+	@Override
+	public void onLoadFinished(Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
+							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
+		// Unused: rows come from GetEventListTask / EnigmaClient.
+	}
+
+	@Override
+	protected void reload() {
+		if (mReference == null) {
+			finish();
+			return;
+		}
+		mReload = false;
+		if (mEvents.isEmpty())
+			setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+		else
+			setEmptyText(null);
+		loadEvents();
+	}
+
+	private void loadEvents() {
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (mEventListTask != null) {
+			mEventListTask.cancel(true);
+		}
+		mEventListTask = new GetEventListTask(this);
+		mEventListTask.execute(getHttpParams(HttpFragmentHelper.LOADER_DEFAULT_ID));
+	}
+
+	@Override
+	public void onEventListReady(boolean success, @NonNull List<Event> events, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		mEvents.clear();
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
+		if (!success) {
+			setEmptyText(errorText);
+			return;
+		}
+		setEmptyText(null);
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+
+		if (events.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mEvents.addAll(events);
+		}
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -282,6 +282,16 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getServicesBlocking(shc, params);
     }
 
+    @NonNull
+    public List<net.reichholf.dreamdroid.enigma.Event> fetchEvents(@NonNull List<NameValuePair> params) {
+        return fetchEvents(mShc, params);
+    }
+
+    @NonNull
+    public static List<net.reichholf.dreamdroid.enigma.Event> fetchEvents(@NonNull SimpleHttpClient shc, @NonNull List<NameValuePair> params) {
+        return EnigmaClient.getEventsBlocking(shc, params);
+    }
+
     public void onLoadStarted() {
         if (mIsReloading)
             return;

--- a/app/src/net/reichholf/dreamdroid/ui/epg/EpgListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/EpgListMapper.kt
@@ -1,0 +1,29 @@
+package net.reichholf.dreamdroid.ui.epg
+
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.enigma2.Event as EventKeys
+
+/**
+ * Service EPG list holds typed [Event] rows. Detail sheet / timer create still take
+ * [ExtendedHashMap]; convert only at that fragment boundary.
+ */
+object EpgListMapper {
+    @JvmStatic
+    fun toExtendedHashMap(event: Event): ExtendedHashMap {
+        val map = ExtendedHashMap()
+        map.put(EventKeys.KEY_EVENT_ID, event.eventId)
+        map.put(EventKeys.KEY_EVENT_TITLE, event.title)
+        map.put(EventKeys.KEY_EVENT_START, event.start)
+        map.put(EventKeys.KEY_EVENT_DURATION, event.duration)
+        map.put(EventKeys.KEY_CURRENT_TIME, event.currentTime)
+        map.put(EventKeys.KEY_EVENT_DESCRIPTION, event.description)
+        map.put(EventKeys.KEY_EVENT_DESCRIPTION_EXTENDED, event.descriptionExtended)
+        map.put(EventKeys.KEY_SERVICE_REFERENCE, event.serviceReference)
+        map.put(EventKeys.KEY_SERVICE_NAME, event.serviceName)
+        map.put(EventKeys.KEY_EVENT_START_READABLE, event.startReadable)
+        map.put(EventKeys.KEY_EVENT_START_TIME_READABLE, event.startTimeReadable)
+        map.put(EventKeys.KEY_EVENT_DURATION_READABLE, event.durationReadable)
+        return map
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/EventParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/EventParserTest.java
@@ -57,4 +57,29 @@ public class EventParserTest {
     public void malformedXmlYieldsNoEvents() {
         assertEquals(0, EventParser.INSTANCE.parse("<e2eventlist><e2event>").size());
     }
+
+    @Test
+    public void stripsIllegalControlCharactersBeforeParse() {
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2eventlist>"
+                + "<e2event>"
+                + "<e2eventid>1</e2eventid>"
+                + "<e2eventstart>1893456000</e2eventstart>"
+                + "<e2eventduration>60</e2eventduration>"
+                + "<e2eventcurrenttime>1893456000</e2eventcurrenttime>"
+                + "<e2eventtitle>News</e2eventtitle>"
+                + "<e2eventdescription>Has\u0001control</e2eventdescription>"
+                + "<e2eventdescriptionextended>More</e2eventdescriptionextended>"
+                + "<e2eventservicereference>1:0:1:1:1:1:0:0:0:0:</e2eventservicereference>"
+                + "<e2eventservicename>TV</e2eventservicename>"
+                + "</e2event>"
+                + "</e2eventlist>";
+        List<Event> events = EventParser.INSTANCE.parse(xml);
+        assertEquals(1, events.size());
+        assertEquals("News", events.get(0).getTitle());
+        assertTrue(events.get(0).getDescription().contains("Has"));
+        assertTrue(events.get(0).getDescription().contains("control"));
+        assertFalse(events.get(0).getDescription().contains("\u0001"));
+    }
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/EventParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/EventParserTest.java
@@ -1,0 +1,60 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class EventParserTest {
+    @Test
+    public void parsesEpgserviceFixtureIntoEventValues() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/epgservice.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        long started = System.nanoTime();
+        List<Event> events = EventParser.INSTANCE.parse(xml);
+        long elapsedNanos = System.nanoTime() - started;
+        System.out.println("EventParser.parse nanos=" + elapsedNanos);
+
+        assertEquals(2, events.size());
+
+        Event first = events.get(0);
+        assertEquals("39150", first.getEventId());
+        assertEquals("Tagesschau", first.getTitle());
+        assertEquals("1893456000", first.getStart());
+        assertEquals("3600", first.getDuration());
+        assertEquals("1893452400", first.getCurrentTime());
+        assertEquals("Nachrichten", first.getDescription());
+        assertTrue(first.getDescriptionExtended().contains("Die Nachrichten um 20 Uhr."));
+        assertTrue(first.getDescriptionExtended().contains("\n"));
+        assertFalse(first.getDescriptionExtended().contains("\u008A"));
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", first.getServiceReference());
+        assertEquals("Das Erste HD", first.getServiceName());
+        assertFalse(first.getStartReadable().isEmpty());
+        assertFalse(first.getStartTimeReadable().isEmpty());
+        assertEquals("60", first.getDurationReadable());
+
+        Event second = events.get(1);
+        assertEquals("39151", second.getEventId());
+        assertEquals("N/A", second.getTitle());
+        assertEquals("1893459600", second.getStart());
+        assertEquals("1800", second.getDuration());
+        assertEquals("30", second.getDurationReadable());
+    }
+
+    @Test
+    public void emptyXmlYieldsNoEvents() {
+        assertEquals(0, EventParser.INSTANCE.parse("").size());
+    }
+
+    @Test
+    public void malformedXmlYieldsNoEvents() {
+        assertEquals(0, EventParser.INSTANCE.parse("<e2eventlist><e2event>").size());
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/epg/EpgListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/epg/EpgListMapperTest.java
@@ -1,0 +1,39 @@
+package net.reichholf.dreamdroid.ui.epg;
+
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.enigma.EventParser;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class EpgListMapperTest {
+    @Test
+    public void toExtendedHashMapCopiesEventFields() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/epgservice.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Event> events = EventParser.INSTANCE.parse(xml);
+        Event event = events.get(0);
+
+        ExtendedHashMap map = EpgListMapper.toExtendedHashMap(event);
+        assertEquals(event.getEventId(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_ID));
+        assertEquals(event.getTitle(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_TITLE));
+        assertEquals(event.getStart(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_START));
+        assertEquals(event.getDuration(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_DURATION));
+        assertEquals(event.getCurrentTime(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_CURRENT_TIME));
+        assertEquals(event.getDescription(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_DESCRIPTION));
+        assertEquals(event.getDescriptionExtended(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_DESCRIPTION_EXTENDED));
+        assertEquals(event.getServiceReference(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE));
+        assertEquals(event.getServiceName(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME));
+        assertEquals(event.getStartReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_START_READABLE));
+        assertEquals(event.getStartTimeReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_START_TIME_READABLE));
+        assertEquals(event.getDurationReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_DURATION_READABLE));
+    }
+}

--- a/app/src/test/resources/web/epgservice.xml
+++ b/app/src/test/resources/web/epgservice.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2eventlist>
+	<e2event>
+		<e2eventid>39150</e2eventid>
+		<e2eventstart>1893456000</e2eventstart>
+		<e2eventduration>3600</e2eventduration>
+		<e2eventcurrenttime>1893452400</e2eventcurrenttime>
+		<e2eventtitle>Tagesschau</e2eventtitle>
+		<e2eventdescription>Nachrichten</e2eventdescription>
+		<e2eventdescriptionextended>Die Nachrichten um 20 Uhr.Mit Wetter.</e2eventdescriptionextended>
+		<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>Das Erste HD</e2eventservicename>
+	</e2event>
+	<e2event>
+		<e2eventid>39151</e2eventid>
+		<e2eventstart>1893459600</e2eventstart>
+		<e2eventduration>1800</e2eventduration>
+		<e2eventcurrenttime>1893452400</e2eventcurrenttime>
+		<e2eventtitle></e2eventtitle>
+		<e2eventdescription/>
+		<e2eventdescriptionextended/>
+		<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>Das Erste HD</e2eventservicename>
+	</e2event>
+</e2eventlist>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -23,11 +23,11 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | Zap typed rows | [#173](https://github.com/sreichholf/dreamDroid/pull/173) | merged | `452f7c80` typed `enigma.Service` into Zap. XML grid stays. |
 | Cloud Agent env | [#174](https://github.com/sreichholf/dreamDroid/pull/174) | merged | Cloud Agent `environment.json` / install helpers. |
 | dead-weight (MediaPlayer + MultiDex lib + orphan layouts) | [#175](https://github.com/sreichholf/dreamDroid/pull/175) | merged | drop unused MediaPlayer UI, `androidx.multidex` install helper, orphan XML. Keep `multiDexEnabled`, `MEDIA_PLAYER_PLAY`, ButterKnife. |
-| Event typed rows (ServiceEpgList) | this PR (`cursor/epg-typed-list-c88a`) | open | typed `enigma.Event` into `ServiceEpgListFragment`. XML list stays. Bouquet/search/timeline not migrated. |
+| Event typed rows (ServiceEpgList) | [#176](https://github.com/sreichholf/dreamDroid/pull/176) | open | typed `enigma.Event` into `ServiceEpgListFragment`. XML list stays. Bouquet/search/timeline not migrated. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175), and (2) Zap typing (#173) are on `main`. This PR continues shape (2) for the service EPG list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175), and (2) Zap typing (#173) are on `main`. [#176](https://github.com/sreichholf/dreamDroid/pull/176) continues shape (2) for the service EPG list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 ### Operator overrides (this program)
 
@@ -46,7 +46,7 @@ Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#1
 - `ProfileAdapter` remains for `ShareActivity`.
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Zap still XML. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker still returns `ExtendedHashMap`; Zap converts at the fragment boundary.
-- Service EPG list still XML. Rows are typed `enigma.Event` in this PR. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Bouquet/search/timeline EPG remain hash maps.
+- Service EPG list still XML. Rows are typed `enigma.Event` in #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Bouquet/search/timeline EPG remain hash maps.
 
 ## How to read this
 
@@ -301,7 +301,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 | Profile add/edit | `ProfileEditFragment` | List is Compose; form is XML. Autodiscovery stays Java. |
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
 | Zap | `ZapFragment`, `ZapAdapter` | XML grid. Rows are typed `enigma.Service` (#173). Picker still `ExtendedHashMap`. |
-| Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (this PR). Detail/timer edge still hash. |
+| Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (#176). Detail/timer edge still hash. |
 | EPG bouquet / search / timeline | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgTimelineFragment`, `EpgAdapter` | Still `ExtendedHashMap`. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
 | Current event | `CurrentServiceFragment` | |
@@ -319,7 +319,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (this PR). Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (5 files), `legacy-support-v4`, `legacy-preference-v14`. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -333,12 +333,12 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** Service EPG list typed in this PR. Bouquet/search/timeline EPG and current event remain.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** Service EPG list typed in #176. Bouquet/search/timeline EPG and current event remain.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), preference-v14, unused MediaPlayer entry. `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). Still open later: preference-v14, legacy-support-v4, dead `EpgTimelineFragment`, unused menus, GONE bottom nav.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
 
-Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Service EPG list typing is this PR. Next typed path: bouquet/search EPG or current event, or Profile edit Compose.
+Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Service EPG list typing is #176. Next typed path: bouquet/search EPG or current event, or Profile edit Compose.
 
 ## Appendix F. Links
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -21,11 +21,13 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | skill+plan | [#171](https://github.com/sreichholf/dreamDroid/pull/171) | merged | `b98ac193` |
 | dead-weight (retrostreams + stub) | [#172](https://github.com/sreichholf/dreamDroid/pull/172) | merged | `970ad4bc` drop android-retrostreams + leftover `app/res/service_list_pager.xml` |
 | Zap typed rows | [#173](https://github.com/sreichholf/dreamDroid/pull/173) | merged | `452f7c80` typed `enigma.Service` into Zap. XML grid stays. |
-| dead-weight (MediaPlayer + MultiDex lib + orphan layouts) | [#175](https://github.com/sreichholf/dreamDroid/pull/175) | open | drop unused MediaPlayer UI, `androidx.multidex` install helper, orphan XML. Keep `multiDexEnabled`, `MEDIA_PLAYER_PLAY`, ButterKnife. |
+| Cloud Agent env | [#174](https://github.com/sreichholf/dreamDroid/pull/174) | merged | Cloud Agent `environment.json` / install helpers. |
+| dead-weight (MediaPlayer + MultiDex lib + orphan layouts) | [#175](https://github.com/sreichholf/dreamDroid/pull/175) | merged | drop unused MediaPlayer UI, `androidx.multidex` install helper, orphan XML. Keep `multiDexEnabled`, `MEDIA_PLAYER_PLAY`, ButterKnife. |
+| Event typed rows (ServiceEpgList) | this PR (`cursor/epg-typed-list-c88a`) | open | typed `enigma.Event` into `ServiceEpgListFragment`. XML list stays. Bouquet/search/timeline not migrated. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172), and (2) Zap typing (#173) are on `main`. [#175](https://github.com/sreichholf/dreamDroid/pull/175) continues dead-weight (4). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175), and (2) Zap typing (#173) are on `main`. This PR continues shape (2) for the service EPG list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 ### Operator overrides (this program)
 
@@ -44,6 +46,7 @@ Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172), 
 - `ProfileAdapter` remains for `ShareActivity`.
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Zap still XML. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker still returns `ExtendedHashMap`; Zap converts at the fragment boundary.
+- Service EPG list still XML. Rows are typed `enigma.Event` in this PR. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Bouquet/search/timeline EPG remain hash maps.
 
 ## How to read this
 
@@ -223,6 +226,23 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 
 - [x] `ZapListMapperTest` plus `ServiceParserTest`. `:app:testGoogleDebugUnitTest`. Assemble googleDebug. Connected tests when a device exists.
 
+## Type Service EPG list rows (pr-epg-event)
+
+**Depends on.** pr-client, #173. **`cursor/epg-typed-list-c88a`, `--base main`.**
+
+**Files.**
+
+- [x] `EventParser` parses `/web/epgservice` into `enigma.Event` (readable fields included).
+- [x] `EnigmaClient.getEvents` / `getEventsBlocking` (+ URI param for later bouquet/search).
+- [x] `GetEventListTask` → `HttpFragmentHelper.fetchEvents` → `EnigmaClient`.
+- [x] `ServiceEpgListFragment` / `ServiceEpgAdapter` hold `List<Event>`. XML `epg_list_item` stays.
+- [x] `EpgListMapper.toExtendedHashMap` at detail/timer edge only. Do not rewrite `EpgDetailBottomSheet`.
+- [ ] `EpgBouquetFragment` / `EpgSearchFragment` / `EpgTimelineFragment`, drawer shell, Compose Navigation **not** in this PR.
+
+**Verify, unit.**
+
+- [x] `EventParserTest` plus `EpgListMapperTest`. `:app:testGoogleDebugUnitTest`. Assemble googleDebug.
+
 ## Appendix A. Prototype evidence
 
 Compose versus XML Views was not prototyped in-repo. Plan mode blocked a throwaway sketch. The choice is Compose because minSdk 26 allows the current BOM, and Material 3 in [`app/res/values/themes.xml`](../app/res/values/themes.xml) already parents `Theme.Material3`.
@@ -281,7 +301,8 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 | Profile add/edit | `ProfileEditFragment` | List is Compose; form is XML. Autodiscovery stays Java. |
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
 | Zap | `ZapFragment`, `ZapAdapter` | XML grid. Rows are typed `enigma.Service` (#173). Picker still `ExtendedHashMap`. |
-| EPG bouquet / search / timeline | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgTimelineFragment`, `ServiceEpgListFragment`, `EpgAdapter` | |
+| Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (this PR). Detail/timer edge still hash. |
+| EPG bouquet / search / timeline | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgTimelineFragment`, `EpgAdapter` | Still `ExtendedHashMap`. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
 | Current event | `CurrentServiceFragment` | |
 | Virtual remote | `VirtualRemoteFragment`, `VirtualRemotePagerFragment` | |
@@ -298,7 +319,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (this PR). Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (5 files), `legacy-support-v4`, `legacy-preference-v14`. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -312,12 +333,12 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** EPG and current event remain.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** Service EPG list typed in this PR. Bouquet/search/timeline EPG and current event remain.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
-4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), preference-v14, unused MediaPlayer entry. `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in [#175](https://github.com/sreichholf/dreamDroid/pull/175). Still open later: preference-v14, legacy-support-v4, dead `EpgTimelineFragment`, unused menus, GONE bottom nav.
+4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen), preference-v14, unused MediaPlayer entry. `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). Still open later: preference-v14, legacy-support-v4, dead `EpgTimelineFragment`, unused menus, GONE bottom nav.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
 
-Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Next typed path: Event list or Profile edit Compose.
+Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Service EPG list typing is this PR. Next typed path: bouquet/search EPG or current event, or Profile edit Compose.
 
 ## Appendix F. Links
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Wave 2 shape (2) after Zap [#173](https://github.com/sreichholf/dreamDroid/pull/173): retire `ExtendedHashMap` on the service EPG list path so typed `enigma.Event` is the row type, not a second unused model.

#174 (Cloud Agent env) and #175 (MediaPlayer dead-weight) are already on `main`.

## Scope

- `EventParser` + `XmlInput` sanitize (mirrors `GenericSaxParser` control-char strip + aggressive retry).
- `EnigmaClient.getEvents` / `getEventsBlocking` (URI param ready for bouquet/search later).
- `GetEventListTask` → `HttpFragmentHelper.fetchEvents`.
- `ServiceEpgListFragment` / `ServiceEpgAdapter` hold `List<Event>`; XML `epg_list_item` stays.
- `EpgListMapper` maps to `ExtendedHashMap` only for `EpgDetailBottomSheet` / timer create.

## Out of scope

- `EpgBouquetFragment` / `EpgSearchFragment` / `EpgTimelineFragment`
- Drawer shell / Compose Navigation
- Leanback, ButterKnife, OkHttp bump

## Verification

JDK 17. Bugbot asked for XML sanitization; addressed with `XmlInput` + control-char unit test.

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL (prior turn)
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL (`EventParserTest`, `EpgListMapperTest`, Zap/ServiceParser/MinSdk)
- connectedAndroidTest — not run on this turn (no booted emulator yet)

Do not pass `-Pandroid.testInstrumentationRunnerArguments...`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

