### PR TITLE
feat(remote): convert VirtualRemoteFragment pad to Compose

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
@@ -1,0 +1,80 @@
+package net.reichholf.dreamdroid.ui.remote
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class VirtualRemoteScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun fullRemoteShowsCoreKeys() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                VirtualRemoteScreen(
+                    layout = VirtualRemoteLayout.Full,
+                    playButtonAsPlayPause = false,
+                    onKey = { _, _ -> },
+                )
+            }
+        }
+        composeRule.onNodeWithText("OK").assertIsDisplayed()
+        composeRule.onNodeWithText("PWR").assertIsDisplayed()
+        composeRule.onNodeWithText("Mute").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Up").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Play").assertIsDisplayed()
+        composeRule.onNodeWithText("TV").assertIsDisplayed()
+    }
+
+    @Test
+    fun simpleRemoteOmitsTransportPlay() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                VirtualRemoteScreen(
+                    layout = VirtualRemoteLayout.Simple,
+                    playButtonAsPlayPause = false,
+                    onKey = { _, _ -> },
+                )
+            }
+        }
+        composeRule.onNodeWithText("OK").assertIsDisplayed()
+        composeRule.onNodeWithText("1").assertIsDisplayed()
+        composeRule.onNodeWithText("RADIO").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Play").assertDoesNotExist()
+    }
+
+    @Test
+    fun quickZapShowsNavigationWithoutDigits() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                VirtualRemoteScreen(
+                    layout = VirtualRemoteLayout.QuickZap,
+                    playButtonAsPlayPause = false,
+                    onKey = { _, _ -> },
+                )
+            }
+        }
+        composeRule.onNodeWithText("OK").assertIsDisplayed()
+        composeRule.onNodeWithText("V+").assertIsDisplayed()
+        composeRule.onNodeWithText("B-").assertIsDisplayed()
+        composeRule.onNodeWithText("1").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Play").assertDoesNotExist()
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
@@ -1,7 +1,6 @@
 package net.reichholf.dreamdroid.ui.remote
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/res/layout-sw720dp-land/virtual_remote_host.xml
+++ b/app/res/layout-sw720dp-land/virtual_remote_host.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="end">
+
+    <FrameLayout
+        android:id="@+id/screenshot_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="320dp"
+        android:layout_marginRight="320dp"
+        android:padding="20dp" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_remote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true" />
+</RelativeLayout>

--- a/app/res/layout-sw720dp/virtual_remote_host.xml
+++ b/app/res/layout-sw720dp/virtual_remote_host.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="end">
+
+    <FrameLayout
+        android:id="@+id/screenshot_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="600dp"
+        android:padding="20dp" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_remote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:paddingBottom="15dp" />
+</RelativeLayout>

--- a/app/res/layout/virtual_remote_host.xml
+++ b/app/res/layout/virtual_remote_host.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_remote"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/app/src/net/reichholf/dreamdroid/fragment/VirtualRemoteFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/VirtualRemoteFragment.java
@@ -20,6 +20,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -32,267 +33,234 @@ import net.reichholf.dreamdroid.helpers.Python;
 import net.reichholf.dreamdroid.helpers.enigma2.Remote;
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.RemoteCommandRequestHandler;
+import net.reichholf.dreamdroid.ui.remote.VirtualRemoteBindKt;
+import net.reichholf.dreamdroid.ui.remote.VirtualRemoteLayout;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A Virtual dreambox remote control using http-requests to send key-strokes
+ * A Virtual dreambox remote control using http-requests to send key-strokes.
+ * Phone pad is Compose Material 3; tablet layouts keep an embedded screenshot host.
  *
  * @author sreichholf
  */
 public class VirtualRemoteFragment extends BaseHttpFragment {
-    @NonNull
+	@NonNull
 	private static String TAG = VirtualRemoteFragment.class.getSimpleName();
 
-    private boolean mQuickZap;
-    private boolean mPlayButtonAsPlayPause;
-    private boolean mSimpleRemote;
-    private String mBaseTitle;
-    @Nullable
+	private boolean mQuickZap;
+	private boolean mPlayButtonAsPlayPause;
+	private boolean mSimpleRemote;
+	private String mBaseTitle;
+	@Nullable
 	private ScreenShotFragment mScreenshotFragment;
-    private Vibrator mVibrator;
-    private Handler mHandler;
-    @Nullable
+	private Vibrator mVibrator;
+	private Handler mHandler;
+	@Nullable
 	private Runnable mScreenShotCallback;
 
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        mShouldRetainInstance = false;
-        super.onCreate(savedInstanceState);
-        initTitles(getString(R.string.virtual_remote));
-        mHttpHelper.showToastOnSimpleResult(false);
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		mShouldRetainInstance = false;
+		super.onCreate(savedInstanceState);
+		initTitles(getString(R.string.virtual_remote));
+		mHttpHelper.showToastOnSimpleResult(false);
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity());
-        mQuickZap = getArguments().getBoolean(DreamDroid.PREFS_KEY_QUICKZAP, prefs.getBoolean(DreamDroid.PREFS_KEY_QUICKZAP, false));
-        mPlayButtonAsPlayPause = getArguments().getBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, prefs.getBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, false));
-        mSimpleRemote = DreamDroid.getCurrentProfile().isSimpleRemote();
-        mVibrator = (Vibrator) getAppCompatActivity().getSystemService(Context.VIBRATOR_SERVICE);
-        mHandler = new Handler();
-    }
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity());
+		mQuickZap = getArguments().getBoolean(DreamDroid.PREFS_KEY_QUICKZAP, prefs.getBoolean(DreamDroid.PREFS_KEY_QUICKZAP, false));
+		mPlayButtonAsPlayPause = getArguments().getBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, prefs.getBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, false));
+		mSimpleRemote = DreamDroid.getCurrentProfile().isSimpleRemote();
+		mVibrator = (Vibrator) getAppCompatActivity().getSystemService(Context.VIBRATOR_SERVICE);
+		mHandler = new Handler();
+	}
 
-    public static Integer[][] getRemoteButtons(boolean isPlayButtonPlayPause) {
+	/**
+	 * Kept for the home-screen widget RemoteViews binder.
+	 */
+	public static Integer[][] getRemoteButtons(boolean isPlayButtonPlayPause) {
 
-        Map<Integer, Integer> buttonMap = new HashMap<>();
-        buttonMap.put(R.id.ButtonPower, Remote.KEY_POWER);
+		Map<Integer, Integer> buttonMap = new HashMap<>();
+		buttonMap.put(R.id.ButtonPower, Remote.KEY_POWER);
 
-        buttonMap.put(R.id.ButtonExit, Remote.KEY_EXIT);
-        buttonMap.put(R.id.ButtonVolP, Remote.KEY_VOLP);
-        buttonMap.put(R.id.ButtonVolM, Remote.KEY_VOLM);
-        buttonMap.put(R.id.ButtonMute, Remote.KEY_MUTE);
-        buttonMap.put(R.id.ButtonBouP, Remote.KEY_BOUP);
-        buttonMap.put(R.id.ButtonBouM, Remote.KEY_BOUM);
-        buttonMap.put(R.id.ButtonUp, Remote.KEY_UP);
-        buttonMap.put(R.id.ButtonDown, Remote.KEY_DOWN);
-        buttonMap.put(R.id.ButtonLeft, Remote.KEY_LEFT);
-        buttonMap.put(R.id.ButtonRight, Remote.KEY_RIGHT);
-        buttonMap.put(R.id.ButtonOk, Remote.KEY_OK);
-        buttonMap.put(R.id.ButtonInfo, Remote.KEY_INFO);
-        buttonMap.put(R.id.ButtonMenu, Remote.KEY_MENU);
-        buttonMap.put(R.id.ButtonHelp, Remote.KEY_HELP);
-        buttonMap.put(R.id.ButtonPvr, Remote.KEY_PVR);
-        buttonMap.put(R.id.ButtonRed, Remote.KEY_RED);
-        buttonMap.put(R.id.ButtonGreen, Remote.KEY_GREEN);
-        buttonMap.put(R.id.ButtonYellow, Remote.KEY_YELLOW);
-        buttonMap.put(R.id.ButtonBlue, Remote.KEY_BLUE);
-        buttonMap.put(R.id.ButtonRwd, Remote.KEY_REWIND);
-        if (isPlayButtonPlayPause) {
-            buttonMap.put(R.id.ButtonPlayPause, Remote.KEY_PLAYPAUSE);
-        } else {
-            buttonMap.put(R.id.ButtonPlay, Remote.KEY_PLAY);
-        }
-        buttonMap.put(R.id.ButtonStop, Remote.KEY_STOP);
-        buttonMap.put(R.id.ButtonFwd, Remote.KEY_FORWARD);
-        buttonMap.put(R.id.ButtonRec, Remote.KEY_RECORD);
-        buttonMap.put(R.id.ButtonAudio, Remote.KEY_AUDIO);
-        buttonMap.put(R.id.Button1, Remote.KEY_1);
-        buttonMap.put(R.id.Button2, Remote.KEY_2);
-        buttonMap.put(R.id.Button3, Remote.KEY_3);
-        buttonMap.put(R.id.Button4, Remote.KEY_4);
-        buttonMap.put(R.id.Button5, Remote.KEY_5);
-        buttonMap.put(R.id.Button6, Remote.KEY_6);
-        buttonMap.put(R.id.Button7, Remote.KEY_7);
-        buttonMap.put(R.id.Button8, Remote.KEY_8);
-        buttonMap.put(R.id.Button9, Remote.KEY_9);
-        buttonMap.put(R.id.Button0, Remote.KEY_0);
-        buttonMap.put(R.id.ButtonLeftArrow, Remote.KEY_PREV);
-        buttonMap.put(R.id.ButtonRightArrow, Remote.KEY_NEXT);
-        buttonMap.put(R.id.ButtonTv, Remote.KEY_TV);
-        buttonMap.put(R.id.ButtonRadio, Remote.KEY_RADIO);
-        buttonMap.put(R.id.ButtonText, Remote.KEY_TEXT);
+		buttonMap.put(R.id.ButtonExit, Remote.KEY_EXIT);
+		buttonMap.put(R.id.ButtonVolP, Remote.KEY_VOLP);
+		buttonMap.put(R.id.ButtonVolM, Remote.KEY_VOLM);
+		buttonMap.put(R.id.ButtonMute, Remote.KEY_MUTE);
+		buttonMap.put(R.id.ButtonBouP, Remote.KEY_BOUP);
+		buttonMap.put(R.id.ButtonBouM, Remote.KEY_BOUM);
+		buttonMap.put(R.id.ButtonUp, Remote.KEY_UP);
+		buttonMap.put(R.id.ButtonDown, Remote.KEY_DOWN);
+		buttonMap.put(R.id.ButtonLeft, Remote.KEY_LEFT);
+		buttonMap.put(R.id.ButtonRight, Remote.KEY_RIGHT);
+		buttonMap.put(R.id.ButtonOk, Remote.KEY_OK);
+		buttonMap.put(R.id.ButtonInfo, Remote.KEY_INFO);
+		buttonMap.put(R.id.ButtonMenu, Remote.KEY_MENU);
+		buttonMap.put(R.id.ButtonHelp, Remote.KEY_HELP);
+		buttonMap.put(R.id.ButtonPvr, Remote.KEY_PVR);
+		buttonMap.put(R.id.ButtonRed, Remote.KEY_RED);
+		buttonMap.put(R.id.ButtonGreen, Remote.KEY_GREEN);
+		buttonMap.put(R.id.ButtonYellow, Remote.KEY_YELLOW);
+		buttonMap.put(R.id.ButtonBlue, Remote.KEY_BLUE);
+		buttonMap.put(R.id.ButtonRwd, Remote.KEY_REWIND);
+		if (isPlayButtonPlayPause) {
+			buttonMap.put(R.id.ButtonPlayPause, Remote.KEY_PLAYPAUSE);
+		} else {
+			buttonMap.put(R.id.ButtonPlay, Remote.KEY_PLAY);
+		}
+		buttonMap.put(R.id.ButtonStop, Remote.KEY_STOP);
+		buttonMap.put(R.id.ButtonFwd, Remote.KEY_FORWARD);
+		buttonMap.put(R.id.ButtonRec, Remote.KEY_RECORD);
+		buttonMap.put(R.id.ButtonAudio, Remote.KEY_AUDIO);
+		buttonMap.put(R.id.Button1, Remote.KEY_1);
+		buttonMap.put(R.id.Button2, Remote.KEY_2);
+		buttonMap.put(R.id.Button3, Remote.KEY_3);
+		buttonMap.put(R.id.Button4, Remote.KEY_4);
+		buttonMap.put(R.id.Button5, Remote.KEY_5);
+		buttonMap.put(R.id.Button6, Remote.KEY_6);
+		buttonMap.put(R.id.Button7, Remote.KEY_7);
+		buttonMap.put(R.id.Button8, Remote.KEY_8);
+		buttonMap.put(R.id.Button9, Remote.KEY_9);
+		buttonMap.put(R.id.Button0, Remote.KEY_0);
+		buttonMap.put(R.id.ButtonLeftArrow, Remote.KEY_PREV);
+		buttonMap.put(R.id.ButtonRightArrow, Remote.KEY_NEXT);
+		buttonMap.put(R.id.ButtonTv, Remote.KEY_TV);
+		buttonMap.put(R.id.ButtonRadio, Remote.KEY_RADIO);
+		buttonMap.put(R.id.ButtonText, Remote.KEY_TEXT);
 
-        Integer[][] keys = new Integer[buttonMap.size()][];
-        int i = 0;
-        for (Map.Entry<Integer,Integer> entry: buttonMap.entrySet()) {
-            keys[i] = new Integer[]{entry.getKey(), entry.getValue()};
-            i++;
-        }
-        return keys;
-    }
+		Integer[][] keys = new Integer[buttonMap.size()][];
+		int i = 0;
+		for (Map.Entry<Integer, Integer> entry : buttonMap.entrySet()) {
+			keys[i] = new Integer[]{entry.getKey(), entry.getValue()};
+			i++;
+		}
+		return keys;
+	}
 
-    @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = getRemoteView();
+	@Override
+	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		View view = inflater.inflate(R.layout.virtual_remote_host, container, false);
+		ComposeView compose = view.findViewById(R.id.compose_remote);
 
-        if (view.findViewById(R.id.screenshot_frame) != null) {
-            mScreenshotFragment = new ScreenShotFragment(false, false, false);
+		VirtualRemoteLayout layout;
+		if (mQuickZap) {
+			layout = VirtualRemoteLayout.QuickZap;
+			mBaseTitle = getString(R.string.app_name_release) + "::" + getString(R.string.quickzap);
+		} else if (mSimpleRemote) {
+			layout = VirtualRemoteLayout.Simple;
+			mBaseTitle = getString(R.string.app_name_release) + "::" + getString(R.string.virtual_remote);
+		} else {
+			layout = VirtualRemoteLayout.Full;
+			mBaseTitle = getString(R.string.app_name_release) + "::" + getString(R.string.virtual_remote);
+		}
+		getAppCompatActivity().setTitle(mBaseTitle);
 
-            FragmentManager fm = getChildFragmentManager();
-            FragmentTransaction ft = fm.beginTransaction();
-            ft.replace(R.id.screenshot_frame, mScreenshotFragment);
-            ft.commit();
-        } else {
-            mScreenshotFragment = null;
-        }
+		VirtualRemoteBindKt.bindVirtualRemoteScreen(
+				compose,
+				layout,
+				mPlayButtonAsPlayPause,
+				(keyCode, longClick) -> {
+					onButtonClicked(keyCode, longClick);
+					return kotlin.Unit.INSTANCE;
+				}
+		);
 
-        View playButton = view.findViewById(R.id.ButtonPlay);
-        if (playButton != null) {
-            playButton.setVisibility(mPlayButtonAsPlayPause ? View.INVISIBLE : View.VISIBLE);
-        }
-        View playPauseButton = view.findViewById(R.id.ButtonPlayPause);
-        if (playPauseButton != null) {
-            playPauseButton.setVisibility(mPlayButtonAsPlayPause ? View.VISIBLE : View.INVISIBLE);
-        }
+		if (view.findViewById(R.id.screenshot_frame) != null) {
+			mScreenshotFragment = new ScreenShotFragment(false, false, false);
 
-        return view;
-    }
+			FragmentManager fm = getChildFragmentManager();
+			FragmentTransaction ft = fm.beginTransaction();
+			ft.replace(R.id.screenshot_frame, mScreenshotFragment);
+			ft.commit();
+		} else {
+			mScreenshotFragment = null;
+		}
 
-    @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        return mScreenshotFragment != null && mScreenshotFragment.onOptionsItemSelected(item);
-    }
+		return view;
+	}
 
-    @Override
-    public void onPause() {
-        abortScreenshotReload();
-        super.onPause();
-    }
+	@Override
+	public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+		return mScreenshotFragment != null && mScreenshotFragment.onOptionsItemSelected(item);
+	}
 
-    /**
-     * @param buttonmap array of (button view id, command id) to register callbacks
-     *                  for
-     */
-    private void registerButtons(@NonNull View view, @NonNull Integer[][] buttonmap) {
-        for (Integer[] aButtonmap : buttonmap) {
-            View v = view.findViewById(aButtonmap[0]);
-            if (v == null)
-                continue;
-            registerOnClickListener(v, aButtonmap[1]);
-        }
-    }
+	@Override
+	public void onPause() {
+		abortScreenshotReload();
+		super.onPause();
+	}
 
-    /**
-     * Apply Gui-Element-Attributes and register OnClickListeners in dependence
-     * of the active layout (Standard or QuickZap)
-     */
-    private View getRemoteView() {
-        LayoutInflater inflater = getAppCompatActivity().getLayoutInflater();
-        View view;
-        if (mQuickZap) {
-            view = inflater.inflate(R.layout.virtual_remote_quick_zap, null, false);
-            mBaseTitle = getString(R.string.app_name_release) + "::" + getString(R.string.quickzap);
-        } else {
-            if (mSimpleRemote)
-                view = inflater.inflate(R.layout.virtual_remote_simple, null, false);
-            else
-                view = inflater.inflate(R.layout.virtual_remote, null, false);
-            mBaseTitle = getString(R.string.app_name_release) + "::" + getString(R.string.virtual_remote);
-        }
-        registerButtons(view, getRemoteButtons(mPlayButtonAsPlayPause));
-        getAppCompatActivity().setTitle(mBaseTitle);
+	/**
+	 * Called after a Button has been clicked
+	 *
+	 * @param id        The remote key command id
+	 * @param longClick If true the item has been long-clicked
+	 */
+	private void onButtonClicked(int id, boolean longClick) {
+		int msec = 25;
+		if (longClick) {
+			msec = 100;
+		}
 
-        return view;
-    }
+		mVibrator.vibrate(msec);
 
-    /**
-     * Registers an OnClickListener for a specific GUI Element. OnClick the
-     * function <code>onButtonClicked</code> will be called with the given id
-     *
-     * @param v  The view to register an OnClickListener for
-     * @param id The item ID to register the listener for
-     */
-    protected void registerOnClickListener(@NonNull View v, final int id) {
-        v.setLongClickable(true);
+		ArrayList<NameValuePair> params = new ArrayList<>();
+		params.add(new NameValuePair("command", String.valueOf(id)));
+		if (mSimpleRemote) {
+			params.add(new NameValuePair("rcu", "standard"));
+		} else {
+			params.add(new NameValuePair("rcu", "advanced"));
+		}
+		if (longClick) {
+			params.add(new NameValuePair("type", Remote.CLICK_TYPE_LONG));
+		}
 
-        v.setOnLongClickListener(v12 -> {
-            onButtonClicked(id, true);
-            return true;
-        });
+		execSimpleResultTask(new RemoteCommandRequestHandler(), params);
+	}
 
-        v.setOnClickListener(v1 -> onButtonClicked(id, false));
-    }
+	private void abortScreenshotReload() {
+		if (mScreenShotCallback != null)
+			mHandler.removeCallbacks(mScreenShotCallback);
+	}
 
-    /**
-     * Called after a Button has been clicked
-     *
-     * @param id        The id of the item
-     * @param longClick If true the item has been long-clicked
-     */
-    private void onButtonClicked(int id, boolean longClick) {
-        int msec = 25;
-        if (longClick) {
-            msec = 100;
-        }
+	public void reloadScreenhot() {
+		Log.w(TAG, "Scheduling screenshot reload");
+		abortScreenshotReload();
+		if (mScreenshotFragment == null || !mScreenshotFragment.isVisible() || mScreenShotCallback != null)
+			return;
 
-        mVibrator.vibrate(msec);
+		mScreenShotCallback = () -> {
+			Log.w(TAG, "Reloading screenshot");
+			mScreenshotFragment.reload();
+			mScreenShotCallback = null;
+		};
+		mHandler.postDelayed(mScreenShotCallback, 700);
+	}
 
-        ArrayList<NameValuePair> params = new ArrayList<>();
-        params.add(new NameValuePair("command", String.valueOf(id)));
-        if (mSimpleRemote) {
-            params.add(new NameValuePair("rcu", "standard"));
-        } else {
-            params.add(new NameValuePair("rcu", "advanced"));
-        }
-        if (longClick) {
-            params.add(new NameValuePair("type", Remote.CLICK_TYPE_LONG));
-        }
+	@Override
+	public void onSimpleResult(boolean success, @NonNull ExtendedHashMap result) {
+		boolean hasError = false;
+		String toastText = getString(R.string.get_content_error);
+		String stateText = result.getString(SimpleResult.KEY_STATE_TEXT);
+		String state = result.getString(SimpleResult.KEY_STATE);
 
-        execSimpleResultTask(new RemoteCommandRequestHandler(), params);
-    }
+		if (stateText == null || "".equals(stateText)) {
+			hasError = true;
+		}
 
-    private void abortScreenshotReload() {
-        if (mScreenShotCallback != null)
-            mHandler.removeCallbacks(mScreenShotCallback);
-    }
+		if (getHttpClient().hasError()) {
+			toastText = toastText + "\n" + getHttpClient().getErrorText(getContext());
+			hasError = true;
+		} else if (Python.FALSE.equals(state)) {
+			hasError = true;
+			toastText = stateText;
+		}
 
-    public void reloadScreenhot() {
-        Log.w(TAG, "Scheduling screenshot reload");
-        abortScreenshotReload();
-        if (mScreenshotFragment == null || !mScreenshotFragment.isVisible() || mScreenShotCallback != null)
-            return;
-
-        mScreenShotCallback = () -> {
-            Log.w(TAG, "Reloading screenshot");
-            mScreenshotFragment.reload();
-            mScreenShotCallback = null;
-        };
-        mHandler.postDelayed(mScreenShotCallback, 700);
-    }
-
-    @Override
-    public void onSimpleResult(boolean success, @NonNull ExtendedHashMap result) {
-        boolean hasError = false;
-        String toastText = getString(R.string.get_content_error);
-        String stateText = result.getString(SimpleResult.KEY_STATE_TEXT);
-        String state = result.getString(SimpleResult.KEY_STATE);
-
-        if (stateText == null || "".equals(stateText)) {
-            hasError = true;
-        }
-
-        if (getHttpClient().hasError()) {
-            toastText = toastText + "\n" + getHttpClient().getErrorText(getContext());
-            hasError = true;
-        } else if (Python.FALSE.equals(state)) {
-            hasError = true;
-            toastText = stateText;
-        }
-
-        if (hasError) {
-            showToast(toastText);
-        } else {
-            reloadScreenhot();
-        }
-    }
+		if (hasError) {
+			showToast(toastText);
+		} else {
+			reloadScreenhot();
+		}
+	}
 }

--- a/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteBind.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteBind.kt
@@ -1,0 +1,22 @@
+package net.reichholf.dreamdroid.ui.remote
+
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+fun ComposeView.bindVirtualRemoteScreen(
+    layout: VirtualRemoteLayout,
+    playButtonAsPlayPause: Boolean,
+    onKey: (keyCode: Int, longClick: Boolean) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            VirtualRemoteScreen(
+                layout = layout,
+                playButtonAsPlayPause = playButtonAsPlayPause,
+                onKey = onKey,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -57,7 +59,8 @@ fun VirtualRemoteScreen(
 ) {
     Column(
         modifier = modifier
-            .fillMaxWidth()
+            .wrapContentWidth()
+            .widthIn(max = 320.dp)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
@@ -1,0 +1,381 @@
+package net.reichholf.dreamdroid.ui.remote
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.helpers.enigma2.Remote
+
+enum class VirtualRemoteLayout {
+    Full,
+    Simple,
+    QuickZap,
+}
+
+private val KeyDark = Color(0xFF424242)
+private val KeyLight = Color(0xFF757575)
+private val KeyRed = Color(0xFFC62828)
+private val KeyGreen = Color(0xFF2E7D32)
+private val KeyYellow = Color(0xFFF9A825)
+private val KeyBlue = Color(0xFF1565C0)
+private val KeyOnDark = Color.White
+private val KeyOnYellow = Color(0xFF212121)
+
+@Composable
+fun VirtualRemoteScreen(
+    layout: VirtualRemoteLayout,
+    playButtonAsPlayPause: Boolean,
+    onKey: (keyCode: Int, longClick: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        when (layout) {
+            VirtualRemoteLayout.QuickZap -> QuickZapPad(onKey = onKey)
+            VirtualRemoteLayout.Simple -> SimplePad(onKey = onKey)
+            VirtualRemoteLayout.Full -> FullPad(
+                playButtonAsPlayPause = playButtonAsPlayPause,
+                onKey = onKey,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullPad(
+    playButtonAsPlayPause: Boolean,
+    onKey: (Int, Boolean) -> Unit,
+) {
+    NumberVolumeBouquetPad(onKey = onKey)
+    ColorKeysRow(onKey = onKey)
+    NavigationPad(onKey = onKey)
+    MuteExitRow(onKey = onKey)
+    TransportPad(playButtonAsPlayPause = playButtonAsPlayPause, onKey = onKey)
+    SourcePad(onKey = onKey)
+}
+
+@Composable
+private fun SimplePad(onKey: (Int, Boolean) -> Unit) {
+    NumberVolumeBouquetPad(onKey = onKey)
+    NavigationPad(onKey = onKey)
+    MuteExitRow(onKey = onKey)
+    ColorKeysRow(onKey = onKey)
+    SourcePad(onKey = onKey)
+}
+
+@Composable
+private fun QuickZapPad(onKey: (Int, Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = 36.dp)
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "V+", keyCode = Remote.KEY_VOLP, onKey = onKey, container = KeyLight)
+            RemoteKey(label = "V-", keyCode = Remote.KEY_VOLM, onKey = onKey, container = KeyLight)
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "Mute", keyCode = Remote.KEY_MUTE, onKey = onKey)
+            RemoteKey(label = "Exit", keyCode = Remote.KEY_EXIT, onKey = onKey, container = KeyRed)
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "B+", keyCode = Remote.KEY_BOUP, onKey = onKey, container = KeyLight)
+            RemoteKey(label = "B-", keyCode = Remote.KEY_BOUM, onKey = onKey, container = KeyLight)
+        }
+        RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = 36.dp)
+    }
+    NavigationPad(onKey = onKey, big = true)
+    ColorKeysRow(onKey = onKey, height = 36.dp)
+}
+
+@Composable
+private fun NumberVolumeBouquetPad(onKey: (Int, Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = 36.dp)
+            RemoteKey(label = "V+", keyCode = Remote.KEY_VOLP, onKey = onKey, container = KeyLight)
+            RemoteKey(label = "V-", keyCode = Remote.KEY_VOLM, onKey = onKey, container = KeyLight)
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                DigitKey("1", Remote.KEY_1, onKey)
+                DigitKey("2", Remote.KEY_2, onKey)
+                DigitKey("3", Remote.KEY_3, onKey)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                DigitKey("4", Remote.KEY_4, onKey)
+                DigitKey("5", Remote.KEY_5, onKey)
+                DigitKey("6", Remote.KEY_6, onKey)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                DigitKey("7", Remote.KEY_7, onKey)
+                DigitKey("8", Remote.KEY_8, onKey)
+                DigitKey("9", Remote.KEY_9, onKey)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                DigitKey("<", Remote.KEY_PREV, onKey)
+                DigitKey("0", Remote.KEY_0, onKey)
+                DigitKey(">", Remote.KEY_NEXT, onKey)
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = 36.dp)
+            RemoteKey(label = "B+", keyCode = Remote.KEY_BOUP, onKey = onKey, container = KeyLight)
+            RemoteKey(label = "B-", keyCode = Remote.KEY_BOUM, onKey = onKey, container = KeyLight)
+        }
+    }
+}
+
+@Composable
+private fun ColorKeysRow(onKey: (Int, Boolean) -> Unit, height: Dp = 30.dp) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        RemoteKey(label = "Red", keyCode = Remote.KEY_RED, onKey = onKey, container = KeyRed, height = height, showLabel = false)
+        RemoteKey(label = "Green", keyCode = Remote.KEY_GREEN, onKey = onKey, container = KeyGreen, height = height, showLabel = false)
+        RemoteKey(label = "Yellow", keyCode = Remote.KEY_YELLOW, onKey = onKey, container = KeyYellow, height = height, showLabel = false, contentColor = KeyOnYellow)
+        RemoteKey(label = "Blue", keyCode = Remote.KEY_BLUE, onKey = onKey, container = KeyBlue, height = height, showLabel = false)
+    }
+}
+
+@Composable
+private fun NavigationPad(onKey: (Int, Boolean) -> Unit, big: Boolean = false) {
+    val size = if (big) 64.dp else 52.dp
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "Info", keyCode = Remote.KEY_INFO, onKey = onKey, width = size, height = size)
+            IconRemoteKey(
+                description = "Up",
+                keyCode = Remote.KEY_UP,
+                iconRes = R.drawable.ic_key_up,
+                onKey = onKey,
+                width = size,
+                height = size,
+                container = KeyLight,
+            )
+            RemoteKey(label = "Menu", keyCode = Remote.KEY_MENU, onKey = onKey, width = size, height = size)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            IconRemoteKey(
+                description = "Left",
+                keyCode = Remote.KEY_LEFT,
+                iconRes = R.drawable.ic_key_left,
+                onKey = onKey,
+                width = size,
+                height = size,
+                container = KeyLight,
+            )
+            RemoteKey(label = "OK", keyCode = Remote.KEY_OK, onKey = onKey, width = size, height = size, container = KeyLight)
+            IconRemoteKey(
+                description = "Right",
+                keyCode = Remote.KEY_RIGHT,
+                iconRes = R.drawable.ic_key_right,
+                onKey = onKey,
+                width = size,
+                height = size,
+                container = KeyLight,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            RemoteKey(label = "Audio", keyCode = Remote.KEY_AUDIO, onKey = onKey, width = size, height = size)
+            IconRemoteKey(
+                description = "Down",
+                keyCode = Remote.KEY_DOWN,
+                iconRes = R.drawable.ic_key_down,
+                onKey = onKey,
+                width = size,
+                height = size,
+                container = KeyLight,
+            )
+            RemoteKey(label = "PVR", keyCode = Remote.KEY_PVR, onKey = onKey, width = size, height = size)
+        }
+    }
+}
+
+@Composable
+private fun MuteExitRow(onKey: (Int, Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        RemoteKey(label = "Mute", keyCode = Remote.KEY_MUTE, onKey = onKey, width = 88.dp, height = 36.dp)
+        RemoteKey(label = "Exit", keyCode = Remote.KEY_EXIT, onKey = onKey, width = 88.dp, height = 36.dp, container = KeyRed)
+    }
+}
+
+@Composable
+private fun TransportPad(playButtonAsPlayPause: Boolean, onKey: (Int, Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        IconRemoteKey(
+            description = "Rewind",
+            keyCode = Remote.KEY_REWIND,
+            iconRes = R.drawable.ic_media_previous_dark,
+            onKey = onKey,
+            width = 56.dp,
+            height = 48.dp,
+        )
+        if (playButtonAsPlayPause) {
+            IconRemoteKey(
+                description = "Play/Pause",
+                keyCode = Remote.KEY_PLAYPAUSE,
+                iconRes = R.drawable.ic_media_play_pause_dark,
+                onKey = onKey,
+                width = 56.dp,
+                height = 48.dp,
+            )
+        } else {
+            IconRemoteKey(
+                description = "Play",
+                keyCode = Remote.KEY_PLAY,
+                iconRes = R.drawable.ic_media_play_dark,
+                onKey = onKey,
+                width = 56.dp,
+                height = 48.dp,
+            )
+        }
+        IconRemoteKey(
+            description = "Stop",
+            keyCode = Remote.KEY_STOP,
+            iconRes = R.drawable.ic_media_stop_dark,
+            onKey = onKey,
+            width = 56.dp,
+            height = 48.dp,
+        )
+        IconRemoteKey(
+            description = "Forward",
+            keyCode = Remote.KEY_FORWARD,
+            iconRes = R.drawable.ic_media_next_dark,
+            onKey = onKey,
+            width = 56.dp,
+            height = 48.dp,
+        )
+    }
+}
+
+@Composable
+private fun SourcePad(onKey: (Int, Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        RemoteKey(label = "TV", keyCode = Remote.KEY_TV, onKey = onKey, width = 56.dp, height = 48.dp)
+        RemoteKey(label = "RADIO", keyCode = Remote.KEY_RADIO, onKey = onKey, width = 56.dp, height = 48.dp)
+        RemoteKey(label = "TEXT", keyCode = Remote.KEY_TEXT, onKey = onKey, width = 56.dp, height = 48.dp)
+        RemoteKey(
+            label = "REC",
+            keyCode = Remote.KEY_RECORD,
+            onKey = onKey,
+            width = 56.dp,
+            height = 48.dp,
+            contentColor = KeyRed,
+        )
+    }
+}
+
+@Composable
+private fun DigitKey(label: String, keyCode: Int, onKey: (Int, Boolean) -> Unit) {
+    RemoteKey(
+        label = label,
+        keyCode = keyCode,
+        onKey = onKey,
+        fontWeight = FontWeight.Bold,
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun RemoteKey(
+    label: String,
+    keyCode: Int,
+    onKey: (Int, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    width: Dp = 52.dp,
+    height: Dp = 48.dp,
+    container: Color = KeyDark,
+    contentColor: Color = KeyOnDark,
+    showLabel: Boolean = true,
+    fontWeight: FontWeight = FontWeight.Normal,
+) {
+    Box(
+        modifier = modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(6.dp))
+            .background(container)
+            .semantics { contentDescription = label }
+            .combinedClickable(
+                onClick = { onKey(keyCode, false) },
+                onLongClick = { onKey(keyCode, true) },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (showLabel) {
+            Text(
+                text = label,
+                color = contentColor,
+                fontSize = 12.sp,
+                fontWeight = fontWeight,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun IconRemoteKey(
+    description: String,
+    keyCode: Int,
+    iconRes: Int,
+    onKey: (Int, Boolean) -> Unit,
+    width: Dp,
+    height: Dp,
+    container: Color = KeyDark,
+) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .clip(RoundedCornerShape(6.dp))
+            .background(container)
+            .semantics { contentDescription = description }
+            .combinedClickable(
+                onClick = { onKey(keyCode, false) },
+                onLongClick = { onKey(keyCode, true) },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = null,
+            tint = KeyOnDark,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -30,13 +30,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | PickService typed list | [#181](https://github.com/sreichholf/dreamDroid/pull/181) | merged | `ce7cfb1d` typed `enigma.Service` into `PickServiceFragment`; load via `GetBouquetListTask`. Intent still maps one `ExtendedHashMap` at send. |
 | CurrentService typed | [#183](https://github.com/sreichholf/dreamDroid/pull/183) | merged | typed `enigma.CurrentService` for `/web/getcurrent`; XML UI stays; hash only at EPG detail/timer edge. |
 | profile-edit-compose | [#184](https://github.com/sreichholf/dreamDroid/pull/184) | merged | `ProfileEditFragment` Compose form + `ProfileEditScreenTest`. |
-| zap-compose ([#185](https://github.com/sreichholf/dreamDroid/pull/185)) | — | open | open on `cursor/zap-compose-c88a` — `ZapFragment` Compose grid + `ZapScreenTest` |
+| zap-compose | [#185](https://github.com/sreichholf/dreamDroid/pull/185) | merged | `55ecc5df` `ZapFragment` Compose grid + `ZapScreenTest`. |
+| virtual-remote-compose | — | open | open on `cursor/virtual-remote-compose-c88a` — `VirtualRemoteFragment` Compose pad + `VirtualRemoteScreenTest` |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
 Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. `profile-edit-compose` is on `main` as #184. Next screen (`zap-compose`) is open on `cursor/zap-compose-c88a`.
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. `profile-edit-compose` is on `main` as #184. `zap-compose` is on `main` as #185. Next screen (`virtual-remote-compose`) is open on `cursor/virtual-remote-compose-c88a`.
 
 ### Operator overrides (this program)
 
@@ -54,8 +55,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Hub + rows are Compose on `main` (#169/#170). `ServiceAdapter` remains for `ShareActivity` / video overlay; a hidden RecyclerView may remain for `BaseRecyclerFragment`.
 - `ProfileAdapter` remains for `ShareActivity`.
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
-- Zap Compose grid is open on `cursor/zap-compose-c88a`. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker list typing is on `main` via #181 (Intent still one `ExtendedHashMap` at send).
+- Zap Compose grid is on `main` via #185. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker list typing is on `main` via #181 (Intent still one `ExtendedHashMap` at send).
 - Profile edit form is Compose on `main` via #184.
+- Virtual remote Compose pad is open on `cursor/virtual-remote-compose-c88a`.
 - Service EPG list still XML. Rows are typed `enigma.Event` on `main` via #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Dead `EpgTimelineFragment` removed in #177.
 - EPG bouquet still XML. Rows are typed `enigma.Event` on `main` via #179. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
 - EPG search still XML. Rows are typed `enigma.Event` on `main` via #180. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
@@ -351,7 +353,7 @@ This was never "replace the phone app with Compose." The original boxes named fi
 
 ### Still Java/XML phone screens (drawer and related)
 
-Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**. The pager pages behind those tabs landed as Compose in #170. Zap Compose is open on `cursor/zap-compose-c88a`.
+Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**, Zap grid (#185). The pager pages behind those tabs landed as Compose in #170. Virtual remote Compose is open on `cursor/virtual-remote-compose-c88a`.
 
 | Surface | Code | Notes |
 | --- | --- | --- |
@@ -360,14 +362,14 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 | Timer list / edit | Compose list on `main` via #170; `TimerEditFragment` | List Compose; edit stays XML. |
 | Profile add/edit | Compose on `main` via #184 | Form Compose; list was #168. Autodiscovery stays Java. |
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
-| Zap | open `cursor/zap-compose-c88a` | Compose grid + Picasso picons. Rows typed `enigma.Service` (#173). Picker list typing on `main` via #181. |
+| Zap | Compose on `main` via #185 | Compose grid + Picasso picons. Rows typed `enigma.Service` (#173). Picker list typing on `main` via #181. |
 | Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (#176). Detail/timer edge still hash. |
 | EPG bouquet | `EpgBouquetFragment`, `EpgBouquetAdapter` | XML list. Rows are typed `enigma.Event` (#179). Detail/timer edge still hash. |
 | EPG search | `EpgSearchFragment`, `EpgBouquetAdapter` | XML list. Rows are typed `enigma.Event` (#180). Detail/timer edge still hash. |
-| Bouquet picker | `PickServiceFragment`, `ServiceNameAdapter` | XML list. Typed `enigma.Service` on open branch `cursor/pick-service-typed-c88a`. Intent still one hash at send. |
+| Bouquet picker | `PickServiceFragment`, `ServiceNameAdapter` | XML list. Typed `enigma.Service` on `main` via #181. Intent still one hash at send. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
-| Current event | `CurrentServiceFragment` | Typed `enigma.CurrentService` on open branch `cursor/current-service-typed-c88a`. Detail/timer edge still hash. |
-| Virtual remote | `VirtualRemoteFragment`, `VirtualRemotePagerFragment` | |
+| Current event | `CurrentServiceFragment` | Typed `enigma.CurrentService` on `main` via #183. Detail/timer edge still hash. |
+| Virtual remote | open `cursor/virtual-remote-compose-c88a` | Compose pad + HTTP keys; tablet screenshot host kept. |
 | Device info | `DeviceInfoFragment` | |
 | Signal | `SignalFragment` + vendored gauge lib | |
 | Screenshot | `ScreenShotFragment` + PhotoView | |
@@ -412,8 +414,8 @@ One PR per screen. Pattern: Compose + Kotlin Material 3 like About (#164) / Prof
 | --- | --- | --- | --- | --- |
 | 1 | `profile-edit-compose` | `ProfileEditFragment` | Profiles FAB/row → `SimpleToolbarFragmentActivity` | No (Room) — **merged** [#184](https://github.com/sreichholf/dreamDroid/pull/184) |
 | 2 | `current-event-compose` | `CurrentServiceFragment` | Drawer current | Yes — type current-service first |
-| 3 | `zap-compose` | `ZapFragment` | Drawer zap | No (rows already typed #173) — **open** on `cursor/zap-compose-c88a` |
-| 4 | `virtual-remote-compose` | `VirtualRemotePagerFragment` / `VirtualRemoteFragment` | Drawer remote | No |
+| 3 | `zap-compose` | `ZapFragment` | Drawer zap | No (rows already typed #173) — **merged** [#185](https://github.com/sreichholf/dreamDroid/pull/185) |
+| 4 | `virtual-remote-compose` | `VirtualRemotePagerFragment` / `VirtualRemoteFragment` | Drawer remote | No — **open** on `cursor/virtual-remote-compose-c88a` |
 | 5 | `device-info-compose` | `DeviceInfoFragment` | Drawer device info | Prefer type device-info first |
 | 6 | `signal-compose` | `SignalFragment` | Drawer signal | Prefer type signal first |
 | 7 | `screenshot-compose` | `ScreenShotFragment` | Drawer screenshot | No |

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -31,7 +31,7 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | CurrentService typed | [#183](https://github.com/sreichholf/dreamDroid/pull/183) | merged | typed `enigma.CurrentService` for `/web/getcurrent`; XML UI stays; hash only at EPG detail/timer edge. |
 | profile-edit-compose | [#184](https://github.com/sreichholf/dreamDroid/pull/184) | merged | `ProfileEditFragment` Compose form + `ProfileEditScreenTest`. |
 | zap-compose | [#185](https://github.com/sreichholf/dreamDroid/pull/185) | merged | `55ecc5df` `ZapFragment` Compose grid + `ZapScreenTest`. |
-| virtual-remote-compose | — | open | open on `cursor/virtual-remote-compose-c88a` — `VirtualRemoteFragment` Compose pad + `VirtualRemoteScreenTest` |
+| virtual-remote-compose ([#186](https://github.com/sreichholf/dreamDroid/pull/186)) | — | open | open on `cursor/virtual-remote-compose-c88a` — `VirtualRemoteFragment` Compose pad + `VirtualRemoteScreenTest` |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Wave 3 screen #4 (Appendix G): Virtual remote pad to Compose. No typed-API wait.

## Scope

- `VirtualRemoteScreen` Full / Simple / QuickZap pads; click + long-click → RCU codes.
- `VirtualRemoteFragment` hosts `ComposeView`; keeps HTTP remote commands and tablet screenshot embed.
- Tablet land: pad `wrapContentWidth` + `widthIn(max=320.dp)` so screenshot stays touchable.
- `VirtualRemoteScreenTest`; docs update.

## Verification

JDK 17. Bugbot: no bugs (after tablet width fix).

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL
- androidTest compile — SUCCESS; connected not run (no emulator)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

