### PR TITLE
feat(epg): type EpgBouquetFragment rows as enigma.Event

### DIFF
--- a/app/src/net/reichholf/dreamdroid/adapter/recyclerview/EpgBouquetAdapter.java
+++ b/app/src/net/reichholf/dreamdroid/adapter/recyclerview/EpgBouquetAdapter.java
@@ -1,0 +1,72 @@
+package net.reichholf.dreamdroid.adapter.recyclerview;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.helpers.Statics;
+import net.reichholf.dreamdroid.helpers.enigma2.Picon;
+
+import java.util.List;
+
+/**
+ * XML multi-service EPG rows bound to typed Event. Detail sheet still receives ExtendedHashMap at the edge.
+ * EpgSearch keeps {@link EpgAdapter} on ExtendedHashMap.
+ */
+public class EpgBouquetAdapter extends RecyclerView.Adapter<EpgBouquetAdapter.EventViewHolder> {
+	private final List<Event> mData;
+
+	public EpgBouquetAdapter(List<Event> data) {
+		mData = data;
+	}
+
+	@NonNull
+	@Override
+	public EventViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+		View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.epg_multi_service_list_item, parent, false);
+		return new EventViewHolder(itemView);
+	}
+
+	@Override
+	public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
+		Event event = mData.get(position);
+		holder.title.setText(event.getTitle());
+		holder.serviceName.setText(event.getServiceName());
+		holder.description.setText(event.getDescriptionExtended());
+		holder.start.setText(event.getStartReadable());
+		holder.duration.setText(event.getDurationReadable());
+		Picon.setPiconForView(holder.itemView.getContext(), holder.picon,
+				event.getServiceReference(), event.getServiceName(), Statics.TAG_PICON, null);
+	}
+
+	@Override
+	public int getItemCount() {
+		return mData.size();
+	}
+
+	static class EventViewHolder extends RecyclerView.ViewHolder {
+		final ImageView picon;
+		final TextView title;
+		final TextView serviceName;
+		final TextView description;
+		final TextView start;
+		final TextView duration;
+
+		EventViewHolder(@NonNull View itemView) {
+			super(itemView);
+			picon = itemView.findViewById(R.id.picon);
+			title = itemView.findViewById(R.id.event_title);
+			serviceName = itemView.findViewById(R.id.service_name);
+			description = itemView.findViewById(R.id.event_short);
+			start = itemView.findViewById(R.id.event_start);
+			duration = itemView.findViewById(R.id.event_duration);
+		}
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetEventListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetEventListTask.java
@@ -6,15 +6,22 @@ import androidx.annotation.Nullable;
 import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
+import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class GetEventListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	private final String mUri;
 	private ArrayList<Event> mEvents;
 
 	public GetEventListTask(GetEventListTaskHandler taskHandler) {
+		this(taskHandler, URIStore.EPG_SERVICE);
+	}
+
+	public GetEventListTask(GetEventListTaskHandler taskHandler, @NonNull String uri) {
 		super(taskHandler);
+		mUri = uri;
 	}
 
 	@NonNull
@@ -25,7 +32,7 @@ public class GetEventListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>
 			return false;
 		}
 		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
-		mEvents.addAll(HttpFragmentHelper.fetchEvents(getHttpClient(), requestParams));
+		mEvents.addAll(HttpFragmentHelper.fetchEvents(getHttpClient(), requestParams, mUri));
 		return !getHttpClient().hasError();
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.loader.content.Loader;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.evernote.android.state.State;
 import com.google.android.material.datepicker.MaterialDatePicker;
@@ -23,27 +24,39 @@ import com.google.android.material.timepicker.TimeFormat;
 
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
-import net.reichholf.dreamdroid.adapter.recyclerview.EpgAdapter;
+import net.reichholf.dreamdroid.adapter.recyclerview.EpgBouquetAdapter;
+import net.reichholf.dreamdroid.asynctask.GetEventListTask;
+import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerEventFragment;
+import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailBottomSheet;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EventListRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 
 /**
- * Created by Stephan on 01.11.2014.
+ * Bouquet EPG at a chosen date/time. Rows are typed {@link Event}; detail/timer still take
+ * ExtendedHashMap at the edge. Bouquet picker still returns ExtendedHashMap; reference/name
+ * are taken at this fragment boundary.
  */
-public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
+public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
+		implements GetEventListTask.GetEventListTaskHandler {
 	private static final String LOG_TAG = EpgBouquetFragment.class.getSimpleName();
+
+	private final ArrayList<Event> mEvents = new ArrayList<>();
+	@Nullable
+	private GetEventListTask mEventListTask;
 
 	private TextView mDateView;
 	private TextView mTimeView;
@@ -64,8 +77,8 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 				mTime = now;
 		}
 		if (mReference == null || mName == null) {
-			mReference = getArguments().getString(Event.KEY_SERVICE_REFERENCE, null);
-			mName = getArguments().getString(Event.KEY_SERVICE_NAME, null);
+			mReference = getArguments().getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE, null);
+			mName = getArguments().getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME, null);
 		}
 
 		mWaitingForPicker = false;
@@ -123,10 +136,19 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
-		setAdapter();
-		if (mMapList.size() <= 0)
+		mAdapter = new EpgBouquetAdapter(mEvents);
+		getRecyclerView().setAdapter(mAdapter);
+		if (mEvents.isEmpty())
 			Log.w(LOG_TAG, String.format("%s", mTime));
 		super.onActivityCreated(savedInstanceState);
+	}
+
+	@Override
+	public void onDestroy() {
+		if (mEventListTask != null) {
+			mEventListTask.cancel(true);
+		}
+		super.onDestroy();
 	}
 
 	@Override
@@ -135,6 +157,13 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 		inflater.inflate(R.menu.epgbouquet, menu);
 	}
 
+	@Override
+	public void onItemClick(RecyclerView parent, View view, int position, long id) {
+		Event event = mEvents.get(position);
+		mCurrentItem = EpgListMapper.toExtendedHashMap(event);
+		EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(mCurrentItem);
+		getMultiPaneHandler().showDialogFragment(epgDetailBottomSheet, "epg_detail_dialog");
+	}
 
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, @NonNull Intent data) {
@@ -142,6 +171,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 			return;
 		switch (requestCode) {
 			case Statics.REQUEST_PICK_BOUQUET:
+				// PickServiceFragment still returns ExtendedHashMap; take reference/name here.
 				ExtendedHashMap service = (ExtendedHashMap) data.getSerializableExtra(PickServiceFragment.KEY_BOUQUET);
 				String reference = service.getString(Service.KEY_REFERENCE);
 				if (!reference.equals(mReference)) {
@@ -158,21 +188,16 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 
 	@Override
 	protected void reload() {
-		if (mReference != null && !mReference.isEmpty())
-			super.reload();
-		else if (!mWaitingForPicker)
+		if (mReference != null && !mReference.isEmpty()) {
+			mReload = false;
+			if (mEvents.isEmpty())
+				setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+			else
+				setEmptyText(null);
+			loadEvents();
+		} else if (!mWaitingForPicker) {
 			pickBouquet();
-	}
-
-	/**
-	 * Initializes the <code>SimpleTextAdapter</code>
-	 */
-	private void setAdapter() {
-		mAdapter = new EpgAdapter(mMapList, R.layout.epg_multi_service_list_item, new String[]{
-				Event.KEY_EVENT_TITLE, Event.KEY_SERVICE_NAME, Event.KEY_EVENT_DESCRIPTION_EXTENDED, Event.KEY_EVENT_START_READABLE,
-				Event.KEY_EVENT_DURATION_READABLE}, new int[]{R.id.event_title, R.id.service_name, R.id.event_short, R.id.event_start,
-				R.id.event_duration});
-		getRecyclerView().setAdapter(mAdapter);
+		}
 	}
 
 	@NonNull
@@ -193,7 +218,56 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
+		// Bouquet EPG no longer starts this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
 		return new AsyncListLoader(getAppCompatActivity(), new EventListRequestHandler(URIStore.EPG_BOUQUET), false, args);
+	}
+
+	@Override
+	public void onLoadFinished(Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
+							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
+		// Unused: rows come from GetEventListTask / EnigmaClient.
+	}
+
+	private void loadEvents() {
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (mEventListTask != null) {
+			mEventListTask.cancel(true);
+		}
+		mEventListTask = new GetEventListTask(this, URIStore.EPG_BOUQUET);
+		mEventListTask.execute(getHttpParams(HttpFragmentHelper.LOADER_DEFAULT_ID));
+	}
+
+	@Override
+	public void onEventListReady(boolean success, @NonNull List<Event> events, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		mEvents.clear();
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
+		if (!success) {
+			setEmptyText(errorText);
+			return;
+		}
+		setEmptyText(null);
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+
+		if (events.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mEvents.addAll(events);
+		}
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
 	}
 
 	@Override
@@ -261,6 +335,4 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 		Log.i(LOG_TAG, String.format("%s", mTime));
 		reload();
 	}
-
-
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -288,8 +288,18 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
     }
 
     @NonNull
+    public List<net.reichholf.dreamdroid.enigma.Event> fetchEvents(@NonNull List<NameValuePair> params, @NonNull String uri) {
+        return fetchEvents(mShc, params, uri);
+    }
+
+    @NonNull
     public static List<net.reichholf.dreamdroid.enigma.Event> fetchEvents(@NonNull SimpleHttpClient shc, @NonNull List<NameValuePair> params) {
-        return EnigmaClient.getEventsBlocking(shc, params);
+        return fetchEvents(shc, params, net.reichholf.dreamdroid.helpers.enigma2.URIStore.EPG_SERVICE);
+    }
+
+    @NonNull
+    public static List<net.reichholf.dreamdroid.enigma.Event> fetchEvents(@NonNull SimpleHttpClient shc, @NonNull List<NameValuePair> params, @NonNull String uri) {
+        return EnigmaClient.getEventsBlocking(shc, params, uri);
     }
 
     public void onLoadStarted() {

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -25,10 +25,11 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | dead-weight (MediaPlayer + MultiDex lib + orphan layouts) | [#175](https://github.com/sreichholf/dreamDroid/pull/175) | merged | drop unused MediaPlayer UI, `androidx.multidex` install helper, orphan XML. Keep `multiDexEnabled`, `MEDIA_PLAYER_PLAY`, ButterKnife. |
 | Event typed rows (ServiceEpgList) | [#176](https://github.com/sreichholf/dreamDroid/pull/176) | merged | typed `enigma.Event` into `ServiceEpgListFragment`. XML list stays. Bouquet/search EPG not migrated. |
 | dead-weight (EPG timeline + prefs + menus + bottom nav) | [#177](https://github.com/sreichholf/dreamDroid/pull/177) | merged | `c89afc11` drop dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. Keep ButterKnife. |
+| EPG bouquet typed rows | open (`cursor/epg-bouquet-typed-c88a`) | open | typed `enigma.Event` into `EpgBouquetFragment` / `EpgBouquetAdapter`. `EpgSearchFragment` still `ExtendedHashMap` via `EpgAdapter`. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) Zap typing (#173) plus Service EPG typing (#176) are on `main`. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) Zap typing (#173) plus Service EPG typing (#176) are on `main`. EPG bouquet typed rows are open on `cursor/epg-bouquet-typed-c88a`. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 ### Operator overrides (this program)
 
@@ -47,7 +48,8 @@ Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#1
 - `ProfileAdapter` remains for `ShareActivity`.
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Zap still XML. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker still returns `ExtendedHashMap`; Zap converts at the fragment boundary.
-- Service EPG list still XML. Rows are typed `enigma.Event` on `main` via #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Bouquet/search EPG remain hash maps. Dead `EpgTimelineFragment` removed in #177.
+- Service EPG list still XML. Rows are typed `enigma.Event` on `main` via #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Dead `EpgTimelineFragment` removed in #177.
+- EPG bouquet typed rows are in progress on `cursor/epg-bouquet-typed-c88a` (`EpgBouquetFragment` / `EpgBouquetAdapter`). `EpgSearchFragment` still uses `ExtendedHashMap` / `EpgAdapter`.
 
 ## How to read this
 
@@ -238,11 +240,27 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 - [x] `GetEventListTask` → `HttpFragmentHelper.fetchEvents` → `EnigmaClient`.
 - [x] `ServiceEpgListFragment` / `ServiceEpgAdapter` hold `List<Event>`. XML `epg_list_item` stays.
 - [x] `EpgListMapper.toExtendedHashMap` at detail/timer edge only. Do not rewrite `EpgDetailBottomSheet`.
-- [ ] `EpgBouquetFragment` / `EpgSearchFragment`, drawer shell, Compose Navigation **not** in this PR. Dead `EpgTimelineFragment` removed separately in dead-weight.
+- [ ] `EpgBouquetFragment` / `EpgSearchFragment`, drawer shell, Compose Navigation **not** in this PR. Dead `EpgTimelineFragment` removed separately in dead-weight. Bouquet typing is the next unit below.
 
 **Verify, unit.**
 
 - [x] `EventParserTest` plus `EpgListMapperTest`. `:app:testGoogleDebugUnitTest`. Assemble googleDebug.
+
+## Type EPG bouquet list rows (pr-epg-bouquet)
+
+**Depends on.** #176. **Open on `cursor/epg-bouquet-typed-c88a`.**
+
+**Files.**
+
+- [x] `HttpFragmentHelper.fetchEvents` / `GetEventListTask` accept optional URI (default `URIStore.EPG_SERVICE`; bouquet uses `URIStore.EPG_BOUQUET`).
+- [x] `EpgBouquetFragment` / `EpgBouquetAdapter` hold `List<Event>`. XML `epg_multi_service_list_item` stays.
+- [x] `EpgListMapper.toExtendedHashMap` at detail/timer edge only. Do not rewrite `EpgDetailBottomSheet`.
+- [x] Bouquet picker (`PickServiceFragment`) still returns `ExtendedHashMap`; reference/name taken at the fragment boundary.
+- [ ] `EpgSearchFragment` still hash via `EpgAdapter`. Drawer shell, Compose Navigation **not** in this PR.
+
+**Verify, unit.**
+
+- [x] Existing `EventParserTest` / `EpgListMapperTest`. `:app:testGoogleDebugUnitTest`. Assemble googleDebug.
 
 ## Appendix A. Prototype evidence
 
@@ -303,7 +321,8 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
 | Zap | `ZapFragment`, `ZapAdapter` | XML grid. Rows are typed `enigma.Service` (#173). Picker still `ExtendedHashMap`. |
 | Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (#176). Detail/timer edge still hash. |
-| EPG bouquet / search | `EpgBouquetFragment`, `EpgSearchFragment`, `EpgAdapter` | Still `ExtendedHashMap`. Dead timeline fragment removed. |
+| EPG bouquet | `EpgBouquetFragment`, `EpgBouquetAdapter` | XML list. Typed `enigma.Event` on open branch `cursor/epg-bouquet-typed-c88a`. Detail/timer edge still hash. |
+| EPG search | `EpgSearchFragment`, `EpgAdapter` | Still `ExtendedHashMap`. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
 | Current event | `CurrentServiceFragment` | |
 | Virtual remote | `VirtualRemoteFragment`, `VirtualRemotePagerFragment` | |
@@ -320,7 +339,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` on `cursor/epg-bouquet-typed-c88a`. `EpgSearch` and other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (5 files). `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -334,12 +353,12 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** Service EPG list typed on `main` as #176. Bouquet/search EPG and current event remain.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Zap typed on `main` as #173.** Service EPG list typed on `main` as #176. EPG bouquet typing open on `cursor/epg-bouquet-typed-c88a`. EPG search and current event remain hash.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen). `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). #177: dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. ButterKnife still open while TV is frozen.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
 
-Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Service EPG list typing is on `main` as #176. Next typed path: bouquet/search EPG or current event, or Profile edit Compose.
+Recommended default if the operator just says go: (1) then (4), then (2) one list path at a time; keep (3) and (5) as later programs. Zap typing is on `main` as #173. Service EPG list typing is on `main` as #176. Bouquet EPG typing is open on `cursor/epg-bouquet-typed-c88a`. Next after that: EPG search or current event, or Profile edit Compose.
 
 ## Appendix F. Links
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Appendix E shape (2): retire `ExtendedHashMap` on one list path at a time. Service EPG (#176) is on `main`; bouquet EPG is next.

## Scope

- `GetEventListTask` / `HttpFragmentHelper.fetchEvents` accept optional URI (default `EPG_SERVICE`); bouquet uses `URIStore.EPG_BOUQUET`.
- `EpgBouquetFragment` holds `List<Event>` via new `EpgBouquetAdapter` (XML `epg_multi_service_list_item` stays).
- Detail/timer edges still use `EpgListMapper.toExtendedHashMap`.
- Bouquet picker hash stays at the fragment boundary.

## Out of scope

- `EpgSearchFragment` (still hash / `EpgAdapter`) — next PR
- Leanback, ButterKnife, OkHttp, drawer shell

## Verification

JDK 17. Bugbot: no bugs.

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL (13 tests)

Do not pass `-Pandroid.testInstrumentationRunnerArguments...`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

