### PR TITLE
feat(settings): Compose Material 3 settings screen

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/settings/SettingsScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/settings/SettingsScreenTest.kt
@@ -1,0 +1,49 @@
+package net.reichholf.dreamdroid.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun preferenceTitlesVisible() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val state = SettingsState.create(context)
+        composeRule.setContent {
+            DreamDroidTheme {
+                SettingsScreen(
+                    state = state,
+                    onThemeChanged = {},
+                    onDynamicColorsChanged = {},
+                    onSyncPicons = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Video Player").assertIsDisplayed()
+        composeRule.onNodeWithText("Integrated video player").assertIsDisplayed()
+        composeRule.onNodeWithText("Useability").assertIsDisplayed()
+        composeRule.onNodeWithText("Appearance").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Day/Night Theme choices").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Picons").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Use Picons").performScrollTo().assertIsDisplayed()
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
@@ -1,148 +1,86 @@
+/* © 2010 Stephan Reichholf <stephan at reichholf dot net>
+ *
+ * Licensed under the Create-Commons Attribution-Noncommercial-Share Alike 3.0 Unported
+ * http://creativecommons.org/licenses/by-nc-sa/3.0/
+ */
+
 package net.reichholf.dreamdroid.fragment;
 
-
-import android.content.SharedPreferences;
-import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
-import android.util.TypedValue;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.color.DynamicColors;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.BaseActivity;
-import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
-import net.reichholf.dreamdroid.video.VLCPlayer;
+import net.reichholf.dreamdroid.fragment.abs.BaseFragment;
+import net.reichholf.dreamdroid.ui.settings.SettingsScreenKt;
+import net.reichholf.dreamdroid.ui.settings.SettingsState;
 
 /**
- * Created by Stephan on 08.04.2015.
+ * Phone settings. Compose Material 3 preference list; keys match {@code R.xml.preferences}.
  */
-public class MyPreferenceFragment extends PreferenceFragmentCompat implements
-		SharedPreferences.OnSharedPreferenceChangeListener, ActivityCallbackHandler, ActionDialog.DialogActionListener {
+public class MyPreferenceFragment extends BaseFragment {
+
+	private SettingsState mState;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
+		mHasFabMain = false;
+		mHasFabReload = false;
 		super.onCreate(savedInstanceState);
+		initTitles(getString(R.string.settings));
+		PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences, false);
+		mState = SettingsState.create(requireContext());
 	}
 
 	@Override
-	public void onCreatePreferences(Bundle bundle, String s) {
-		addPreferencesFromResource(R.xml.preferences);
-		getActivity().setTitle(R.string.settings);
+	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		requireActivity().setTitle(R.string.settings);
 
-		PreferenceManager.setDefaultValues(getActivity(), R.xml.preferences, false);
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
-
-		Preference syncPref = findPreference(DreamDroid.PREFS_KEY_SYNC_PICONS);
-		syncPref.setOnPreferenceClickListener(preference -> {
-			startPiconSync();
-			return true;
-		});
-		findPreference(DreamDroid.PREFS_KEY_DYNAMIC_THEME_COLORS).setVisible(DynamicColors.isDynamicColorAvailable());
-		updateThemeSummary();
-		updateHwAccelSummary(prefs);
-	}
-
-	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-		TypedValue typedValue = new TypedValue();
-		getActivity().getTheme().resolveAttribute(android.R.attr.listSelector, typedValue, true);
-
-		boolean isDebuggable = (0 != (getActivity().getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
-		if (!isDebuggable) {
-			Preference dev = findPreference("developer");
-			if (dev != null) //Already removed?
-				getPreferenceScreen().removePreference(dev);
-		}
-
-		View header = getActivity().findViewById(R.id.content_header);
-		if (header != null)
-			header.setVisibility(View.GONE);
-	}
-
-	@Override
-	public void onResume() {
-		super.onResume();
-		PreferenceManager.getDefaultSharedPreferences(getActivity()).registerOnSharedPreferenceChangeListener(this);
-	}
-
-	@Override
-	public void onPause() {
-		PreferenceManager.getDefaultSharedPreferences(getActivity()).unregisterOnSharedPreferenceChangeListener(this);
-		super.onPause();
-	}
-
-	@Override
-	public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
-		setFabEnabled(R.id.fab_reload, false);
-		setFabEnabled(R.id.fab_main, false);
-	}
-
-	protected void setFabEnabled(int id, boolean enabled) {
-		FloatingActionButton fab = getActivity().findViewById(id);
-		if (fab == null)
-			return;
-		fab.setTag(R.id.fab_scrolling_view_behavior_enabled, enabled);
-		if (enabled)
-			fab.show();
-		else
-			fab.hide();
-	}
-
-	@Override
-	public void onSharedPreferenceChanged(@NonNull SharedPreferences prefs, String key) {
-		Log.w(DreamDroid.LOG_TAG, key);
-		if (DreamDroid.PREFS_KEY_THEME_TYPE.equals(key)) {
-			updateThemeSummary();
-			DreamDroid.setTheme((AppCompatActivity) getActivity());
-		} else if (DreamDroid.PREFS_KEY_DYNAMIC_THEME_COLORS.equals(key)) {
-			if (DynamicColors.isDynamicColorAvailable())
-				new Handler(Looper.getMainLooper()).postDelayed(() -> DreamDroid.restart(getContext()), 300);
-		} else if (DreamDroid.PREFS_KEY_HWACCEL.equals(key))
-			updateHwAccelSummary(prefs);
-	}
-
-	protected void updateThemeSummary() {
-		if (getActivity() == null)
-			return;
-		int idx = DreamDroid.getThemeType(getActivity());
-		Preference themePref = findPreference(DreamDroid.PREFS_KEY_THEME_TYPE);
-		themePref.setSummary(getResources().getStringArray(R.array.theme_option_entries)[idx]);
-	}
-
-	protected void updateHwAccelSummary(@NonNull SharedPreferences prefs) {
-		if (getActivity() == null)
-			return;
-		int idx = Integer.parseInt(prefs.getString(DreamDroid.PREFS_KEY_HWACCEL, Integer.toString(VLCPlayer.MEDIA_HWACCEL_ENABLED)));
-		Preference themePref = findPreference(DreamDroid.PREFS_KEY_HWACCEL);
-		themePref.setSummary(getString(R.string.use_hw_accel_long, getResources().getStringArray(R.array.hw_accel_entries)[idx]));
+		ComposeView composeView = new ComposeView(requireContext());
+		composeView.setLayoutParams(new ViewGroup.LayoutParams(
+			ViewGroup.LayoutParams.MATCH_PARENT,
+			ViewGroup.LayoutParams.MATCH_PARENT
+		));
+		SettingsScreenKt.bindSettingsScreen(
+			composeView,
+			mState,
+			() -> {
+				DreamDroid.setTheme((AppCompatActivity) requireActivity());
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				if (DynamicColors.isDynamicColorAvailable()) {
+					new Handler(Looper.getMainLooper()).postDelayed(
+						() -> DreamDroid.restart(requireContext()),
+						300
+					);
+				}
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				startPiconSync();
+				return kotlin.Unit.INSTANCE;
+			}
+		);
+		return composeView;
 	}
 
 	public void startPiconSync() {
-		((BaseActivity) getActivity()).startPiconSync();
-	}
-
-	@Override
-	public void onDrawerOpened() {
-	}
-
-	@Override
-	public void onDrawerClosed() {
+		((BaseActivity) requireActivity()).startPiconSync();
 	}
 
 	@Override
@@ -154,9 +92,4 @@ public class MyPreferenceFragment extends PreferenceFragmentCompat implements
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
 		return false;
 	}
-
-	@Override
-	public void onDialogAction(int action, Object details, String dialogTag) {
-	}
 }
-

--- a/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
@@ -1,0 +1,495 @@
+package net.reichholf.dreamdroid.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+@Composable
+fun SettingsScreen(
+    state: SettingsState,
+    onThemeChanged: () -> Unit,
+    onDynamicColorsChanged: () -> Unit,
+    onSyncPicons: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var listDialog by remember { mutableStateOf<ListDialogSpec?>(null) }
+    var editDialog by remember { mutableStateOf<EditDialogSpec?>(null) }
+
+    val themeEntries = stringArrayResource(R.array.theme_option_entries)
+    val themeValues = stringArrayResource(R.array.theme_option_values)
+    val hwEntries = stringArrayResource(R.array.hw_accel_entries)
+    val hwValues = stringArrayResource(R.array.hw_accel_values)
+    val gridEntries = stringArrayResource(R.array.max_grid_col_entries)
+    val gridValues = stringArrayResource(R.array.max_grid_col_values)
+
+    val hwAccelDialogTitle = stringResource(R.string.video_use_hw_accel)
+    val themeDialogTitle = stringResource(R.string.theme)
+    val gridDialogTitle = stringResource(R.string.max_grid_cols)
+    val syncPathDialogTitle = stringResource(R.string.sync_picons_path)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 24.dp),
+    ) {
+        PreferenceCategoryHeader(stringResource(R.string.video_player))
+        SwitchPreferenceRow(
+            title = stringResource(R.string.integrated_video_player),
+            summary = stringResource(R.string.integrated_video_player_long),
+            checked = state.integratedVideoPlayer,
+            onCheckedChange = {
+                state.setBoolean(DreamDroid.PREFS_KEY_INTEGRATED_PLAYER, it)
+            },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.video_enable_gestures),
+            summary = stringResource(R.string.video_enable_gestures_long),
+            checked = state.videoEnableGestures,
+            enabled = state.integratedVideoPlayer,
+            onCheckedChange = {
+                state.setBoolean(DreamDroid.PREFS_KEY_VIDEO_ENABLE_GESTURES, it)
+            },
+        )
+        ListPreferenceRow(
+            title = stringResource(R.string.use_hw_accel),
+            summary = stringResource(
+                R.string.use_hw_accel_long,
+                entryLabel(hwEntries, hwValues, state.videoHardwareAcceleration),
+            ),
+            enabled = state.integratedVideoPlayer,
+            onClick = {
+                listDialog = ListDialogSpec(
+                    title = hwAccelDialogTitle,
+                    entries = hwEntries.toList(),
+                    values = hwValues.toList(),
+                    selectedValue = state.videoHardwareAcceleration,
+                    key = DreamDroid.PREFS_KEY_HWACCEL,
+                )
+            },
+        )
+
+        PreferenceCategoryHeader(stringResource(R.string.usability))
+        SwitchPreferenceRow(
+            title = stringResource(R.string.enable_volume_control),
+            summary = stringResource(R.string.enable_volume_control_long),
+            checked = state.volumeControl,
+            onCheckedChange = { state.setBoolean(SettingsState.KEY_VOLUME_CONTROL, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.enable_instant_zap),
+            summary = stringResource(R.string.enable_instant_zap_long),
+            checked = state.instantZap,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_INSTANT_ZAP, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.default_to_full_vrm),
+            summary = stringResource(R.string.default_to_full_vrm_long),
+            checked = state.simpleVrm,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_SIMPLE_VRM, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.mobile_imdb),
+            summary = stringResource(R.string.mobile_imdb_long),
+            checked = state.mobileImdb,
+            onCheckedChange = { state.setBoolean(SettingsState.KEY_MOBILE_IMDB, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.confirm_app_close),
+            summary = stringResource(R.string.confirm_app_close_long),
+            checked = state.confirmAppClose,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_CONFIRM_APP_CLOSE, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.play_button_as_play_pause),
+            summary = stringResource(R.string.play_button_as_play_pause_long),
+            checked = state.playButtonAsPlayPause,
+            onCheckedChange = {
+                state.setBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, it)
+            },
+        )
+
+        PreferenceCategoryHeader(stringResource(R.string.appearance))
+        ListPreferenceRow(
+            title = stringResource(R.string.theme_long),
+            summary = entryLabel(themeEntries, themeValues, state.themeType),
+            onClick = {
+                listDialog = ListDialogSpec(
+                    title = themeDialogTitle,
+                    entries = themeEntries.toList(),
+                    values = themeValues.toList(),
+                    selectedValue = state.themeType,
+                    key = DreamDroid.PREFS_KEY_THEME_TYPE,
+                )
+            },
+        )
+        if (state.showDynamicThemeColors) {
+            SwitchPreferenceRow(
+                title = stringResource(R.string.dynamic_theme_colors),
+                summary = stringResource(R.string.dynamic_theme_colors_long),
+                checked = state.dynamicThemeColors,
+                onCheckedChange = {
+                    state.setBoolean(DreamDroid.PREFS_KEY_DYNAMIC_THEME_COLORS, it)
+                    onDynamicColorsChanged()
+                },
+            )
+        }
+        SwitchPreferenceRow(
+            title = stringResource(R.string.disable_fab_reload),
+            summary = stringResource(R.string.disable_fab_reload_long),
+            checked = state.disableFabReload,
+            onCheckedChange = { state.setBoolean(SettingsState.KEY_DISABLE_FAB_RELOAD, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.enable_animations),
+            summary = stringResource(R.string.enable_animations_long),
+            checked = state.enableAnimations,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_ENABLE_ANIMATIONS, it) },
+        )
+        ListPreferenceRow(
+            title = stringResource(R.string.max_grid_cols),
+            summary = stringResource(R.string.max_grid_cols_long),
+            onClick = {
+                listDialog = ListDialogSpec(
+                    title = gridDialogTitle,
+                    entries = gridEntries.toList(),
+                    values = gridValues.toList(),
+                    selectedValue = state.gridMaxCols,
+                    key = DreamDroid.PREFS_KEY_GRID_MAX_COLS,
+                )
+            },
+        )
+
+        PreferenceCategoryHeader(stringResource(R.string.picons))
+        SwitchPreferenceRow(
+            title = stringResource(R.string.use_picons),
+            summary = stringResource(R.string.use_picons_long),
+            checked = state.picons,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.online_picons),
+            summary = stringResource(R.string.online_picons_long),
+            checked = state.piconsOnline,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_PICONS_ONLINE, it) },
+        )
+        SwitchPreferenceRow(
+            title = stringResource(R.string.use_name_as_picon_filename),
+            summary = stringResource(R.string.use_name_as_picon_filename_long),
+            checked = state.useNameAsPiconFilename,
+            enabled = state.picons,
+            onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_PICONS_USE_NAME, it) },
+        )
+        ActionPreferenceRow(
+            title = stringResource(R.string.sync_picons),
+            summary = stringResource(R.string.sync_picons_long),
+            enabled = state.picons,
+            onClick = onSyncPicons,
+        )
+        ActionPreferenceRow(
+            title = stringResource(R.string.sync_picons_path),
+            summary = stringResource(R.string.sync_picons_path_long),
+            enabled = state.picons,
+            onClick = {
+                editDialog = EditDialogSpec(
+                    title = syncPathDialogTitle,
+                    value = state.syncPiconsPath,
+                    key = DreamDroid.PREFS_KEY_SYNC_PICONS_PATH,
+                )
+            },
+        )
+
+        if (state.showDeveloperCategory) {
+            PreferenceCategoryHeader(stringResource(R.string.developer_settings))
+            SwitchPreferenceRow(
+                title = stringResource(R.string.developer_settings_enable),
+                summary = null,
+                checked = state.enableDeveloper,
+                onCheckedChange = {
+                    state.setBoolean(DreamDroid.PREFS_KEY_ENABLE_DEVELOPER_SETTINGS, it)
+                },
+            )
+            SwitchPreferenceRow(
+                title = stringResource(R.string.use_fake_picon),
+                summary = stringResource(R.string.use_fake_picon_long),
+                checked = state.fakePicon,
+                enabled = state.enableDeveloper,
+                onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_FAKE_PICON, it) },
+            )
+            SwitchPreferenceRow(
+                title = stringResource(R.string.dump_xml),
+                summary = stringResource(R.string.dump_xml_long),
+                checked = state.xmlDebug,
+                enabled = state.enableDeveloper,
+                onCheckedChange = { state.setBoolean(DreamDroid.PREFS_KEY_XML_DEBUG, it) },
+            )
+        }
+
+        PreferenceCategoryHeader(stringResource(R.string.profile))
+        SwitchPreferenceRow(
+            title = stringResource(R.string.auto_switch_profile_wifi_based),
+            summary = stringResource(R.string.auto_switch_profile_wifi_based_long),
+            checked = state.autoSwitchProfileWifiBased,
+            onCheckedChange = {
+                state.setBoolean(DreamDroid.PREFS_KEY_AUTO_SWITCH_PROFILE_WIFI_BASED, it)
+            },
+        )
+    }
+
+    listDialog?.let { dialog ->
+        ListPreferenceDialog(
+            spec = dialog,
+            onDismiss = { listDialog = null },
+            onSelect = { value ->
+                state.setString(dialog.key, value)
+                if (dialog.key == DreamDroid.PREFS_KEY_THEME_TYPE) {
+                    onThemeChanged()
+                }
+                listDialog = null
+            },
+        )
+    }
+
+    editDialog?.let { dialog ->
+        EditTextPreferenceDialog(
+            spec = dialog,
+            onDismiss = { editDialog = null },
+            onConfirm = { value ->
+                state.setString(dialog.key, value)
+                editDialog = null
+            },
+        )
+    }
+}
+
+private data class ListDialogSpec(
+    val title: String,
+    val entries: List<String>,
+    val values: List<String>,
+    val selectedValue: String,
+    val key: String,
+)
+
+private data class EditDialogSpec(
+    val title: String,
+    val value: String,
+    val key: String,
+)
+
+@Composable
+private fun PreferenceCategoryHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp),
+    )
+}
+
+@Composable
+private fun SwitchPreferenceRow(
+    title: String,
+    summary: String?,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
+) {
+    val contentAlpha = if (enabled) 1f else 0.38f
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+            )
+            if (!summary.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+                )
+            }
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
+            enabled = enabled,
+        )
+    }
+}
+
+@Composable
+private fun ListPreferenceRow(
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
+    ActionPreferenceRow(title = title, summary = summary, enabled = enabled, onClick = onClick)
+}
+
+@Composable
+private fun ActionPreferenceRow(
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
+    val contentAlpha = if (enabled) 1f else 0.38f
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = summary,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+        )
+    }
+}
+
+@Composable
+private fun ListPreferenceDialog(
+    spec: ListDialogSpec,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(spec.title) },
+        text = {
+            Column {
+                spec.entries.zip(spec.values).forEach { (entry, value) ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(value) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = value == spec.selectedValue,
+                            onClick = { onSelect(value) },
+                        )
+                        Text(
+                            text = entry,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun EditTextPreferenceDialog(
+    spec: EditDialogSpec,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var text by remember(spec.value) { mutableStateOf(spec.value) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(spec.title) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text) }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
+private fun entryLabel(entries: Array<String>, values: Array<String>, selected: String): String {
+    val idx = values.indexOf(selected)
+    return if (idx in entries.indices) entries[idx] else selected
+}
+
+fun ComposeView.bindSettingsScreen(
+    state: SettingsState,
+    onThemeChanged: () -> Unit,
+    onDynamicColorsChanged: () -> Unit,
+    onSyncPicons: () -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            SettingsScreen(
+                state = state,
+                onThemeChanged = onThemeChanged,
+                onDynamicColorsChanged = onDynamicColorsChanged,
+                onSyncPicons = onSyncPicons,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/settings/SettingsState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/settings/SettingsState.kt
@@ -1,0 +1,135 @@
+package net.reichholf.dreamdroid.ui.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.ApplicationInfo
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.preference.PreferenceManager
+import com.google.android.material.color.DynamicColors
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.video.VLCPlayer
+
+/**
+ * Preference keys and defaults match [R.xml.preferences] / PreferenceManager.
+ * Values are read and written through the default SharedPreferences.
+ */
+class SettingsState(
+    private val prefs: SharedPreferences,
+    val showDeveloperCategory: Boolean,
+    val showDynamicThemeColors: Boolean,
+) {
+    var integratedVideoPlayer by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_INTEGRATED_PLAYER, true),
+    )
+    var videoEnableGestures by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_VIDEO_ENABLE_GESTURES, true),
+    )
+    var videoHardwareAcceleration by mutableStateOf(
+        prefs.getString(
+            DreamDroid.PREFS_KEY_HWACCEL,
+            VLCPlayer.MEDIA_HWACCEL_ENABLED.toString(),
+        ) ?: VLCPlayer.MEDIA_HWACCEL_ENABLED.toString(),
+    )
+
+    var volumeControl by mutableStateOf(prefs.getBoolean(KEY_VOLUME_CONTROL, false))
+    var instantZap by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_INSTANT_ZAP, false))
+    var simpleVrm by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_SIMPLE_VRM, true))
+    var mobileImdb by mutableStateOf(prefs.getBoolean(KEY_MOBILE_IMDB, false))
+    var confirmAppClose by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_CONFIRM_APP_CLOSE, true),
+    )
+    var playButtonAsPlayPause by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE, false),
+    )
+
+    var themeType by mutableStateOf(
+        prefs.getString(DreamDroid.PREFS_KEY_THEME_TYPE, "1") ?: "1",
+    )
+    var dynamicThemeColors by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_DYNAMIC_THEME_COLORS, false),
+    )
+    var disableFabReload by mutableStateOf(prefs.getBoolean(KEY_DISABLE_FAB_RELOAD, false))
+    var enableAnimations by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_ENABLE_ANIMATIONS, true),
+    )
+    var gridMaxCols by mutableStateOf(
+        prefs.getString(DreamDroid.PREFS_KEY_GRID_MAX_COLS, "-1") ?: "-1",
+    )
+
+    var picons by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, false))
+    var piconsOnline by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_PICONS_ONLINE, false))
+    var useNameAsPiconFilename by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_PICONS_USE_NAME, false),
+    )
+    var syncPiconsPath by mutableStateOf(
+        prefs.getString(DreamDroid.PREFS_KEY_SYNC_PICONS_PATH, DEFAULT_SYNC_PICONS_PATH)
+            ?: DEFAULT_SYNC_PICONS_PATH,
+    )
+
+    var enableDeveloper by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_ENABLE_DEVELOPER_SETTINGS, false),
+    )
+    var fakePicon by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_FAKE_PICON, false))
+    var xmlDebug by mutableStateOf(prefs.getBoolean(DreamDroid.PREFS_KEY_XML_DEBUG, false))
+
+    var autoSwitchProfileWifiBased by mutableStateOf(
+        prefs.getBoolean(DreamDroid.PREFS_KEY_AUTO_SWITCH_PROFILE_WIFI_BASED, false),
+    )
+
+    fun setBoolean(key: String, value: Boolean) {
+        prefs.edit().putBoolean(key, value).apply()
+        when (key) {
+            DreamDroid.PREFS_KEY_INTEGRATED_PLAYER -> integratedVideoPlayer = value
+            DreamDroid.PREFS_KEY_VIDEO_ENABLE_GESTURES -> videoEnableGestures = value
+            KEY_VOLUME_CONTROL -> volumeControl = value
+            DreamDroid.PREFS_KEY_INSTANT_ZAP -> instantZap = value
+            DreamDroid.PREFS_KEY_SIMPLE_VRM -> simpleVrm = value
+            KEY_MOBILE_IMDB -> mobileImdb = value
+            DreamDroid.PREFS_KEY_CONFIRM_APP_CLOSE -> confirmAppClose = value
+            DreamDroid.PREFS_KEY_PLAY_BUTTON_AS_PLAY_PAUSE -> playButtonAsPlayPause = value
+            DreamDroid.PREFS_KEY_DYNAMIC_THEME_COLORS -> dynamicThemeColors = value
+            KEY_DISABLE_FAB_RELOAD -> disableFabReload = value
+            DreamDroid.PREFS_KEY_ENABLE_ANIMATIONS -> enableAnimations = value
+            DreamDroid.PREFS_KEY_PICONS_ENABLED -> picons = value
+            DreamDroid.PREFS_KEY_PICONS_ONLINE -> piconsOnline = value
+            DreamDroid.PREFS_KEY_PICONS_USE_NAME -> useNameAsPiconFilename = value
+            DreamDroid.PREFS_KEY_ENABLE_DEVELOPER_SETTINGS -> enableDeveloper = value
+            DreamDroid.PREFS_KEY_FAKE_PICON -> fakePicon = value
+            DreamDroid.PREFS_KEY_XML_DEBUG -> xmlDebug = value
+            DreamDroid.PREFS_KEY_AUTO_SWITCH_PROFILE_WIFI_BASED -> autoSwitchProfileWifiBased = value
+        }
+    }
+
+    fun setString(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+        when (key) {
+            DreamDroid.PREFS_KEY_HWACCEL -> videoHardwareAcceleration = value
+            DreamDroid.PREFS_KEY_THEME_TYPE -> themeType = value
+            DreamDroid.PREFS_KEY_GRID_MAX_COLS -> gridMaxCols = value
+            DreamDroid.PREFS_KEY_SYNC_PICONS_PATH -> syncPiconsPath = value
+        }
+    }
+
+    companion object {
+        const val KEY_VOLUME_CONTROL = "volume_control"
+        const val KEY_MOBILE_IMDB = "mobile_imdb"
+        const val KEY_DISABLE_FAB_RELOAD = "disable_fab_reload"
+        const val DEFAULT_SYNC_PICONS_PATH = "/usr/share/enigma2/picon"
+
+        @JvmStatic
+        fun create(context: Context): SettingsState {
+            PreferenceManager.setDefaultValues(context, R.xml.preferences, false)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val debuggable =
+                0 != (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE)
+            return SettingsState(
+                prefs = prefs,
+                showDeveloperCategory = debuggable,
+                showDynamicThemeColors = DynamicColors.isDynamicColorAvailable(),
+            )
+        }
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -32,13 +32,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | profile-edit-compose | [#184](https://github.com/sreichholf/dreamDroid/pull/184) | merged | `ProfileEditFragment` Compose form + `ProfileEditScreenTest`. |
 | zap-compose | [#185](https://github.com/sreichholf/dreamDroid/pull/185) | merged | `55ecc5df` `ZapFragment` Compose grid + `ZapScreenTest`. |
 | virtual-remote-compose | [#186](https://github.com/sreichholf/dreamDroid/pull/186) | merged | `bd2ccfb9` `VirtualRemoteFragment` Compose pad + `VirtualRemoteScreenTest`. |
-| screenshot-compose ([#187](https://github.com/sreichholf/dreamDroid/pull/187)) | — | open | open on `cursor/screenshot-compose-c88a` — `ScreenShotFragment` Compose + PhotoView + `ScreenshotScreenTest` |
+| screenshot-compose | [#187](https://github.com/sreichholf/dreamDroid/pull/187) | merged | `527e4c7f` `ScreenShotFragment` Compose + PhotoView + `ScreenshotScreenTest`. |
+| settings-compose | — | open | open on `cursor/settings-compose-c88a` — `MyPreferenceFragment` Compose prefs + `SettingsScreenTest` |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
 Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. `profile-edit-compose` is on `main` as #184. `zap-compose` is on `main` as #185. `virtual-remote-compose` is on `main` as #186. Next screen (`screenshot-compose`) is open on `cursor/screenshot-compose-c88a`.
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. `profile-edit-compose` is on `main` as #184. `zap-compose` is on `main` as #185. `virtual-remote-compose` is on `main` as #186. `screenshot-compose` is on `main` as #187. Next screen (`settings-compose`) is open on `cursor/settings-compose-c88a`.
 
 ### Operator overrides (this program)
 
@@ -59,7 +60,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Zap Compose grid is on `main` via #185. Rows are typed `enigma.Service` on `main` via #173. Bouquet picker list typing is on `main` via #181 (Intent still one `ExtendedHashMap` at send).
 - Profile edit form is Compose on `main` via #184.
 - Virtual remote Compose pad is on `main` via #186. Tablet screenshot host kept.
-- Screenshot Compose is open on `cursor/screenshot-compose-c88a`.
+- Screenshot Compose is on `main` via #187.
+- Settings Compose is open on `cursor/settings-compose-c88a`.
 - Service EPG list still XML. Rows are typed `enigma.Event` on `main` via #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Dead `EpgTimelineFragment` removed in #177.
 - EPG bouquet still XML. Rows are typed `enigma.Event` on `main` via #179. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
 - EPG search still XML. Rows are typed `enigma.Event` on `main` via #180. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
@@ -355,7 +357,7 @@ This was never "replace the phone app with Compose." The original boxes named fi
 
 ### Still Java/XML phone screens (drawer and related)
 
-Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**, Zap grid (#185), Virtual remote (#186). The pager pages behind those tabs landed as Compose in #170. Screenshot Compose is open on `cursor/screenshot-compose-c88a`.
+Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**, Zap grid (#185), Virtual remote (#186), Screenshot (#187). The pager pages behind those tabs landed as Compose in #170. Settings Compose is open on `cursor/settings-compose-c88a`.
 
 | Surface | Code | Notes |
 | --- | --- | --- |
@@ -374,8 +376,8 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 | Virtual remote | Compose on `main` via #186 | Compose pad + HTTP keys; tablet screenshot host kept. |
 | Device info | `DeviceInfoFragment` | |
 | Signal | `SignalFragment` + vendored gauge lib | |
-| Screenshot | open `cursor/screenshot-compose-c88a` | Compose + PhotoView AndroidView; reload/share/save kept. |
-| Settings | `MyPreferenceFragment`, `androidx.preference` | `legacy-preference-v14` removed; phone themes use `PreferenceThemeOverlay`. |
+| Screenshot | Compose on `main` via #187 | Compose + PhotoView AndroidView; reload/share/save kept. |
+| Settings | open `cursor/settings-compose-c88a` | Compose preference list; same PreferenceManager keys as `R.xml.preferences`. TV Leanback prefs unchanged. |
 | Backup | `BackupFragment`, `DreamDroidBackupAgent` | Still talks to legacy SQLite. |
 | Sleep timer / send message / power / changelog | dialogs | |
 | Mediaplayer | removed (#175) | Drawer entry was commented; UI stack deleted. `URIStore.MEDIA_PLAYER_PLAY` kept for `ShareActivity`. |
@@ -420,8 +422,8 @@ One PR per screen. Pattern: Compose + Kotlin Material 3 like About (#164) / Prof
 | 4 | `virtual-remote-compose` | `VirtualRemotePagerFragment` / `VirtualRemoteFragment` | Drawer remote | No — **merged** [#186](https://github.com/sreichholf/dreamDroid/pull/186) |
 | 5 | `device-info-compose` | `DeviceInfoFragment` | Drawer device info | Prefer type device-info first |
 | 6 | `signal-compose` | `SignalFragment` | Drawer signal | Prefer type signal first |
-| 7 | `screenshot-compose` | `ScreenShotFragment` | Drawer screenshot | No — **open** on `cursor/screenshot-compose-c88a` |
-| 8 | `settings-compose` | `MyPreferenceFragment` | Drawer settings | No |
+| 7 | `screenshot-compose` | `ScreenShotFragment` | Drawer screenshot | No — **merged** [#187](https://github.com/sreichholf/dreamDroid/pull/187) |
+| 8 | `settings-compose` | `MyPreferenceFragment` | Drawer settings | No — **open** on `cursor/settings-compose-c88a` |
 | 9 | `backup-compose` | `BackupFragment` | Drawer backup | No |
 | 10 | `timer-edit-compose` | `TimerEditFragment` | Hub / EPG → timer edit | Yes — type timers list/edit path |
 | 11 | `movie-detail-compose` | `MovieDetailBottomSheet` | Movies row tap | Yes — typed `enigma.Movie` edge (ButterKnife) |

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -33,7 +33,7 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | zap-compose | [#185](https://github.com/sreichholf/dreamDroid/pull/185) | merged | `55ecc5df` `ZapFragment` Compose grid + `ZapScreenTest`. |
 | virtual-remote-compose | [#186](https://github.com/sreichholf/dreamDroid/pull/186) | merged | `bd2ccfb9` `VirtualRemoteFragment` Compose pad + `VirtualRemoteScreenTest`. |
 | screenshot-compose | [#187](https://github.com/sreichholf/dreamDroid/pull/187) | merged | `527e4c7f` `ScreenShotFragment` Compose + PhotoView + `ScreenshotScreenTest`. |
-| settings-compose | — | open | open on `cursor/settings-compose-c88a` — `MyPreferenceFragment` Compose prefs + `SettingsScreenTest` |
+| settings-compose ([#188](https://github.com/sreichholf/dreamDroid/pull/188)) | — | open | open on `cursor/settings-compose-c88a` — `MyPreferenceFragment` Compose prefs + `SettingsScreenTest` |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Wave 3 screen #8 (Appendix G): Settings to Compose Material 3. No typed-API wait.

## Scope

- Compose preference list over the same `PreferenceManager` keys from `R.xml.preferences`.
- `MyPreferenceFragment` hosts `ComposeView`; theme / dynamic colors / picon sync kept.
- `SettingsScreenTest`; docs (#187 marked merged).

## Verification

JDK 17. Bugbot: no bugs.

- `./gradlew :app:assembleGoogleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testGoogleDebugUnitTest` — BUILD SUCCESSFUL
- androidTest compile — SUCCESS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

