### PR TITLE
feat(epg): EpgBouquetFragment Compose list

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/epg/EpgBouquetScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/epg/EpgBouquetScreenTest.kt
@@ -1,0 +1,82 @@
+package net.reichholf.dreamdroid.ui.epg
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EpgBouquetScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit()
+            .putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1")
+            .putBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, false)
+            .commit()
+    }
+
+    @Test
+    fun seededEventsShowFieldsAndClick() {
+        val first = Event(
+            eventId = "100",
+            title = "Tagesschau",
+            serviceReference = "1:0:1:6DCA:44D:1:C00000:0:0:0:",
+            serviceName = "Das Erste HD",
+            startReadable = "20:00",
+            durationReadable = "15",
+            descriptionExtended = "Die Nachrichten.",
+        )
+        val second = Event(
+            eventId = "101",
+            title = "Wetter",
+            serviceReference = "1:0:1:6DCB:44D:1:C00000:0:0:0:",
+            serviceName = "ZDF HD",
+            startReadable = "20:15",
+            durationReadable = "10",
+            descriptionExtended = "Der Wetterbericht.",
+        )
+        var clicked: Event? = null
+        composeRule.setContent {
+            DreamDroidTheme {
+                EpgBouquetScreen(
+                    items = listOf(first, second),
+                    onItemClick = { clicked = it },
+                )
+            }
+        }
+        composeRule.onNodeWithText("Tagesschau").assertIsDisplayed()
+        composeRule.onNodeWithText("Das Erste HD").assertIsDisplayed()
+        composeRule.onNodeWithText("20:00").assertIsDisplayed()
+        composeRule.onNodeWithText("15").assertIsDisplayed()
+        composeRule.onNodeWithText("Die Nachrichten.").assertIsDisplayed()
+        composeRule.onNodeWithText("Wetter").assertIsDisplayed().performClick()
+        assertEquals(second, clicked)
+    }
+
+    @Test
+    fun emptyStateShowsMessage() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                EpgBouquetScreen(
+                    items = emptyList(),
+                    onItemClick = {},
+                    emptyMessage = "No items to display…",
+                )
+            }
+        }
+        composeRule.onNodeWithText("No items to display…").assertIsDisplayed()
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -24,7 +25,6 @@ import com.google.android.material.timepicker.TimeFormat;
 
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
-import net.reichholf.dreamdroid.adapter.recyclerview.EpgBouquetAdapter;
 import net.reichholf.dreamdroid.asynctask.GetEventListTask;
 import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerEventFragment;
@@ -38,6 +38,8 @@ import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EventListRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.epg.EpgBouquetListState;
+import net.reichholf.dreamdroid.ui.epg.EpgBouquetListStateKt;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 
 import java.text.SimpleDateFormat;
@@ -46,15 +48,16 @@ import java.util.Calendar;
 import java.util.List;
 
 /**
- * Bouquet EPG at a chosen date/time. Rows are typed {@link Event}; detail/timer still take
- * ExtendedHashMap at the edge. Bouquet picker still returns ExtendedHashMap; reference/name
- * are taken at this fragment boundary.
+ * Bouquet EPG at a chosen date/time. Compose Material 3 list of typed {@link Event};
+ * detail/timer still take ExtendedHashMap at the edge. Bouquet picker still returns
+ * ExtendedHashMap; reference/name are taken at this fragment boundary.
  */
 public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 		implements GetEventListTask.GetEventListTaskHandler {
 	private static final String LOG_TAG = EpgBouquetFragment.class.getSimpleName();
 
 	private final ArrayList<Event> mEvents = new ArrayList<>();
+	private EpgBouquetListState mListState;
 	@Nullable
 	private GetEventListTask mEventListTask;
 
@@ -69,6 +72,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 		mCardListStyle = true;
 		mEnableReload = true;
 		super.onCreate(savedInstanceState);
+		mListState = new EpgBouquetListState();
 		initTitle(getString(R.string.epg));
 
 		int now = mTime = (int) (Calendar.getInstance().getTimeInMillis() / 1000);
@@ -87,7 +91,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		View view = inflater.inflate(R.layout.card_recycler_content, container, false);
+		View view = inflater.inflate(R.layout.compose_swipe_list, container, false);
 		View header = inflater.inflate(R.layout.date_time_picker_header, null, false);
 
 		Calendar cal = getCalendar();
@@ -135,9 +139,23 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 	}
 
 	@Override
+	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		ComposeView compose = view.findViewById(R.id.compose_list);
+		EpgBouquetListStateKt.bindEpgBouquetScreen(
+				compose,
+				mListState,
+				event -> {
+					mCurrentItem = EpgListMapper.toExtendedHashMap(event);
+					EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(mCurrentItem);
+					getMultiPaneHandler().showDialogFragment(epgDetailBottomSheet, "epg_detail_dialog");
+					return kotlin.Unit.INSTANCE;
+				}
+		);
+	}
+
+	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
-		mAdapter = new EpgBouquetAdapter(mEvents);
-		getRecyclerView().setAdapter(mAdapter);
 		if (mEvents.isEmpty())
 			Log.w(LOG_TAG, String.format("%s", mTime));
 		super.onActivityCreated(savedInstanceState);
@@ -159,10 +177,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 
 	@Override
 	public void onItemClick(RecyclerView parent, View view, int position, long id) {
-		Event event = mEvents.get(position);
-		mCurrentItem = EpgListMapper.toExtendedHashMap(event);
-		EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(mCurrentItem);
-		getMultiPaneHandler().showDialogFragment(epgDetailBottomSheet, "epg_detail_dialog");
+		// Compose owns clicks.
 	}
 
 	@Override
@@ -177,7 +192,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 				if (!reference.equals(mReference)) {
 					mReference = reference;
 					mName = service.getString(Service.KEY_NAME);
-					getRecyclerView().smoothScrollToPosition(0);
+					mListState.scrollToTop();
 				}
 				reload();
 				mWaitingForPicker = false;
@@ -247,9 +262,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 	public void onEventListReady(boolean success, @NonNull List<Event> events, @Nullable String errorText) {
 		mHttpHelper.onLoadFinished();
 		mEvents.clear();
-		if (mAdapter != null) {
-			mAdapter.notifyDataSetChanged();
-		}
+		mListState.replaceAll(java.util.Collections.emptyList());
 		if (!success) {
 			setEmptyText(errorText);
 			return;
@@ -264,9 +277,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment
 			setEmptyText(getText(R.string.no_list_item));
 		} else {
 			mEvents.addAll(events);
-		}
-		if (mAdapter != null) {
-			mAdapter.notifyDataSetChanged();
+			mListState.replaceAll(events);
 		}
 	}
 

--- a/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetListState.kt
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.ui.epg
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+class EpgBouquetListState(initial: List<Event> = emptyList()) {
+    val items: SnapshotStateList<Event> = initial.toMutableStateList()
+    val listState = LazyListState()
+    var scrollEpoch by mutableIntStateOf(0)
+        private set
+
+    fun replaceAll(next: List<Event>) {
+        items.clear()
+        items.addAll(next)
+    }
+
+    fun scrollToTop() {
+        scrollEpoch++
+    }
+}
+
+fun ComposeView.bindEpgBouquetScreen(
+    state: EpgBouquetListState,
+    onItemClick: (Event) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            EpgBouquetScreen(
+                items = state.items,
+                listState = state.listState,
+                scrollEpoch = state.scrollEpoch,
+                onItemClick = onItemClick,
+            )
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetScreen.kt
@@ -1,0 +1,171 @@
+package net.reichholf.dreamdroid.ui.epg
+
+import android.widget.ImageView
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.preference.PreferenceManager
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.helpers.Statics
+import net.reichholf.dreamdroid.helpers.enigma2.Picon
+
+@Composable
+fun EpgBouquetScreen(
+    items: List<Event>,
+    onItemClick: (Event) -> Unit,
+    modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
+    scrollEpoch: Int = 0,
+    emptyMessage: String? = null,
+) {
+    LaunchedEffect(scrollEpoch) {
+        if (scrollEpoch > 0) {
+            listState.scrollToItem(0)
+        }
+    }
+
+    if (items.isEmpty()) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (emptyMessage != null) {
+                Text(
+                    text = emptyMessage,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(24.dp),
+                )
+            }
+        }
+        return
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+    ) {
+        items(items, key = { "${it.serviceReference}:${it.eventId}:${it.start}:${it.title}" }) { event ->
+            EpgBouquetRow(
+                event = event,
+                onClick = { onItemClick(event) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpgBouquetRow(
+    event: Event,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val piconsEnabled = PreferenceManager.getDefaultSharedPreferences(context)
+        .getBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, DreamDroid.isTV(context))
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (piconsEnabled) {
+                    AndroidView(
+                        factory = { ctx ->
+                            ImageView(ctx).apply {
+                                scaleType = ImageView.ScaleType.FIT_CENTER
+                            }
+                        },
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .width(57.dp)
+                            .height(36.dp),
+                        update = { view ->
+                            Picon.setPiconForView(
+                                context,
+                                view,
+                                event.serviceReference,
+                                event.serviceName,
+                                Statics.TAG_PICON,
+                                null,
+                            )
+                        },
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = event.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = event.serviceName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Row(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+                Text(
+                    text = event.startReadable,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = event.durationReadable,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            if (event.descriptionExtended.isNotEmpty()) {
+                Text(
+                    text = event.descriptionExtended,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -36,13 +36,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | settings-compose | [#188](https://github.com/sreichholf/dreamDroid/pull/188) | merged | `63ea96ba` `MyPreferenceFragment` Compose prefs + `SettingsScreenTest`. |
 | backup-compose | [#189](https://github.com/sreichholf/dreamDroid/pull/189) | merged | `16e86fa2` `BackupFragment` Compose + `BackupScreenTest`. |
 | current-event-compose | [#190](https://github.com/sreichholf/dreamDroid/pull/190) | merged | `CurrentServiceFragment` Compose + `CurrentServiceScreenTest`.
-| pick-service-compose | — | open | open on `cursor/pick-service-compose-c88a` — `PickServiceFragment` Compose list + `PickServiceScreenTest` |
+| pick-service-compose | [#191](https://github.com/sreichholf/dreamDroid/pull/191) | merged | `PickServiceFragment` Compose list + `PickServiceScreenTest`.
+| epg-bouquet-compose | — | open | open on `cursor/epg-bouquet-compose-c88a` — `EpgBouquetFragment` Compose list + `EpgBouquetScreenTest` |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E.
 
 Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. `profile-edit-compose` is on `main` as #184. `zap-compose` is on `main` as #185. `virtual-remote-compose` is on `main` as #186. `screenshot-compose` is on `main` as #187. `settings-compose` is on `main` as #188. `backup-compose` is on `main` as #189. `current-event-compose` is on `main` as #190. `pick-service-compose` is open on `cursor/pick-service-compose-c88a`.
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**, after the typed API queue. Checklist in Appendix G. Drawer shell and Leanback TV stay later programs. Compose on `main` through #191 (current-event, pick-service). `epg-bouquet-compose` is open on `cursor/epg-bouquet-compose-c88a`.
 
 ### Operator overrides (this program)
 
@@ -67,9 +68,10 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Settings Compose is on `main` via #188.
 - Backup Compose is on `main` via #189.
 - Current event Compose is on `main` via #190.
-- PickService Compose list is open on `cursor/pick-service-compose-c88a`. Rows typed `enigma.Service` (#181); Intent still one hash at send. Dropped `ServiceNameAdapter` / `DividerItemDecoration`.
+- PickService Compose list is on `main` via #191. Rows typed `enigma.Service` (#181); Intent still one hash at send.
+- EPG bouquet Compose list is open on `cursor/epg-bouquet-compose-c88a`. Rows typed `enigma.Event` (#179); `EpgBouquetAdapter` kept for EPG search. Detail/timer edge still hash.
 - Service EPG list still XML. Rows are typed `enigma.Event` on `main` via #176. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge. Dead `EpgTimelineFragment` removed in #177.
-- EPG bouquet still XML. Rows are typed `enigma.Event` on `main` via #179. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
+- EPG bouquet Compose is open on `cursor/epg-bouquet-compose-c88a`. Rows typed `enigma.Event` (#179). Adapter kept for search until search Compose lands.
 - EPG search still XML. Rows are typed `enigma.Event` on `main` via #180. Detail sheet / timer create still take `ExtendedHashMap` at the fragment edge.
 
 ## How to read this
@@ -363,7 +365,7 @@ This was never "replace the phone app with Compose." The original boxes named fi
 
 ### Still Java/XML phone screens (drawer and related)
 
-Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**, Zap grid (#185), Virtual remote (#186), Screenshot (#187), Settings (#188), Backup (#189), Current event (#190). The pager pages behind those tabs landed as Compose in #170. PickService Compose is open on `cursor/pick-service-compose-c88a`.
+Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies **tabs/bar**, Zap grid (#185), Virtual remote (#186), Screenshot (#187), Settings (#188), Backup (#189), Current event (#190). The pager pages behind those tabs landed as Compose in #170. PickService Compose is on `main` via #191. EPG bouquet Compose is open on `cursor/epg-bouquet-compose-c88a`.
 
 | Surface | Code | Notes |
 | --- | --- | --- |
@@ -374,9 +376,9 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 | Share / pick profile | `ShareActivity` + `ProfileAdapter` | |
 | Zap | Compose on `main` via #185 | Compose grid + Picasso picons. Rows typed `enigma.Service` (#173). Picker list typing on `main` via #181. |
 | Service EPG list | `ServiceEpgListFragment`, `ServiceEpgAdapter` | XML list. Rows are typed `enigma.Event` (#176). Detail/timer edge still hash. |
-| EPG bouquet | `EpgBouquetFragment`, `EpgBouquetAdapter` | XML list. Rows are typed `enigma.Event` (#179). Detail/timer edge still hash. |
+| EPG bouquet | open `cursor/epg-bouquet-compose-c88a` | Compose list; typed `enigma.Event` (#179). Adapter kept for search. Detail/timer edge still hash. |
 | EPG search | `EpgSearchFragment`, `EpgBouquetAdapter` | XML list. Rows are typed `enigma.Event` (#180). Detail/timer edge still hash. |
-| Bouquet picker | open `cursor/pick-service-compose-c88a` | Compose list; typed `enigma.Service` (#181). Intent still one hash at send. |
+| Bouquet picker | Compose on `main` via #191 | Compose list; typed `enigma.Service` (#181). Intent still one hash at send. |
 | EPG detail | `EpgDetailBottomSheet` | ButterKnife. |
 | Current event | Compose on `main` via #190 | Compose now/next + stream; typed `enigma.CurrentService` (#183). Detail/timer edge still hash. |
 | Virtual remote | Compose on `main` via #186 | Compose pad + HTTP keys; tablet screenshot host kept. |
@@ -435,10 +437,10 @@ One PR per screen. Pattern: Compose + Kotlin Material 3 like About (#164) / Prof
 | 11 | `movie-detail-compose` | `MovieDetailBottomSheet` | Movies row tap | Yes — typed `enigma.Movie` edge (ButterKnife) |
 | 12 | `epg-detail-compose` | `EpgDetailBottomSheet` | EPG / current / channel popup | Yes — accept typed `enigma.Event` |
 | 13 | `drawer-dialogs-compose` | Sleep timer / send message / power / changelog / connection error | Drawer dialogs | Partial (sleep-timer result optional) |
-| 14 | `epg-bouquet-compose` | `EpgBouquetFragment` | Drawer EPG | No for list (rows typed #179); detail with #12 |
+| 14 | `epg-bouquet-compose` | `EpgBouquetFragment` | Drawer EPG | No for list (rows typed #179); detail with #12 — **open** on `cursor/epg-bouquet-compose-c88a` |
 | 15 | `epg-search-compose` | `EpgSearchFragment` | Toolbar search | No for list (rows typed #180) |
 | 16 | `service-epg-compose` | `ServiceEpgListFragment` | Channel → EPG | No for list (rows typed #176) |
-| 17 | `pick-service-compose` | `PickServiceFragment` | Zap / EPG bouquet pick | No for list (rows typed #181) — **open** on `cursor/pick-service-compose-c88a` |
+| 17 | `pick-service-compose` | `PickServiceFragment` | Zap / EPG bouquet pick | No for list (rows typed #181) — **merged** [#191](https://github.com/sreichholf/dreamDroid/pull/191) |
 | 18 | `timer-service-pick-compose` | `ServiceListFragment` (pick mode) | Timer edit service pick | Yes — type pick path |
 | 19 | `share-profiles-compose` | `ShareActivity` + `ProfileAdapter` | Share intent | No (Room) |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Converts the drawer **EPG bouquet** list (`EpgBouquetFragment`) from RecyclerView/`EpgBouquetAdapter` to Compose + Kotlin (Material 3, `DreamDroidTheme`).

Rows stay typed `enigma.Event` (#179). Date/time header stays XML. Detail opens via `EpgListMapper.toExtendedHashMap` → `EpgDetailBottomSheet` (hash edge unchanged).

**Keeps** `EpgBouquetAdapter` + `epg_multi_service_list_item.xml` for `EpgSearchFragment` until `epg-search-compose`.

## Changes
- `EpgBouquetScreen` + `EpgBouquetListState` on `compose_swipe_list`
- Picon slot gated on prefs; scroll-to-top on bouquet change
- `EpgBouquetScreenTest`
- Docs / Appendix G updates

## Test plan
- [x] `./gradlew :app:assembleGoogleDebug :app:testGoogleDebugUnitTest` (JDK 17)
- [ ] connected Compose test when emulator available
- [ ] Bugbot before merge
- [ ] Bouquet pick + date/time reload still work; search still uses adapter
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

