### PR TITLE
feat(current): type CurrentServiceFragment /web/getcurrent

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
@@ -16,7 +16,7 @@ public class GetCurrentServiceTask extends AsyncHttpTaskBase<Void, String, Boole
 
 	@NonNull
 	@Override
-	protected Boolean doInBackground(Void... voids) {
+	protected Boolean doInBackground(Void unused) {
 		mCurrent = null;
 		if (isCancelled()) {
 			return false;

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
@@ -22,7 +22,11 @@ public class GetCurrentServiceTask extends AsyncHttpTaskBase<Void, String, Boole
 			return false;
 		}
 		mCurrent = HttpFragmentHelper.fetchCurrentService(getHttpClient());
-		return !getHttpClient().hasError();
+		if (getHttpClient().hasError()) {
+			return false;
+		}
+		// HTTP ok but SAX/parser failed — not a successful load.
+		return mCurrent != null;
 	}
 
 	@Override
@@ -31,8 +35,16 @@ public class GetCurrentServiceTask extends AsyncHttpTaskBase<Void, String, Boole
 		if (isInvalid(handler)) {
 			return;
 		}
-		boolean success = Boolean.TRUE.equals(result);
-		handler.onCurrentServiceReady(success, mCurrent, success ? null : getErrorText());
+		boolean success = Boolean.TRUE.equals(result) && mCurrent != null;
+		String errorText = null;
+		if (!success) {
+			if (getHttpClient().hasError()) {
+				errorText = getErrorText();
+			} else {
+				errorText = handler.getString(net.reichholf.dreamdroid.R.string.error_parsing);
+			}
+		}
+		handler.onCurrentServiceReady(success, mCurrent, errorText);
 	}
 
 	public interface GetCurrentServiceTaskHandler extends AsyncHttpTaskBaseHandler {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetCurrentServiceTask.java
@@ -1,0 +1,41 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.CurrentService;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+
+public class GetCurrentServiceTask extends AsyncHttpTaskBase<Void, String, Boolean> {
+	@Nullable
+	private CurrentService mCurrent;
+
+	public GetCurrentServiceTask(GetCurrentServiceTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(Void... voids) {
+		mCurrent = null;
+		if (isCancelled()) {
+			return false;
+		}
+		mCurrent = HttpFragmentHelper.fetchCurrentService(getHttpClient());
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetCurrentServiceTaskHandler handler = (GetCurrentServiceTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onCurrentServiceReady(success, mCurrent, success ? null : getErrorText());
+	}
+
+	public interface GetCurrentServiceTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onCurrentServiceReady(boolean success, @Nullable CurrentService current, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/CurrentService.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/CurrentService.kt
@@ -1,0 +1,16 @@
+package net.reichholf.dreamdroid.enigma
+
+import java.io.Serializable
+
+/**
+ * Typed `/web/getcurrent` payload: the tuned [Service] plus now/next [Event]s.
+ */
+data class CurrentService(
+    val service: Service = Service("", ""),
+    val now: Event? = null,
+    val next: Event? = null
+) : Serializable {
+    fun isEmpty(): Boolean {
+        return service.reference.isEmpty() && service.name.isEmpty() && now == null && next == null
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
@@ -41,18 +41,6 @@ private class CurrentServiceHandler : DefaultHandler() {
     private var inServiceReference = false
     private var inServiceName = false
     private var inProviderName = false
-    private var inVideoWidth = false
-    private var inVideoHeight = false
-    private var inVideoSize = false
-    private var inIsWideScreen = false
-    private var inApid = false
-    private var inVpid = false
-    private var inPcrPid = false
-    private var inPmtPid = false
-    private var inTxtPid = false
-    private var inTsid = false
-    private var inOnid = false
-    private var inSid = false
 
     private var inEventServiceReference = false
     private var inEventServiceName = false
@@ -67,18 +55,6 @@ private class CurrentServiceHandler : DefaultHandler() {
     private val serviceReference = StringBuilder()
     private val serviceName = StringBuilder()
     private val provider = StringBuilder()
-    private val videoWidth = StringBuilder()
-    private val videoHeight = StringBuilder()
-    private val videoSize = StringBuilder()
-    private val widescreen = StringBuilder()
-    private val apid = StringBuilder()
-    private val vpid = StringBuilder()
-    private val pcrPid = StringBuilder()
-    private val pmtPid = StringBuilder()
-    private val txtPid = StringBuilder()
-    private val tsid = StringBuilder()
-    private val onid = StringBuilder()
-    private val sid = StringBuilder()
 
     private val eventId = StringBuilder()
     private val title = StringBuilder()
@@ -100,34 +76,10 @@ private class CurrentServiceHandler : DefaultHandler() {
                 serviceReference.setLength(0)
                 serviceName.setLength(0)
                 provider.setLength(0)
-                videoWidth.setLength(0)
-                videoHeight.setLength(0)
-                videoSize.setLength(0)
-                widescreen.setLength(0)
-                apid.setLength(0)
-                vpid.setLength(0)
-                pcrPid.setLength(0)
-                pmtPid.setLength(0)
-                txtPid.setLength(0)
-                tsid.setLength(0)
-                onid.setLength(0)
-                sid.setLength(0)
             }
             "e2servicereference" -> if (inService) inServiceReference = true
             "e2servicename" -> if (inService) inServiceName = true
             "e2providername" -> if (inService) inProviderName = true
-            "e2videowidth" -> if (inService) inVideoWidth = true
-            "e2videoheight" -> if (inService) inVideoHeight = true
-            "e2servicevideosize" -> if (inService) inVideoSize = true
-            "e2iswidescreen" -> if (inService) inIsWideScreen = true
-            "e2apid" -> if (inService) inApid = true
-            "e2vpid" -> if (inService) inVpid = true
-            "e2pcrpid" -> if (inService) inPcrPid = true
-            "e2pmtpid" -> if (inService) inPmtPid = true
-            "e2txtpid" -> if (inService) inTxtPid = true
-            "e2tsid" -> if (inService) inTsid = true
-            "e2onid" -> if (inService) inOnid = true
-            "e2sid" -> if (inService) inSid = true
             "e2event" -> {
                 inEvent = true
                 eventId.setLength(0)
@@ -159,36 +111,12 @@ private class CurrentServiceHandler : DefaultHandler() {
                 service = Service(
                     reference = serviceReference.toString().trim(),
                     name = serviceName.toString().replace("\\p{Cntrl}".toRegex(), "").trim(),
-                    provider = provider.toString().trim(),
-                    videoWidth = videoWidth.toString().trim(),
-                    videoHeight = videoHeight.toString().trim(),
-                    videoSize = videoSize.toString().trim(),
-                    widescreen = widescreen.toString().trim(),
-                    apid = apid.toString().trim(),
-                    vpid = vpid.toString().trim(),
-                    pcrPid = pcrPid.toString().trim(),
-                    pmtPid = pmtPid.toString().trim(),
-                    txtPid = txtPid.toString().trim(),
-                    tsid = tsid.toString().trim(),
-                    onid = onid.toString().trim(),
-                    sid = sid.toString().trim()
+                    provider = provider.toString().trim()
                 )
             }
             "e2servicereference" -> inServiceReference = false
             "e2servicename" -> inServiceName = false
             "e2providername" -> inProviderName = false
-            "e2videowidth" -> inVideoWidth = false
-            "e2videoheight" -> inVideoHeight = false
-            "e2servicevideosize" -> inVideoSize = false
-            "e2iswidescreen" -> inIsWideScreen = false
-            "e2apid" -> inApid = false
-            "e2vpid" -> inVpid = false
-            "e2pcrpid" -> inPcrPid = false
-            "e2pmtpid" -> inPmtPid = false
-            "e2txtpid" -> inTxtPid = false
-            "e2tsid" -> inTsid = false
-            "e2onid" -> inOnid = false
-            "e2sid" -> inSid = false
             "e2event" -> {
                 inEvent = false
                 events.add(buildEvent())
@@ -218,18 +146,6 @@ private class CurrentServiceHandler : DefaultHandler() {
                 inServiceReference -> serviceReference.append(ch, startIdx, length)
                 inServiceName -> serviceName.append(ch, startIdx, length)
                 inProviderName -> provider.append(ch, startIdx, length)
-                inVideoWidth -> videoWidth.append(ch, startIdx, length)
-                inVideoHeight -> videoHeight.append(ch, startIdx, length)
-                inVideoSize -> videoSize.append(ch, startIdx, length)
-                inIsWideScreen -> widescreen.append(ch, startIdx, length)
-                inApid -> apid.append(ch, startIdx, length)
-                inVpid -> vpid.append(ch, startIdx, length)
-                inPcrPid -> pcrPid.append(ch, startIdx, length)
-                inPmtPid -> pmtPid.append(ch, startIdx, length)
-                inTxtPid -> txtPid.append(ch, startIdx, length)
-                inTsid -> tsid.append(ch, startIdx, length)
-                inOnid -> onid.append(ch, startIdx, length)
-                inSid -> sid.append(ch, startIdx, length)
             }
             return
         }

--- a/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
@@ -46,6 +46,7 @@ private class CurrentServiceHandler : DefaultHandler() {
     private var inEventServiceName = false
     private var inEventId = false
     private var inEventTitle = false
+    private var inEventName = false
     private var inEventDescription = false
     private var inEventStart = false
     private var inEventDuration = false
@@ -58,6 +59,7 @@ private class CurrentServiceHandler : DefaultHandler() {
 
     private val eventId = StringBuilder()
     private val title = StringBuilder()
+    private val eventName = StringBuilder()
     private val start = StringBuilder()
     private val duration = StringBuilder()
     private val currentTime = StringBuilder()
@@ -84,6 +86,7 @@ private class CurrentServiceHandler : DefaultHandler() {
                 inEvent = true
                 eventId.setLength(0)
                 title.setLength(0)
+                eventName.setLength(0)
                 start.setLength(0)
                 duration.setLength(0)
                 currentTime.setLength(0)
@@ -96,6 +99,7 @@ private class CurrentServiceHandler : DefaultHandler() {
             "e2eventservicename" -> if (inEvent) inEventServiceName = true
             "e2eventid" -> if (inEvent) inEventId = true
             "e2eventtitle" -> if (inEvent) inEventTitle = true
+            "e2eventname" -> if (inEvent) inEventName = true
             "e2eventdescription" -> if (inEvent) inEventDescription = true
             "e2eventstart" -> if (inEvent) inEventStart = true
             "e2eventduration" -> if (inEvent) inEventDuration = true
@@ -125,6 +129,7 @@ private class CurrentServiceHandler : DefaultHandler() {
             "e2eventservicename" -> inEventServiceName = false
             "e2eventid" -> inEventId = false
             "e2eventtitle" -> inEventTitle = false
+            "e2eventname" -> inEventName = false
             "e2eventdescription" -> inEventDescription = false
             "e2eventstart" -> inEventStart = false
             "e2eventduration" -> inEventDuration = false
@@ -157,6 +162,7 @@ private class CurrentServiceHandler : DefaultHandler() {
             inEventServiceName -> eventServiceName.append(ch, startIdx, length)
             inEventId -> eventId.append(ch, startIdx, length)
             inEventTitle -> title.append(ch, startIdx, length)
+            inEventName -> eventName.append(ch, startIdx, length)
             inEventDescription -> description.append(ch, startIdx, length)
             inEventStart -> start.append(ch, startIdx, length)
             inEventDuration -> duration.append(ch, startIdx, length)
@@ -169,6 +175,10 @@ private class CurrentServiceHandler : DefaultHandler() {
         val startRaw = start.toString().trim()
         val durationRaw = duration.toString().trim()
         var titleRaw = title.toString().trim()
+        if (titleRaw.isEmpty() || Python.NONE == titleRaw) {
+            // WebInterface 1.5 may send e2eventname instead of e2eventtitle.
+            titleRaw = eventName.toString().trim()
+        }
         if (titleRaw.isEmpty() || Python.NONE == titleRaw) {
             titleRaw = "N/A"
         }

--- a/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/CurrentServiceParser.kt
@@ -1,0 +1,295 @@
+package net.reichholf.dreamdroid.enigma
+
+import net.reichholf.dreamdroid.helpers.DateTime
+import net.reichholf.dreamdroid.helpers.Python
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object CurrentServiceParser {
+    fun parse(xml: String): CurrentService? {
+        if (xml.isEmpty()) {
+            return null
+        }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): CurrentService? {
+        return try {
+            val handler = CurrentServiceHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
+            handler.result
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+private class CurrentServiceHandler : DefaultHandler() {
+    var result: CurrentService? = null
+
+    private var inService = false
+    private var inEvent = false
+
+    private var inServiceReference = false
+    private var inServiceName = false
+    private var inProviderName = false
+    private var inVideoWidth = false
+    private var inVideoHeight = false
+    private var inVideoSize = false
+    private var inIsWideScreen = false
+    private var inApid = false
+    private var inVpid = false
+    private var inPcrPid = false
+    private var inPmtPid = false
+    private var inTxtPid = false
+    private var inTsid = false
+    private var inOnid = false
+    private var inSid = false
+
+    private var inEventServiceReference = false
+    private var inEventServiceName = false
+    private var inEventId = false
+    private var inEventTitle = false
+    private var inEventDescription = false
+    private var inEventStart = false
+    private var inEventDuration = false
+    private var inEventCurrentTime = false
+    private var inEventDescriptionExtended = false
+
+    private val serviceReference = StringBuilder()
+    private val serviceName = StringBuilder()
+    private val provider = StringBuilder()
+    private val videoWidth = StringBuilder()
+    private val videoHeight = StringBuilder()
+    private val videoSize = StringBuilder()
+    private val widescreen = StringBuilder()
+    private val apid = StringBuilder()
+    private val vpid = StringBuilder()
+    private val pcrPid = StringBuilder()
+    private val pmtPid = StringBuilder()
+    private val txtPid = StringBuilder()
+    private val tsid = StringBuilder()
+    private val onid = StringBuilder()
+    private val sid = StringBuilder()
+
+    private val eventId = StringBuilder()
+    private val title = StringBuilder()
+    private val start = StringBuilder()
+    private val duration = StringBuilder()
+    private val currentTime = StringBuilder()
+    private val description = StringBuilder()
+    private val descriptionExtended = StringBuilder()
+    private val eventServiceReference = StringBuilder()
+    private val eventServiceName = StringBuilder()
+
+    private var service: Service = Service("", "")
+    private val events = ArrayList<Event>()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2service" -> {
+                inService = true
+                serviceReference.setLength(0)
+                serviceName.setLength(0)
+                provider.setLength(0)
+                videoWidth.setLength(0)
+                videoHeight.setLength(0)
+                videoSize.setLength(0)
+                widescreen.setLength(0)
+                apid.setLength(0)
+                vpid.setLength(0)
+                pcrPid.setLength(0)
+                pmtPid.setLength(0)
+                txtPid.setLength(0)
+                tsid.setLength(0)
+                onid.setLength(0)
+                sid.setLength(0)
+            }
+            "e2servicereference" -> if (inService) inServiceReference = true
+            "e2servicename" -> if (inService) inServiceName = true
+            "e2providername" -> if (inService) inProviderName = true
+            "e2videowidth" -> if (inService) inVideoWidth = true
+            "e2videoheight" -> if (inService) inVideoHeight = true
+            "e2servicevideosize" -> if (inService) inVideoSize = true
+            "e2iswidescreen" -> if (inService) inIsWideScreen = true
+            "e2apid" -> if (inService) inApid = true
+            "e2vpid" -> if (inService) inVpid = true
+            "e2pcrpid" -> if (inService) inPcrPid = true
+            "e2pmtpid" -> if (inService) inPmtPid = true
+            "e2txtpid" -> if (inService) inTxtPid = true
+            "e2tsid" -> if (inService) inTsid = true
+            "e2onid" -> if (inService) inOnid = true
+            "e2sid" -> if (inService) inSid = true
+            "e2event" -> {
+                inEvent = true
+                eventId.setLength(0)
+                title.setLength(0)
+                start.setLength(0)
+                duration.setLength(0)
+                currentTime.setLength(0)
+                description.setLength(0)
+                descriptionExtended.setLength(0)
+                eventServiceReference.setLength(0)
+                eventServiceName.setLength(0)
+            }
+            "e2eventservicereference" -> if (inEvent) inEventServiceReference = true
+            "e2eventservicename" -> if (inEvent) inEventServiceName = true
+            "e2eventid" -> if (inEvent) inEventId = true
+            "e2eventtitle" -> if (inEvent) inEventTitle = true
+            "e2eventdescription" -> if (inEvent) inEventDescription = true
+            "e2eventstart" -> if (inEvent) inEventStart = true
+            "e2eventduration" -> if (inEvent) inEventDuration = true
+            "e2eventcurrenttime" -> if (inEvent) inEventCurrentTime = true
+            "e2eventdescriptionextended" -> if (inEvent) inEventDescriptionExtended = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2service" -> {
+                inService = false
+                service = Service(
+                    reference = serviceReference.toString().trim(),
+                    name = serviceName.toString().replace("\\p{Cntrl}".toRegex(), "").trim(),
+                    provider = provider.toString().trim(),
+                    videoWidth = videoWidth.toString().trim(),
+                    videoHeight = videoHeight.toString().trim(),
+                    videoSize = videoSize.toString().trim(),
+                    widescreen = widescreen.toString().trim(),
+                    apid = apid.toString().trim(),
+                    vpid = vpid.toString().trim(),
+                    pcrPid = pcrPid.toString().trim(),
+                    pmtPid = pmtPid.toString().trim(),
+                    txtPid = txtPid.toString().trim(),
+                    tsid = tsid.toString().trim(),
+                    onid = onid.toString().trim(),
+                    sid = sid.toString().trim()
+                )
+            }
+            "e2servicereference" -> inServiceReference = false
+            "e2servicename" -> inServiceName = false
+            "e2providername" -> inProviderName = false
+            "e2videowidth" -> inVideoWidth = false
+            "e2videoheight" -> inVideoHeight = false
+            "e2servicevideosize" -> inVideoSize = false
+            "e2iswidescreen" -> inIsWideScreen = false
+            "e2apid" -> inApid = false
+            "e2vpid" -> inVpid = false
+            "e2pcrpid" -> inPcrPid = false
+            "e2pmtpid" -> inPmtPid = false
+            "e2txtpid" -> inTxtPid = false
+            "e2tsid" -> inTsid = false
+            "e2onid" -> inOnid = false
+            "e2sid" -> inSid = false
+            "e2event" -> {
+                inEvent = false
+                events.add(buildEvent())
+            }
+            "e2eventservicereference" -> inEventServiceReference = false
+            "e2eventservicename" -> inEventServiceName = false
+            "e2eventid" -> inEventId = false
+            "e2eventtitle" -> inEventTitle = false
+            "e2eventdescription" -> inEventDescription = false
+            "e2eventstart" -> inEventStart = false
+            "e2eventduration" -> inEventDuration = false
+            "e2eventcurrenttime" -> inEventCurrentTime = false
+            "e2eventdescriptionextended" -> inEventDescriptionExtended = false
+            "e2currentserviceinformation" -> {
+                result = CurrentService(
+                    service = service,
+                    now = events.getOrNull(0),
+                    next = events.getOrNull(1)
+                )
+            }
+        }
+    }
+
+    override fun characters(ch: CharArray, startIdx: Int, length: Int) {
+        if (inService) {
+            when {
+                inServiceReference -> serviceReference.append(ch, startIdx, length)
+                inServiceName -> serviceName.append(ch, startIdx, length)
+                inProviderName -> provider.append(ch, startIdx, length)
+                inVideoWidth -> videoWidth.append(ch, startIdx, length)
+                inVideoHeight -> videoHeight.append(ch, startIdx, length)
+                inVideoSize -> videoSize.append(ch, startIdx, length)
+                inIsWideScreen -> widescreen.append(ch, startIdx, length)
+                inApid -> apid.append(ch, startIdx, length)
+                inVpid -> vpid.append(ch, startIdx, length)
+                inPcrPid -> pcrPid.append(ch, startIdx, length)
+                inPmtPid -> pmtPid.append(ch, startIdx, length)
+                inTxtPid -> txtPid.append(ch, startIdx, length)
+                inTsid -> tsid.append(ch, startIdx, length)
+                inOnid -> onid.append(ch, startIdx, length)
+                inSid -> sid.append(ch, startIdx, length)
+            }
+            return
+        }
+        if (!inEvent) {
+            return
+        }
+        when {
+            inEventServiceReference -> eventServiceReference.append(ch, startIdx, length)
+            inEventServiceName -> eventServiceName.append(ch, startIdx, length)
+            inEventId -> eventId.append(ch, startIdx, length)
+            inEventTitle -> title.append(ch, startIdx, length)
+            inEventDescription -> description.append(ch, startIdx, length)
+            inEventStart -> start.append(ch, startIdx, length)
+            inEventDuration -> duration.append(ch, startIdx, length)
+            inEventCurrentTime -> currentTime.append(ch, startIdx, length)
+            inEventDescriptionExtended -> descriptionExtended.append(ch, startIdx, length)
+        }
+    }
+
+    private fun buildEvent(): Event {
+        val startRaw = start.toString().trim()
+        val durationRaw = duration.toString().trim()
+        var titleRaw = title.toString().trim()
+        if (titleRaw.isEmpty() || Python.NONE == titleRaw) {
+            titleRaw = "N/A"
+        }
+        val extDesc = descriptionExtended.toString().replace("\u008A", "\n")
+
+        var startReadable = ""
+        var startTimeReadable = ""
+        var durationReadable = ""
+        if (startRaw.isNotEmpty() && Python.NONE != startRaw) {
+            startReadable = DateTime.getDateTimeString(startRaw)
+            startTimeReadable = DateTime.getTimeString(startRaw)
+            durationReadable = try {
+                DateTime.getDurationString(durationRaw, startRaw) ?: durationRaw
+            } catch (e: NumberFormatException) {
+                durationRaw
+            }
+        }
+
+        return Event(
+            eventId = eventId.toString().trim(),
+            title = titleRaw,
+            start = startRaw,
+            duration = durationRaw,
+            currentTime = currentTime.toString().trim(),
+            description = description.toString(),
+            descriptionExtended = extDesc,
+            serviceReference = eventServiceReference.toString().trim(),
+            serviceName = eventServiceName.toString().replace("\\p{Cntrl}".toRegex(), "").trim(),
+            startReadable = startReadable,
+            startTimeReadable = startTimeReadable,
+            durationReadable = durationReadable
+        )
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -34,6 +34,16 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getCurrent(): CurrentService? {
+        return withContext(Dispatchers.IO) {
+            if (!http.fetchPageContent(URIStore.CURRENT, ArrayList())) {
+                null
+            } else {
+                CurrentServiceParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
@@ -51,6 +61,13 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         ): List<Event> {
             return runBlocking {
                 EnigmaClient(http).getEvents(params, uri)
+            }
+        }
+
+        @JvmStatic
+        fun getCurrentBlocking(http: SimpleHttpClient): CurrentService? {
+            return runBlocking {
+                EnigmaClient(http).getCurrent()
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/Event.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Event.kt
@@ -1,5 +1,7 @@
 package net.reichholf.dreamdroid.enigma
 
+import java.io.Serializable
+
 data class Event(
     val eventId: String = "",
     val title: String = "",
@@ -13,4 +15,4 @@ data class Event(
     val startReadable: String = "",
     val startTimeReadable: String = "",
     val durationReadable: String = ""
-)
+) : Serializable

--- a/app/src/net/reichholf/dreamdroid/enigma/Service.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Service.kt
@@ -2,20 +2,8 @@ package net.reichholf.dreamdroid.enigma
 
 import java.io.Serializable
 
-data class Service(
+data class Service @JvmOverloads constructor(
     val reference: String,
     val name: String,
-    val provider: String = "",
-    val videoWidth: String = "",
-    val videoHeight: String = "",
-    val videoSize: String = "",
-    val widescreen: String = "",
-    val apid: String = "",
-    val vpid: String = "",
-    val pcrPid: String = "",
-    val pmtPid: String = "",
-    val txtPid: String = "",
-    val tsid: String = "",
-    val onid: String = "",
-    val sid: String = ""
+    val provider: String = ""
 ) : Serializable

--- a/app/src/net/reichholf/dreamdroid/enigma/Service.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Service.kt
@@ -1,6 +1,21 @@
 package net.reichholf.dreamdroid.enigma
 
+import java.io.Serializable
+
 data class Service(
     val reference: String,
-    val name: String
-)
+    val name: String,
+    val provider: String = "",
+    val videoWidth: String = "",
+    val videoHeight: String = "",
+    val videoSize: String = "",
+    val widescreen: String = "",
+    val apid: String = "",
+    val vpid: String = "",
+    val pcrPid: String = "",
+    val pmtPid: String = "",
+    val txtPid: String = "",
+    val tsid: String = "",
+    val onid: String = "",
+    val sid: String = ""
+) : Serializable

--- a/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
@@ -24,30 +24,32 @@ import com.evernote.android.state.State;
 
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
+import net.reichholf.dreamdroid.asynctask.GetCurrentServiceTask;
+import net.reichholf.dreamdroid.enigma.CurrentService;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailBottomSheet;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.CurrentService;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Picon;
-import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.helpers.enigma2.Timer;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.CurrentServiceRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerAddByEventIdRequestHandler;
 import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.loader.AsyncSimpleLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
-
-import java.util.ArrayList;
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 
 /**
- * Shows some information about the service currently running on TV
+ * Shows some information about the service currently running on TV.
+ * Holds typed {@link CurrentService}; detail/timer still take ExtendedHashMap at the edge.
  * 
  * @author sreichholf
  * 
  */
-public class CurrentServiceFragment extends BaseHttpFragment {
+public class CurrentServiceFragment extends BaseHttpFragment
+		implements GetCurrentServiceTask.GetCurrentServiceTaskHandler {
 	@SuppressWarnings("unused")
 	private static final String LOG_TAG = "CurrentServiceFragment";
 
@@ -67,17 +69,21 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	protected ProgressDialog mProgress;
 
 	@Nullable
-	private ExtendedHashMap mService;
-	private ExtendedHashMap mNow;
-	private ExtendedHashMap mNext;
+	private Service mService;
+	@Nullable
+	private Event mNow;
+	@Nullable
+	private Event mNext;
 	private boolean mCurrentServiceReady;
 
 	@Nullable
-	@State public ExtendedHashMap mCurrent;
+	@State public CurrentService mCurrent;
 	@Nullable
 	@State public ExtendedHashMap mCurrentItem;
 
-	@SuppressWarnings("unchecked")
+	@Nullable
+	private GetCurrentServiceTask mCurrentServiceTask;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -116,8 +122,16 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 			mReload = true;
 
 		super.onViewCreated(view, savedInstanceState);
-		if(!mReload)
-			applyData(0, mCurrent);
+		if (!mReload)
+			applyCurrent(mCurrent);
+	}
+
+	@Override
+	public void onDestroy() {
+		if (mCurrentServiceTask != null) {
+			mCurrentServiceTask.cancel(true);
+		}
+		super.onDestroy();
 	}
 
 	/**
@@ -139,12 +153,11 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	 */
 	@Override
 	protected boolean onItemSelected(int id) {
-		if(!mCurrentServiceReady){
+		if (!mCurrentServiceReady) {
 			showToast(getText(R.string.not_available));
 			return true;
 		}
 
-		String ref;
 		switch (id) {
 		case Statics.ITEM_NOW:
 			showEpgDetail(mNow);
@@ -153,22 +166,24 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 			showEpgDetail(mNext);
 			return true;
 		case Statics.ITEM_STREAM:
-			ref = mService.getString(Service.KEY_REFERENCE);
-			String name = mService.getString(Service.KEY_NAME);
-			if (!"".equals(ref) && ref != null) {
-				streamService(ref, name);
-			} else {
-				showToast(getText(R.string.not_available));
+			if (mService != null) {
+				String ref = mService.getReference();
+				String name = mService.getName();
+				if (ref != null && !"".equals(ref)) {
+					streamService(ref, name);
+					return true;
+				}
 			}
+			showToast(getText(R.string.not_available));
 			return true;
 		default:
 			return super.onItemSelected(id);
 		}
 	}
 
-	private void showEpgDetail(@Nullable ExtendedHashMap event) {
+	private void showEpgDetail(@Nullable Event event) {
 		if (event != null) {
-			mCurrentItem = event;
+			mCurrentItem = EpgListMapper.toExtendedHashMap(event);
 			Bundle args = new Bundle();
 			args.putSerializable("currentItem", mCurrentItem);
 			((MultiPaneHandler) getAppCompatActivity()).showDialogFragment(EpgDetailBottomSheet.class, args,
@@ -180,34 +195,36 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	 * Called after loading the current service has finished to update the
 	 * GUI-Content
 	 */
-	@Override
-	public void applyData(int loaderId, @Nullable ExtendedHashMap content) {
+	private void applyCurrent(@Nullable CurrentService content) {
 		if (content != null && !content.isEmpty()) {
 			mCurrent = content;
 			mCurrentServiceReady = true;
 
-			mService = (ExtendedHashMap) mCurrent.get(CurrentService.KEY_SERVICE);
-			@SuppressWarnings("unchecked")
-			ArrayList<ExtendedHashMap> events = (ArrayList<ExtendedHashMap>) mCurrent.get(CurrentService.KEY_EVENTS);
-			mNow = events.get(0);
-			mNext = events.get(1);
+			mService = content.getService();
+			mNow = content.getNow();
+			mNext = content.getNext();
 
-			mServiceName.setText(mService.getString(CurrentService.KEY_SERVICE_NAME));
-			mProvider.setText(mService.getString(CurrentService.KEY_SERVICE_PROVIDER));
+			mServiceName.setText(mService != null ? mService.getName() : "");
+			mProvider.setText(mService != null ? mService.getProvider() : "");
 			// Now
-			mNowStart.setText(mNow.getString(Event.KEY_EVENT_START_READABLE));
-			mNowTitle.setText(mNow.getString(Event.KEY_EVENT_TITLE));
-			mNowDesc.setText(mNow.getString(Event.KEY_EVENT_DESCRIPTION_EXTENDED, ""));
-			mNowDuration.setText(mNow.getString(Event.KEY_EVENT_DURATION_READABLE));
+			mNowStart.setText(mNow != null ? mNow.getStartReadable() : "");
+			mNowTitle.setText(mNow != null ? mNow.getTitle() : "");
+			mNowDesc.setText(mNow != null ? mNow.getDescriptionExtended() : "");
+			mNowDuration.setText(mNow != null ? mNow.getDurationReadable() : "");
 			// Next
-			mNextStart.setText(mNext.getString(Event.KEY_EVENT_START_READABLE));
-			mNextTitle.setText(mNext.getString(Event.KEY_EVENT_TITLE));
-			mNextDesc.setText(mNext.getString(Event.KEY_EVENT_DESCRIPTION_EXTENDED, ""));
-			mNextDuration.setText(mNext.getString(Event.KEY_EVENT_DURATION_READABLE));
+			mNextStart.setText(mNext != null ? mNext.getStartReadable() : "");
+			mNextTitle.setText(mNext != null ? mNext.getTitle() : "");
+			mNextDesc.setText(mNext != null ? mNext.getDescriptionExtended() : "");
+			mNextDuration.setText(mNext != null ? mNext.getDurationReadable() : "");
 
-			ImageView piconView = getView().findViewById(R.id.picon);
-			Picon.setPiconForView(getAppCompatActivity(), piconView, mService, Statics.TAG_PICON);
+			View root = getView();
+			if (root != null && mService != null) {
+				ImageView piconView = root.findViewById(R.id.picon);
+				Picon.setPiconForView(getAppCompatActivity(), piconView, mService.getReference(), mService.getName(),
+						Statics.TAG_PICON, null);
+			}
 		} else {
+			mCurrentServiceReady = false;
 			showToast(getText(R.string.not_available));
 		}
 	}
@@ -279,7 +296,51 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ExtendedHashMap>> onCreateLoader(int id, Bundle args) {
+		// Current service no longer starts this loader. BaseHttpFragment still requires LoaderCallbacks.
 		return new AsyncSimpleLoader(getAppCompatActivity(), new CurrentServiceRequestHandler(),
 				args);
+	}
+
+	@Override
+	public void onLoadFinished(@NonNull Loader<LoaderResult<ExtendedHashMap>> loader,
+			@NonNull LoaderResult<ExtendedHashMap> result) {
+		// Unused: content comes from GetCurrentServiceTask / EnigmaClient.
+	}
+
+	@Override
+	protected void reload() {
+		mReload = false;
+		loadCurrentService();
+	}
+
+	private void loadCurrentService() {
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (mCurrentServiceTask != null) {
+			mCurrentServiceTask.cancel(true);
+		}
+		mCurrentServiceTask = new GetCurrentServiceTask(this);
+		mCurrentServiceTask.execute();
+	}
+
+	@Override
+	public void onCurrentServiceReady(boolean success, @Nullable CurrentService current,
+			@Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (!success) {
+			mCurrentServiceReady = false;
+			showToast(errorText != null ? errorText : getText(R.string.not_available));
+			return;
+		}
+		applyCurrent(current);
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -302,6 +302,16 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getEventsBlocking(shc, params, uri);
     }
 
+    @Nullable
+    public net.reichholf.dreamdroid.enigma.CurrentService fetchCurrentService() {
+        return fetchCurrentService(mShc);
+    }
+
+    @Nullable
+    public static net.reichholf.dreamdroid.enigma.CurrentService fetchCurrentService(@NonNull SimpleHttpClient shc) {
+        return EnigmaClient.getCurrentBlocking(shc);
+    }
+
     public void onLoadStarted() {
         if (mIsReloading)
             return;

--- a/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceMapper.kt
@@ -1,0 +1,61 @@
+package net.reichholf.dreamdroid.ui.current
+
+import net.reichholf.dreamdroid.enigma.CurrentService
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.enigma.Service
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.enigma2.CurrentService as CurrentServiceKeys
+import net.reichholf.dreamdroid.helpers.enigma2.Service as ServiceKeys
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper
+
+/**
+ * Current service screen holds typed [CurrentService]. Detail sheet / timer create
+ * still take [ExtendedHashMap]; convert only at that fragment boundary.
+ */
+object CurrentServiceMapper {
+    @JvmStatic
+    fun eventToExtendedHashMap(event: Event?): ExtendedHashMap? {
+        if (event == null) {
+            return null
+        }
+        return EpgListMapper.toExtendedHashMap(event)
+    }
+
+    @JvmStatic
+    fun serviceToExtendedHashMap(service: Service?): ExtendedHashMap {
+        val map = ExtendedHashMap()
+        if (service == null) {
+            return map
+        }
+        map.put(ServiceKeys.KEY_REFERENCE, service.reference)
+        map.put(ServiceKeys.KEY_NAME, service.name)
+        map.put(CurrentServiceKeys.KEY_SERVICE_PROVIDER, service.provider)
+        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_WIDTH, service.videoWidth)
+        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_HEIGHT, service.videoHeight)
+        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_SIZE, service.videoSize)
+        map.put(CurrentServiceKeys.KEY_SERVICE_IS_WIDESCREEN, service.widescreen)
+        map.put(CurrentServiceKeys.KEY_SERVICE_APID, service.apid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_VPID, service.vpid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_PCRPID, service.pcrPid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_PMTPID, service.pmtPid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_TXTPID, service.txtPid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_TSID, service.tsid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_ONID, service.onid)
+        map.put(CurrentServiceKeys.KEY_SERVICE_SID, service.sid)
+        return map
+    }
+
+    @JvmStatic
+    fun toExtendedHashMap(current: CurrentService?): ExtendedHashMap {
+        val map = ExtendedHashMap()
+        if (current == null) {
+            return map
+        }
+        map.put(CurrentServiceKeys.KEY_SERVICE, serviceToExtendedHashMap(current.service))
+        val events = ArrayList<ExtendedHashMap>()
+        current.now?.let { events.add(EpgListMapper.toExtendedHashMap(it)) }
+        current.next?.let { events.add(EpgListMapper.toExtendedHashMap(it)) }
+        map.put(CurrentServiceKeys.KEY_EVENTS, events)
+        return map
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceMapper.kt
@@ -30,18 +30,6 @@ object CurrentServiceMapper {
         map.put(ServiceKeys.KEY_REFERENCE, service.reference)
         map.put(ServiceKeys.KEY_NAME, service.name)
         map.put(CurrentServiceKeys.KEY_SERVICE_PROVIDER, service.provider)
-        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_WIDTH, service.videoWidth)
-        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_HEIGHT, service.videoHeight)
-        map.put(CurrentServiceKeys.KEY_SERVICE_VIDEO_SIZE, service.videoSize)
-        map.put(CurrentServiceKeys.KEY_SERVICE_IS_WIDESCREEN, service.widescreen)
-        map.put(CurrentServiceKeys.KEY_SERVICE_APID, service.apid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_VPID, service.vpid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_PCRPID, service.pcrPid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_PMTPID, service.pmtPid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_TXTPID, service.txtPid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_TSID, service.tsid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_ONID, service.onid)
-        map.put(CurrentServiceKeys.KEY_SERVICE_SID, service.sid)
         return map
     }
 

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
@@ -27,13 +27,6 @@ public class CurrentServiceParserTest {
         assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", service.getReference());
         assertEquals("Das Erste HD", service.getName());
         assertEquals("ARD", service.getProvider());
-        assertEquals("1280", service.getVideoWidth());
-        assertEquals("720", service.getVideoHeight());
-        assertEquals("1280x720", service.getVideoSize());
-        assertEquals("True", service.getWidescreen());
-        assertEquals("101", service.getApid());
-        assertEquals("102", service.getVpid());
-        assertEquals("28000", service.getSid());
 
         Event now = current.getNow();
         assertNotNull(now);

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
@@ -1,0 +1,72 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CurrentServiceParserTest {
+    @Test
+    public void parsesGetcurrentFixtureIntoCurrentService() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/getcurrent.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        long started = System.nanoTime();
+        CurrentService current = CurrentServiceParser.INSTANCE.parse(xml);
+        long elapsedNanos = System.nanoTime() - started;
+        System.out.println("CurrentServiceParser.parse nanos=" + elapsedNanos);
+
+        assertNotNull(current);
+        Service service = current.getService();
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", service.getReference());
+        assertEquals("Das Erste HD", service.getName());
+        assertEquals("ARD", service.getProvider());
+        assertEquals("1280", service.getVideoWidth());
+        assertEquals("720", service.getVideoHeight());
+        assertEquals("1280x720", service.getVideoSize());
+        assertEquals("True", service.getWidescreen());
+        assertEquals("101", service.getApid());
+        assertEquals("102", service.getVpid());
+        assertEquals("28000", service.getSid());
+
+        Event now = current.getNow();
+        assertNotNull(now);
+        assertEquals("39150", now.getEventId());
+        assertEquals("Tagesschau", now.getTitle());
+        assertEquals("1893456000", now.getStart());
+        assertEquals("3600", now.getDuration());
+        assertEquals("1893452400", now.getCurrentTime());
+        assertEquals("Nachrichten", now.getDescription());
+        assertTrue(now.getDescriptionExtended().contains("Die Nachrichten um 20 Uhr."));
+        assertTrue(now.getDescriptionExtended().contains("\n"));
+        assertFalse(now.getDescriptionExtended().contains("\u008A"));
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", now.getServiceReference());
+        assertEquals("Das Erste HD", now.getServiceName());
+        assertFalse(now.getStartReadable().isEmpty());
+        assertEquals("60", now.getDurationReadable());
+
+        Event next = current.getNext();
+        assertNotNull(next);
+        assertEquals("39151", next.getEventId());
+        assertEquals("N/A", next.getTitle());
+        assertEquals("1893459600", next.getStart());
+        assertEquals("1800", next.getDuration());
+        assertEquals("30", next.getDurationReadable());
+    }
+
+    @Test
+    public void emptyXmlYieldsNull() {
+        assertNull(CurrentServiceParser.INSTANCE.parse(""));
+    }
+
+    @Test
+    public void malformedXmlYieldsNull() {
+        assertNull(CurrentServiceParser.INSTANCE.parse("<e2currentserviceinformation><e2service>"));
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/CurrentServiceParserTest.java
@@ -62,4 +62,32 @@ public class CurrentServiceParserTest {
     public void malformedXmlYieldsNull() {
         assertNull(CurrentServiceParser.INSTANCE.parse("<e2currentserviceinformation><e2service>"));
     }
+
+    @Test
+    public void fallsBackToEventNameWhenTitleMissing() {
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2currentserviceinformation>"
+                + "<e2service>"
+                + "<e2servicereference>1:0:1:1:1:1:0:0:0:0:</e2servicereference>"
+                + "<e2servicename>TV</e2servicename>"
+                + "<e2providername>P</e2providername>"
+                + "</e2service>"
+                + "<e2event>"
+                + "<e2eventid>1</e2eventid>"
+                + "<e2eventstart>1893456000</e2eventstart>"
+                + "<e2eventduration>60</e2eventduration>"
+                + "<e2eventcurrenttime>1893456000</e2eventcurrenttime>"
+                + "<e2eventname>Legacy Title</e2eventname>"
+                + "<e2eventdescription/>"
+                + "<e2eventdescriptionextended/>"
+                + "<e2eventservicereference>1:0:1:1:1:1:0:0:0:0:</e2eventservicereference>"
+                + "<e2eventservicename>TV</e2eventservicename>"
+                + "</e2event>"
+                + "</e2currentserviceinformation>";
+        CurrentService current = CurrentServiceParser.INSTANCE.parse(xml);
+        assertNotNull(current);
+        assertNotNull(current.getNow());
+        assertEquals("Legacy Title", current.getNow().getTitle());
+    }
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/current/CurrentServiceMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/current/CurrentServiceMapperTest.java
@@ -1,0 +1,71 @@
+package net.reichholf.dreamdroid.ui.current;
+
+import net.reichholf.dreamdroid.enigma.CurrentService;
+import net.reichholf.dreamdroid.enigma.CurrentServiceParser;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class CurrentServiceMapperTest {
+    @Test
+    public void eventToExtendedHashMapCopiesEventFields() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/getcurrent.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        CurrentService current = CurrentServiceParser.INSTANCE.parse(xml);
+        assertNotNull(current);
+        Event event = current.getNow();
+        assertNotNull(event);
+
+        ExtendedHashMap map = CurrentServiceMapper.eventToExtendedHashMap(event);
+        assertNotNull(map);
+        assertEquals(event.getEventId(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_ID));
+        assertEquals(event.getTitle(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_TITLE));
+        assertEquals(EpgListMapper.toExtendedHashMap(event).getString(
+                net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_START_READABLE),
+                map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_START_READABLE));
+    }
+
+    @Test
+    public void eventToExtendedHashMapNullIsNull() {
+        assertNull(CurrentServiceMapper.eventToExtendedHashMap(null));
+    }
+
+    @Test
+    public void toExtendedHashMapCopiesServiceAndEvents() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/getcurrent.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        CurrentService current = CurrentServiceParser.INSTANCE.parse(xml);
+        assertNotNull(current);
+
+        ExtendedHashMap map = CurrentServiceMapper.toExtendedHashMap(current);
+        ExtendedHashMap service = (ExtendedHashMap) map.get(
+                net.reichholf.dreamdroid.helpers.enigma2.CurrentService.KEY_SERVICE);
+        assertNotNull(service);
+        assertEquals(current.getService().getReference(),
+                service.getString(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_REFERENCE));
+        assertEquals(current.getService().getProvider(),
+                service.getString(net.reichholf.dreamdroid.helpers.enigma2.CurrentService.KEY_SERVICE_PROVIDER));
+
+        @SuppressWarnings("unchecked")
+        ArrayList<ExtendedHashMap> events = (ArrayList<ExtendedHashMap>) map.get(
+                net.reichholf.dreamdroid.helpers.enigma2.CurrentService.KEY_EVENTS);
+        assertNotNull(events);
+        assertEquals(2, events.size());
+        assertEquals(current.getNow().getEventId(),
+                events.get(0).getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_ID));
+        assertEquals(current.getNext().getEventId(),
+                events.get(1).getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_ID));
+    }
+}

--- a/app/src/test/resources/web/getcurrent.xml
+++ b/app/src/test/resources/web/getcurrent.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2currentserviceinformation>
+	<e2service>
+		<e2servicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2servicereference>
+		<e2servicename>Das Erste HD</e2servicename>
+		<e2providername>ARD</e2providername>
+		<e2videowidth>1280</e2videowidth>
+		<e2videoheight>720</e2videoheight>
+		<e2servicevideosize>1280x720</e2servicevideosize>
+		<e2iswidescreen>True</e2iswidescreen>
+		<e2apid>101</e2apid>
+		<e2vpid>102</e2vpid>
+		<e2pcrpid>103</e2pcrpid>
+		<e2pmtpid>104</e2pmtpid>
+		<e2txtpid>105</e2txtpid>
+		<e2tsid>1101</e2tsid>
+		<e2onid>1</e2onid>
+		<e2sid>28000</e2sid>
+	</e2service>
+	<e2eventlist>
+		<e2event>
+			<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+			<e2eventservicename>Das Erste HD</e2eventservicename>
+			<e2eventprovidername>ARD</e2eventprovidername>
+			<e2eventid>39150</e2eventid>
+			<e2eventname>Tagesschau</e2eventname>
+			<e2eventtitle>Tagesschau</e2eventtitle>
+			<e2eventdescription>Nachrichten</e2eventdescription>
+			<e2eventstart>1893456000</e2eventstart>
+			<e2eventduration>3600</e2eventduration>
+			<e2eventremaining>1800</e2eventremaining>
+			<e2eventcurrenttime>1893452400</e2eventcurrenttime>
+			<e2eventdescriptionextended>Die Nachrichten um 20 Uhr.Mit Wetter.</e2eventdescriptionextended>
+		</e2event>
+		<e2event>
+			<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+			<e2eventservicename>Das Erste HD</e2eventservicename>
+			<e2eventprovidername>ARD</e2eventprovidername>
+			<e2eventid>39151</e2eventid>
+			<e2eventname></e2eventname>
+			<e2eventtitle></e2eventtitle>
+			<e2eventdescription/>
+			<e2eventstart>1893459600</e2eventstart>
+			<e2eventduration>1800</e2eventduration>
+			<e2eventremaining>0</e2eventremaining>
+			<e2eventcurrenttime>1893452400</e2eventcurrenttime>
+			<e2eventdescriptionextended/>
+		</e2event>
+	</e2eventlist>
+</e2currentserviceinformation>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -28,10 +28,11 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | EPG bouquet typed rows | [#179](https://github.com/sreichholf/dreamDroid/pull/179) | merged | `21b6db59` typed `enigma.Event` into `EpgBouquetFragment` / `EpgBouquetAdapter`. Search EPG not migrated. |
 | EPG search typed rows | [#180](https://github.com/sreichholf/dreamDroid/pull/180) | merged | `4f3249b2` typed `enigma.Event` into `EpgSearchFragment`; reuses `EpgBouquetAdapter`. Drop unused `EpgAdapter`. |
 | PickService typed list | [#181](https://github.com/sreichholf/dreamDroid/pull/181) | merged | `ce7cfb1d` typed `enigma.Service` into `PickServiceFragment`; load via `GetBouquetListTask`. Intent still maps one `ExtendedHashMap` at send. |
+| CurrentService typed | open (`cursor/current-service-typed-c88a`) | open | typed `enigma.CurrentService` for `/web/getcurrent`; XML UI stays; hash only at EPG detail/timer edge. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181) are on `main`. Remaining typed API: current event, hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181) are on `main`. Remaining typed API: current event (open on `cursor/current-service-typed-c88a`), hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs.
 
@@ -362,7 +363,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 | EPG search | `EpgSearchFragment`, `EpgBouquetAdapter` | XML list. Rows are typed `enigma.Event` (#180). Detail/timer edge still hash. |
 | Bouquet picker | `PickServiceFragment`, `ServiceNameAdapter` | XML list. Typed `enigma.Service` on open branch `cursor/pick-service-typed-c88a`. Intent still one hash at send. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
-| Current event | `CurrentServiceFragment` | |
+| Current event | `CurrentServiceFragment` | Typed `enigma.CurrentService` on open branch `cursor/current-service-typed-c88a`. Detail/timer edge still hash. |
 | Virtual remote | `VirtualRemoteFragment`, `VirtualRemotePagerFragment` | |
 | Device info | `DeviceInfoFragment` | |
 | Signal | `SignalFragment` + vendored gauge lib | |
@@ -391,7 +392,7 @@ Compose on `main`: About dialog, Profiles list (not the edit form), TV & Movies 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181. **Still hash:** current event, hub now/next channel rows, movies list fetch, timers list fetch, device info, signal.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181. **Still hash / in flight:** current event typing open on `cursor/current-service-typed-c88a`; hub now/next, movies, timers, device info, signal remain.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen). `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). #177: dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. ButterKnife still open while TV is frozen.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -28,7 +28,7 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | EPG bouquet typed rows | [#179](https://github.com/sreichholf/dreamDroid/pull/179) | merged | `21b6db59` typed `enigma.Event` into `EpgBouquetFragment` / `EpgBouquetAdapter`. Search EPG not migrated. |
 | EPG search typed rows | [#180](https://github.com/sreichholf/dreamDroid/pull/180) | merged | `4f3249b2` typed `enigma.Event` into `EpgSearchFragment`; reuses `EpgBouquetAdapter`. Drop unused `EpgAdapter`. |
 | PickService typed list | [#181](https://github.com/sreichholf/dreamDroid/pull/181) | merged | `ce7cfb1d` typed `enigma.Service` into `PickServiceFragment`; load via `GetBouquetListTask`. Intent still maps one `ExtendedHashMap` at send. |
-| CurrentService typed | open (`cursor/current-service-typed-c88a`) | open | typed `enigma.CurrentService` for `/web/getcurrent`; XML UI stays; hash only at EPG detail/timer edge. |
+| CurrentService typed | [#183](https://github.com/sreichholf/dreamDroid/pull/183) | open | typed `enigma.CurrentService` for `/web/getcurrent`; XML UI stays; hash only at EPG detail/timer edge. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Appendix E shape (2): type `/web/getcurrent` after PickService [#181](https://github.com/sreichholf/dreamDroid/pull/181). Unblocks wave-3 `current-event-compose`.

## Scope

- `enigma.CurrentService` (Service + now/next Event), `CurrentServiceParser`, `EnigmaClient.getCurrent` / `getCurrentBlocking`, `GetCurrentServiceTask`.
- `CurrentServiceFragment` holds typed state; XML layout stays.
- Hash only at EPG detail / timer edges via mappers.
- `e2eventname` fallback for WebInterface 1.5; parse failure → `error_parsing`.

## Verification

JDK 17. Bugbot: no bugs.

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL (`CurrentServiceParserTest`, `CurrentServiceMapperTest`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

