### PR TITLE
feat(client): typed DeviceInfo for /web/deviceinfo

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/GetDeviceInfoTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetDeviceInfoTask.java
@@ -1,0 +1,52 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.DeviceInfo;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+
+public class GetDeviceInfoTask extends AsyncHttpTaskBase<Void, String, Boolean> {
+	@Nullable
+	private DeviceInfo mInfo;
+
+	public GetDeviceInfoTask(GetDeviceInfoTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(Void unused) {
+		mInfo = null;
+		if (isCancelled()) {
+			return false;
+		}
+		mInfo = HttpFragmentHelper.fetchDeviceInfo(getHttpClient());
+		if (getHttpClient().hasError()) {
+			return false;
+		}
+		return mInfo != null;
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetDeviceInfoTaskHandler handler = (GetDeviceInfoTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result) && mInfo != null;
+		String errorText = null;
+		if (!success) {
+			if (getHttpClient().hasError()) {
+				errorText = getErrorText();
+			} else {
+				errorText = handler.getString(net.reichholf.dreamdroid.R.string.error_parsing);
+			}
+		}
+		handler.onDeviceInfoReady(success, mInfo, errorText);
+	}
+
+	public interface GetDeviceInfoTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onDeviceInfoReady(boolean success, @Nullable DeviceInfo info, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetDeviceInfoTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetDeviceInfoTask.java
@@ -25,7 +25,8 @@ public class GetDeviceInfoTask extends AsyncHttpTaskBase<Void, String, Boolean> 
 		if (getHttpClient().hasError()) {
 			return false;
 		}
-		return mInfo != null;
+		// Successful SAX can still yield an empty object; treat that as parse failure.
+		return mInfo != null && !mInfo.isEmpty();
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/enigma/DeviceInfo.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/DeviceInfo.kt
@@ -1,0 +1,48 @@
+package net.reichholf.dreamdroid.enigma
+
+import java.io.Serializable
+
+data class DeviceFrontend(
+    val name: String = "",
+    val model: String = "",
+) : Serializable
+
+data class DeviceNic(
+    val name: String = "",
+    val mac: String = "",
+    val dhcp: String = "",
+    val ip: String = "",
+    val gateway: String = "",
+    val netmask: String = "",
+) : Serializable
+
+data class DeviceHdd(
+    val model: String = "",
+    val capacity: String = "",
+    val free: String = "",
+) : Serializable
+
+/**
+ * Typed `/web/deviceinfo` payload.
+ */
+data class DeviceInfo(
+    val guiVersion: String = "",
+    val imageVersion: String = "",
+    val interfaceVersion: String = "",
+    val frontProcessorVersion: String = "",
+    val deviceName: String = "",
+    val frontends: List<DeviceFrontend> = emptyList(),
+    val nics: List<DeviceNic> = emptyList(),
+    val hdds: List<DeviceHdd> = emptyList(),
+) : Serializable {
+    fun isEmpty(): Boolean {
+        return guiVersion.isEmpty()
+            && imageVersion.isEmpty()
+            && interfaceVersion.isEmpty()
+            && frontProcessorVersion.isEmpty()
+            && deviceName.isEmpty()
+            && frontends.isEmpty()
+            && nics.isEmpty()
+            && hdds.isEmpty()
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/DeviceInfoParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/DeviceInfoParser.kt
@@ -1,0 +1,212 @@
+package net.reichholf.dreamdroid.enigma
+
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object DeviceInfoParser {
+    fun parse(xml: String): DeviceInfo? {
+        if (xml.isEmpty()) {
+            return null
+        }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): DeviceInfo? {
+        return try {
+            val handler = DeviceInfoHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
+            handler.result
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+private class DeviceInfoHandler : DefaultHandler() {
+    var result: DeviceInfo? = null
+
+    private var inGuiVersion = false
+    private var inImageVersion = false
+    private var inInterfaceVersion = false
+    private var inFpVersion = false
+    private var inDeviceName = false
+    private var inFrontend = false
+    private var inNic = false
+    private var inHdd = false
+    private var inName = false
+    private var inModel = false
+    private var inMac = false
+    private var inDhcp = false
+    private var inIp = false
+    private var inGateway = false
+    private var inNetmask = false
+    private var inCapacity = false
+    private var inFree = false
+
+    private val guiVersion = StringBuilder()
+    private val imageVersion = StringBuilder()
+    private val interfaceVersion = StringBuilder()
+    private val fpVersion = StringBuilder()
+    private val deviceName = StringBuilder()
+
+    private val frontendName = StringBuilder()
+    private val frontendModel = StringBuilder()
+    private val nicName = StringBuilder()
+    private val nicMac = StringBuilder()
+    private val nicDhcp = StringBuilder()
+    private val nicIp = StringBuilder()
+    private val nicGateway = StringBuilder()
+    private val nicNetmask = StringBuilder()
+    private val hddModel = StringBuilder()
+    private val hddCapacity = StringBuilder()
+    private val hddFree = StringBuilder()
+
+    private val frontends = ArrayList<DeviceFrontend>()
+    private val nics = ArrayList<DeviceNic>()
+    private val hdds = ArrayList<DeviceHdd>()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2enigmaversion" -> inGuiVersion = true
+            "e2imageversion" -> inImageVersion = true
+            "e2webifversion" -> inInterfaceVersion = true
+            "e2fpversion" -> inFpVersion = true
+            "e2devicename" -> inDeviceName = true
+            "e2frontend" -> {
+                inFrontend = true
+                frontendName.setLength(0)
+                frontendModel.setLength(0)
+            }
+            "e2interface" -> {
+                inNic = true
+                nicName.setLength(0)
+                nicMac.setLength(0)
+                nicDhcp.setLength(0)
+                nicIp.setLength(0)
+                nicGateway.setLength(0)
+                nicNetmask.setLength(0)
+            }
+            "e2hdd" -> {
+                inHdd = true
+                hddModel.setLength(0)
+                hddCapacity.setLength(0)
+                hddFree.setLength(0)
+            }
+            "e2name" -> inName = true
+            "e2model" -> inModel = true
+            "e2mac" -> inMac = true
+            "e2dhcp" -> inDhcp = true
+            "e2ip" -> inIp = true
+            "e2gateway" -> inGateway = true
+            "e2netmask" -> inNetmask = true
+            "e2capacity" -> inCapacity = true
+            "e2free" -> inFree = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2enigmaversion" -> inGuiVersion = false
+            "e2imageversion" -> inImageVersion = false
+            "e2webifversion" -> inInterfaceVersion = false
+            "e2fpversion" -> inFpVersion = false
+            "e2devicename" -> inDeviceName = false
+            "e2frontend" -> {
+                inFrontend = false
+                frontends.add(
+                    DeviceFrontend(
+                        name = frontendName.toString().trim(),
+                        model = frontendModel.toString().trim(),
+                    ),
+                )
+            }
+            "e2interface" -> {
+                inNic = false
+                nics.add(
+                    DeviceNic(
+                        name = nicName.toString().trim(),
+                        mac = nicMac.toString().trim(),
+                        dhcp = nicDhcp.toString().trim(),
+                        ip = nicIp.toString().trim(),
+                        gateway = nicGateway.toString().trim(),
+                        netmask = nicNetmask.toString().trim(),
+                    ),
+                )
+            }
+            "e2hdd" -> {
+                inHdd = false
+                hdds.add(
+                    DeviceHdd(
+                        model = hddModel.toString().trim(),
+                        capacity = hddCapacity.toString().trim(),
+                        free = hddFree.toString().trim(),
+                    ),
+                )
+            }
+            "e2name" -> inName = false
+            "e2model" -> inModel = false
+            "e2mac" -> inMac = false
+            "e2dhcp" -> inDhcp = false
+            "e2ip" -> inIp = false
+            "e2gateway" -> inGateway = false
+            "e2netmask" -> inNetmask = false
+            "e2capacity" -> inCapacity = false
+            "e2free" -> inFree = false
+            "e2deviceinfo" -> finalizeResult()
+        }
+    }
+
+    override fun endDocument() {
+        if (result == null) {
+            finalizeResult()
+        }
+    }
+
+    private fun finalizeResult() {
+        result = DeviceInfo(
+            guiVersion = guiVersion.toString().trim(),
+            imageVersion = imageVersion.toString().trim(),
+            interfaceVersion = interfaceVersion.toString().trim(),
+            frontProcessorVersion = fpVersion.toString().trim(),
+            deviceName = deviceName.toString().trim(),
+            frontends = frontends.toList(),
+            nics = nics.toList(),
+            hdds = hdds.toList(),
+        )
+    }
+
+    override fun characters(ch: CharArray, startIdx: Int, length: Int) {
+        when {
+            inGuiVersion -> guiVersion.append(ch, startIdx, length)
+            inImageVersion -> imageVersion.append(ch, startIdx, length)
+            inInterfaceVersion -> interfaceVersion.append(ch, startIdx, length)
+            inFpVersion -> fpVersion.append(ch, startIdx, length)
+            inDeviceName -> deviceName.append(ch, startIdx, length)
+            inFrontend && inName -> frontendName.append(ch, startIdx, length)
+            inFrontend && inModel -> frontendModel.append(ch, startIdx, length)
+            inNic && inName -> nicName.append(ch, startIdx, length)
+            inNic && inMac -> nicMac.append(ch, startIdx, length)
+            inNic && inDhcp -> nicDhcp.append(ch, startIdx, length)
+            inNic && inIp -> nicIp.append(ch, startIdx, length)
+            inNic && inGateway -> nicGateway.append(ch, startIdx, length)
+            inNic && inNetmask -> nicNetmask.append(ch, startIdx, length)
+            inHdd && inModel -> hddModel.append(ch, startIdx, length)
+            inHdd && inCapacity -> hddCapacity.append(ch, startIdx, length)
+            inHdd && inFree -> hddFree.append(ch, startIdx, length)
+        }
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/DeviceInfoParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/DeviceInfoParser.kt
@@ -171,7 +171,7 @@ private class DeviceInfoHandler : DefaultHandler() {
     }
 
     private fun finalizeResult() {
-        result = DeviceInfo(
+        val built = DeviceInfo(
             guiVersion = guiVersion.toString().trim(),
             imageVersion = imageVersion.toString().trim(),
             interfaceVersion = interfaceVersion.toString().trim(),
@@ -181,6 +181,7 @@ private class DeviceInfoHandler : DefaultHandler() {
             nics = nics.toList(),
             hdds = hdds.toList(),
         )
+        result = if (built.isEmpty()) null else built
     }
 
     override fun characters(ch: CharArray, startIdx: Int, length: Int) {

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -44,6 +44,16 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getDeviceInfo(): DeviceInfo? {
+        return withContext(Dispatchers.IO) {
+            if (!http.fetchPageContent(URIStore.DEVICE_INFO, ArrayList())) {
+                null
+            } else {
+                DeviceInfoParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
@@ -68,6 +78,13 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         fun getCurrentBlocking(http: SimpleHttpClient): CurrentService? {
             return runBlocking {
                 EnigmaClient(http).getCurrent()
+            }
+        }
+
+        @JvmStatic
+        fun getDeviceInfoBlocking(http: SimpleHttpClient): DeviceInfo? {
+            return runBlocking {
+                EnigmaClient(http).getDeviceInfo()
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
@@ -16,24 +16,33 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.evernote.android.state.State;
+
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.asynctask.GetDeviceInfoTask;
+import net.reichholf.dreamdroid.enigma.DeviceHdd;
+import net.reichholf.dreamdroid.enigma.DeviceFrontend;
+import net.reichholf.dreamdroid.enigma.DeviceInfo;
+import net.reichholf.dreamdroid.enigma.DeviceNic;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
-import net.reichholf.dreamdroid.helpers.enigma2.DeviceInfo;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.DeviceInfoRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncSimpleLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
 
-import java.util.ArrayList;
-
 /**
  * Shows device-specific information for the active profile.
- * 
+ * Typed {@link DeviceInfo}; XML UI stays until device-info Compose.
+ *
  * @author sreichholf
- * 
+ *
  */
-public class DeviceInfoFragment extends BaseHttpFragment {
-	private ExtendedHashMap mInfo;
+public class DeviceInfoFragment extends BaseHttpFragment
+		implements GetDeviceInfoTask.GetDeviceInfoTaskHandler {
+	@Nullable
+	@State
+	public DeviceInfo mInfo;
+
 	private TextView mGuiVersion;
 	private TextView mImageVersion;
 	private TextView mInterfaceVersion;
@@ -42,24 +51,19 @@ public class DeviceInfoFragment extends BaseHttpFragment {
 	private LinearLayout mFrontendsList;
 	private LinearLayout mNicsList;
 	private LinearLayout mHddsList;
-	private ArrayList<ExtendedHashMap> mFrontends;
-	private ArrayList<ExtendedHashMap> mNics;
-	private ArrayList<ExtendedHashMap> mHdds;
 	private LayoutInflater mInflater;
+
+	@Nullable
+	private GetDeviceInfoTask mDeviceInfoTask;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		initTitles(getString(R.string.device_info));
-		mInfo = new ExtendedHashMap();
 	}
 
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		mFrontends = new ArrayList<>();
-		mNics = new ArrayList<>();
-		mHdds = new ArrayList<>();
-
 		mInflater = getLayoutInflater();
 		View view = mInflater.inflate(R.layout.device_info, null);
 
@@ -68,101 +72,116 @@ public class DeviceInfoFragment extends BaseHttpFragment {
 		mInterfaceVersion = view.findViewById(R.id.InterfaceVersion);
 		mFrontprocessorVersion = view.findViewById(R.id.FrontprocessorVersion);
 		mDeviceName = view.findViewById(R.id.DeviceName);
-		
+
 		mFrontendsList = view.findViewById(R.id.FrontendsList);
 		mNicsList = view.findViewById(R.id.NicsList);
 		mHddsList = view.findViewById(R.id.HddsList);
 
-		if (mInfo == null || mInfo.isEmpty()) {
-			mReload = true;
-		} else {
-			onInfoReady();
-		}
-
 		return view;
 	}
 
-	/**
-	 * Called when device info has been loaded and parsed successfully
-	 */
-	@SuppressWarnings("unchecked")
-	private void onInfoReady() {
-		mFrontends.clear();
-		mFrontends.addAll((ArrayList<ExtendedHashMap>) mInfo.get(DeviceInfo.KEY_FRONTENDS));
+	@Override
+	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+		boolean needReload = mInfo == null || mInfo.isEmpty();
+		if (needReload) {
+			mReload = true;
+		}
+		super.onViewCreated(view, savedInstanceState);
+		if (!needReload) {
+			onInfoReady(mInfo);
+		}
+	}
 
+	@Override
+	public void onDestroy() {
+		if (mDeviceInfoTask != null) {
+			mDeviceInfoTask.cancel(true);
+			mDeviceInfoTask = null;
+		}
+		super.onDestroy();
+	}
+
+	private void onInfoReady(@NonNull DeviceInfo info) {
 		mFrontendsList.removeAllViews();
-
-		for (int i=0; i<mFrontends.size(); i++) {
+		for (DeviceFrontend frontend : info.getFrontends()) {
 			View item = mInflater.inflate(R.layout.two_line_list_item, null);
-			
 			TextView title = item.findViewById(android.R.id.text1);
-			title.setText((String) mFrontends.get(i).get(DeviceInfo.KEY_FRONTEND_NAME));
-			
+			title.setText(frontend.getName());
 			TextView desc = item.findViewById(android.R.id.text2);
-			desc.setText((String) mFrontends.get(i).get(DeviceInfo.KEY_FRONTEND_MODEL));
-			
+			desc.setText(frontend.getModel());
 			mFrontendsList.addView(item);
 		}
 
-		mNics.clear();
-		mNics.addAll((ArrayList<ExtendedHashMap>) mInfo.get(DeviceInfo.KEY_NICS));
-
 		mNicsList.removeAllViews();
-
-		for (int i=0; i<mNics.size(); i++) {
+		for (DeviceNic nic : info.getNics()) {
 			View item = mInflater.inflate(R.layout.two_line_list_item, null);
-			
 			TextView title = item.findViewById(android.R.id.text1);
-			title.setText((String) mNics.get(i).get(DeviceInfo.KEY_NIC_NAME));
-			
+			title.setText(nic.getName());
 			TextView desc = item.findViewById(android.R.id.text2);
-			desc.setText((String) mNics.get(i).get(DeviceInfo.KEY_NIC_IP));
-			
+			desc.setText(nic.getIp());
 			mNicsList.addView(item);
 		}
 
-		mHdds.clear();
-		mHdds.addAll((ArrayList<ExtendedHashMap>) mInfo.get(DeviceInfo.KEY_HDDS));
-
 		mHddsList.removeAllViews();
-
-		for (int i=0; i<mHdds.size(); i++) {
+		for (DeviceHdd hdd : info.getHdds()) {
 			View item = mInflater.inflate(R.layout.two_line_list_item, null);
-			
 			TextView title = item.findViewById(android.R.id.text1);
-			title.setText((String) mHdds.get(i).get(DeviceInfo.KEY_HDD_MODEL));
-			
+			title.setText(hdd.getModel());
 			TextView desc = item.findViewById(android.R.id.text2);
-			desc.setText(String.format(getString(R.string.hdd_capacity),
-					mHdds.get(i).get(DeviceInfo.KEY_HDD_CAPACITY),
-					mHdds.get(i).get(DeviceInfo.KEY_HDD_FREE_SPACE)));
-			
+			desc.setText(String.format(getString(R.string.hdd_capacity), hdd.getCapacity(), hdd.getFree()));
 			mHddsList.addView(item);
 		}
 
-		mGuiVersion.setText(mInfo.getString(DeviceInfo.KEY_GUI_VERSION));
-		mImageVersion.setText(mInfo.getString(DeviceInfo.KEY_IMAGE_VERSION));
-		mInterfaceVersion.setText(mInfo.getString(DeviceInfo.KEY_INTERFACE_VERSION));
-		mFrontprocessorVersion.setText(mInfo.getString(DeviceInfo.KEY_FRONT_PROCESSOR_VERSION));
-		mDeviceName.setText(mInfo.getString(DeviceInfo.KEY_DEVICE_NAME));
+		mGuiVersion.setText(info.getGuiVersion());
+		mImageVersion.setText(info.getImageVersion());
+		mInterfaceVersion.setText(info.getInterfaceVersion());
+		mFrontprocessorVersion.setText(info.getFrontProcessorVersion());
+		mDeviceName.setText(info.getDeviceName());
 	}
 
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ExtendedHashMap>> onCreateLoader(int id, Bundle args) {
+		// Unused: content comes from GetDeviceInfoTask / EnigmaClient.
 		return new AsyncSimpleLoader(getAppCompatActivity(), new DeviceInfoRequestHandler(), args);
 	}
 
-	/*
-	 * You want override this if you don't override onLoadFinished!
-	 */
+	@Override
 	public void applyData(int loaderId, @Nullable ExtendedHashMap content) {
-		if (content != null) {
-			mInfo.clear();
-			mInfo.putAll(content);
-			onInfoReady();
+		// Unused: content comes from GetDeviceInfoTask / EnigmaClient.
+	}
+
+	@Override
+	protected void reload() {
+		mReload = false;
+		loadDeviceInfo();
+	}
+
+	private void loadDeviceInfo() {
+		if (!isAdded()) {
+			return;
+		}
+		if (mDeviceInfoTask != null) {
+			mDeviceInfoTask.cancel(true);
+		}
+		mDeviceInfoTask = new GetDeviceInfoTask(this);
+		mDeviceInfoTask.execute();
+	}
+
+	@Override
+	public void onDeviceInfoReady(boolean success, @Nullable DeviceInfo info, @Nullable String errorText) {
+		if (!isAdded()) {
+			return;
+		}
+		if (success && info != null) {
+			mInfo = info;
+			onInfoReady(info);
 		} else {
-			showToast(getText(R.string.not_available));
+			if (errorText != null && !errorText.isEmpty()) {
+				showToast(errorText);
+			} else {
+				showToast(getText(R.string.not_available));
+			}
 		}
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
@@ -161,6 +161,13 @@ public class DeviceInfoFragment extends BaseHttpFragment
 		if (!isAdded()) {
 			return;
 		}
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
 		if (mDeviceInfoTask != null) {
 			mDeviceInfoTask.cancel(true);
 		}
@@ -172,6 +179,11 @@ public class DeviceInfoFragment extends BaseHttpFragment
 	public void onDeviceInfoReady(boolean success, @Nullable DeviceInfo info, @Nullable String errorText) {
 		if (!isAdded()) {
 			return;
+		}
+		mHttpHelper.onLoadFinished();
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
 		}
 		if (success && info != null) {
 			mInfo = info;

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -312,6 +312,11 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getCurrentBlocking(shc);
     }
 
+    @Nullable
+    public static net.reichholf.dreamdroid.enigma.DeviceInfo fetchDeviceInfo(@NonNull SimpleHttpClient shc) {
+        return EnigmaClient.getDeviceInfoBlocking(shc);
+    }
+
     public void onLoadStarted() {
         if (mIsReloading)
             return;

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
@@ -68,10 +68,10 @@ public class CheckProfile {
 						xml = dirh.get(shc);
 
 					if (xml != null && !shc.hasError()) {
-						profile.setCachedDeviceInfo(xml);
 						DeviceInfo deviceInfo = DeviceInfoParser.INSTANCE.parse(xml);
 
 						if (deviceInfo != null && !deviceInfo.isEmpty()) {
+							profile.setCachedDeviceInfo(xml);
 							addEntry(resultList, R.string.device_name, false,
 									deviceInfo.getDeviceName());
 
@@ -98,6 +98,7 @@ public class CheckProfile {
 								setError(checkResult, true, true, R.string.version_too_low);
 							}
 						} else {
+							profile.setCachedDeviceInfo(null);
 							addEntry(resultList, R.string.connection, true, String.valueOf(host), R.string.get_content_error);
 							setError(checkResult, true, R.string.get_content_error);
 						}

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/CheckProfile.java
@@ -14,6 +14,8 @@ import androidx.annotation.Nullable;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.enigma.DeviceInfo;
+import net.reichholf.dreamdroid.enigma.DeviceInfoParser;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.SimpleHttpClient;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.DeviceInfoRequestHandler;
@@ -67,13 +69,16 @@ public class CheckProfile {
 
 					if (xml != null && !shc.hasError()) {
 						profile.setCachedDeviceInfo(xml);
-						ExtendedHashMap deviceInfo = new ExtendedHashMap();
+						DeviceInfo deviceInfo = DeviceInfoParser.INSTANCE.parse(xml);
 
-						if (dirh.parse(xml, deviceInfo)) {
+						if (deviceInfo != null && !deviceInfo.isEmpty()) {
 							addEntry(resultList, R.string.device_name, false,
-									deviceInfo.getString(DeviceInfo.KEY_DEVICE_NAME));
+									deviceInfo.getDeviceName());
 
-							String version = deviceInfo.getString(DeviceInfo.KEY_INTERFACE_VERSION, "0");
+							String version = deviceInfo.getInterfaceVersion();
+							if (version == null || version.isEmpty()) {
+								version = "0";
+							}
 							int vc = checkVersion(version);
 							if (vc >= 0) {
 								int[] requiredForSleeptimer = { 1, 6, 5 };

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/DeviceInfoParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/DeviceInfoParserTest.java
@@ -1,0 +1,55 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class DeviceInfoParserTest {
+    @Test
+    public void parsesDeviceinfoFixture() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/deviceinfo.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        DeviceInfo info = DeviceInfoParser.INSTANCE.parse(xml);
+        assertNotNull(info);
+        assertFalse(info.isEmpty());
+
+        assertEquals("2016-07-28-vti-master (d75da0c)", info.getGuiVersion());
+        assertEquals("9.0.3.", info.getImageVersion());
+        assertEquals("1.7.4", info.getInterfaceVersion());
+        assertEquals("0", info.getFrontProcessorVersion());
+        assertEquals("Solo4K", info.getDeviceName());
+
+        assertEquals(2, info.getFrontends().size());
+        assertEquals("Tuner A", info.getFrontends().get(0).getName());
+        assertTrue(info.getFrontends().get(0).getModel().contains("DVB-S2"));
+        assertEquals("Tuner B", info.getFrontends().get(1).getName());
+
+        assertEquals(1, info.getNics().size());
+        assertEquals("eth0", info.getNics().get(0).getName());
+        assertEquals("192.168.0.8", info.getNics().get(0).getIp());
+        assertEquals("00:1d:ec:0a:be:ae", info.getNics().get(0).getMac());
+
+        assertEquals(1, info.getHdds().size());
+        assertEquals("ATA(ST2000LM003 HN-M)", info.getHdds().get(0).getModel());
+        assertEquals("1.82 TB", info.getHdds().get(0).getCapacity());
+        assertEquals("1405.121 GB", info.getHdds().get(0).getFree());
+    }
+
+    @Test
+    public void emptyXmlYieldsNull() {
+        assertNull(DeviceInfoParser.INSTANCE.parse(""));
+    }
+
+    @Test
+    public void malformedXmlYieldsNull() {
+        assertNull(DeviceInfoParser.INSTANCE.parse("<e2deviceinfo><e2devicename>Solo"));
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/DeviceInfoParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/DeviceInfoParserTest.java
@@ -52,4 +52,10 @@ public class DeviceInfoParserTest {
     public void malformedXmlYieldsNull() {
         assertNull(DeviceInfoParser.INSTANCE.parse("<e2deviceinfo><e2devicename>Solo"));
     }
+
+    @Test
+    public void emptyDeviceInfoElementYieldsNull() {
+        assertNull(DeviceInfoParser.INSTANCE.parse(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><e2deviceinfo></e2deviceinfo>"));
+    }
 }

--- a/app/src/test/resources/web/deviceinfo.xml
+++ b/app/src/test/resources/web/deviceinfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2deviceinfo>
+	<e2enigmaversion>2016-07-28-vti-master (d75da0c)</e2enigmaversion>
+	<e2imageversion>9.0.3.</e2imageversion>
+	<e2webifversion>1.7.4</e2webifversion>
+	<e2fpversion>0</e2fpversion>
+	<e2devicename>Solo4K</e2devicename>
+	<e2frontends>
+		<e2frontend>
+			<e2name>Tuner A</e2name>
+			<e2model>Vuplus DVB-S NIM(7376 FBC) (DVB-S2)</e2model>
+		</e2frontend>
+		<e2frontend>
+			<e2name>Tuner B</e2name>
+			<e2model>Vuplus DVB-T NIM(TT3L10) (DVB-T2)</e2model>
+		</e2frontend>
+	</e2frontends>
+	<e2network>
+		<e2interface>
+			<e2name>eth0</e2name>
+			<e2mac>00:1d:ec:0a:be:ae</e2mac>
+			<e2dhcp>True</e2dhcp>
+			<e2ip>192.168.0.8</e2ip>
+			<e2gateway>192.168.0.1</e2gateway>
+			<e2netmask>255.255.255.0</e2netmask>
+		</e2interface>
+	</e2network>
+	<e2hdds>
+		<e2hdd>
+			<e2model>ATA(ST2000LM003 HN-M)</e2model>
+			<e2capacity>1.82 TB</e2capacity>
+			<e2free>1405.121 GB</e2free>
+		</e2hdd>
+	</e2hdds>
+</e2deviceinfo>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -42,13 +42,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | epg-search-compose | [#193](https://github.com/sreichholf/dreamDroid/pull/193) | merged | `EpgSearchFragment` Compose list; dropped `EpgBouquetAdapter` + multi-service row XML. |
 | share-profiles-compose | [#196](https://github.com/sreichholf/dreamDroid/pull/196) | merged | `ShareActivity` Compose list + `ShareProfilesScreenTest`; dropped `ProfileAdapter`.
 | epg-detail-compose | [#197](https://github.com/sreichholf/dreamDroid/pull/197) | merged | `EpgDetailBottomSheet` Compose + typed `Event`; pinned actions outside scroll.
-| drawer-dialogs-compose | [#198](https://github.com/sreichholf/dreamDroid/pull/198) | open | Sleep timer / send message / power / changelog / connection error → Compose; drop sleeptimer/send_message XML.
+| drawer-dialogs-compose | [#198](https://github.com/sreichholf/dreamDroid/pull/198) | merged | Sleep timer / send message / power / changelog / connection error → Compose; drop sleeptimer/send_message XML. |
+| device-info-typed | [#199](https://github.com/sreichholf/dreamDroid/pull/199) | open | typed `enigma.DeviceInfo` for `/web/deviceinfo`; XML UI stays; CheckProfile uses typed parse. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, device info, signal. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, signal (device info typed in this PR). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #197** (Share #196, EPG detail #197). `drawer-dialogs-compose` is open as [#198](https://github.com/sreichholf/dreamDroid/pull/198). Still open in G: device-info, signal, timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #198** (Share #196, EPG detail #197, drawer dialogs #198). Still open in G: device-info Compose (after this typed PR), signal, timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
 
 ### Operator overrides (this program)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Typed `enigma.DeviceInfo` + `DeviceInfoParser`, `EnigmaClient.getDeviceInfo`, `GetDeviceInfoTask`.
- `DeviceInfoFragment` and `CheckProfile` consume the typed model; XML UI stays until device-info Compose.
- Cache deviceinfo XML only after parse OK; empty payload treated as parse failure.

## Test plan
- [x] Unit test fixture for frontends/NICs/HDDs
- [x] Rebased onto `main` after #196–#198
- [ ] Bugbot before land
- [ ] Land when authorized (unblocks #201 Compose)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

