### PR TITLE
feat(client): typed Signal for /web/signal

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/AsyncTaskExecutorService.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/AsyncTaskExecutorService.java
@@ -14,6 +14,7 @@ public abstract class AsyncTaskExecutorService<Params, Progress, Result> {
 	private ExecutorService executor;
 	private Handler handler;
 	private Future future;
+	private volatile boolean cancelled;
 
 	protected AsyncTaskExecutorService() {
 		executor = Executors.newSingleThreadExecutor(r -> {
@@ -56,21 +57,43 @@ public abstract class AsyncTaskExecutorService<Params, Progress, Result> {
 	}
 
 	public void execute(Params params) {
+		cancelled = false;
 		getHandler().post(() -> {
 			onPreExecute();
 			future = executor.submit(() -> {
 				Result result = doInBackground(params);
-				getHandler().post(() -> onPostExecute(result));
+				getHandler().post(() -> {
+					try {
+						onPostExecute(result);
+					} finally {
+						shutdownExecutor();
+					}
+				});
 			});
 		});
 	}
 
 	public void cancel(boolean mayInterruptIfRunning) {
-		if (future != null && !future.isDone())
+		cancelled = true;
+		if (future != null && !future.isDone()) {
 			future.cancel(mayInterruptIfRunning);
+		}
+		shutdownExecutor();
 	}
 
 	public boolean isCancelled() {
-		return future.isCancelled() || executor == null || executor.isTerminated() || executor.isShutdown();
+		if (cancelled) {
+			return true;
+		}
+		if (future != null && future.isCancelled()) {
+			return true;
+		}
+		return executor == null || executor.isTerminated() || executor.isShutdown();
+	}
+
+	private void shutdownExecutor() {
+		if (executor != null && !executor.isShutdown()) {
+			executor.shutdownNow();
+		}
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/asynctask/AsyncTaskExecutorService.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/AsyncTaskExecutorService.java
@@ -8,12 +8,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 
 public abstract class AsyncTaskExecutorService<Params, Progress, Result> {
 
 	private ExecutorService executor;
 	private Handler handler;
-	private Future future;
+	private Future<?> future;
 	private volatile boolean cancelled;
 
 	protected AsyncTaskExecutorService() {
@@ -59,17 +60,31 @@ public abstract class AsyncTaskExecutorService<Params, Progress, Result> {
 	public void execute(Params params) {
 		cancelled = false;
 		getHandler().post(() -> {
+			if (cancelled) {
+				shutdownExecutor();
+				return;
+			}
 			onPreExecute();
-			future = executor.submit(() -> {
-				Result result = doInBackground(params);
-				getHandler().post(() -> {
-					try {
-						onPostExecute(result);
-					} finally {
-						shutdownExecutor();
-					}
+			if (cancelled) {
+				shutdownExecutor();
+				return;
+			}
+			try {
+				future = executor.submit(() -> {
+					Result result = doInBackground(params);
+					getHandler().post(() -> {
+						try {
+							if (!cancelled) {
+								onPostExecute(result);
+							}
+						} finally {
+							shutdownExecutor();
+						}
+					});
 				});
-			});
+			} catch (RejectedExecutionException ignored) {
+				shutdownExecutor();
+			}
 		});
 	}
 
@@ -78,7 +93,11 @@ public abstract class AsyncTaskExecutorService<Params, Progress, Result> {
 		if (future != null && !future.isDone()) {
 			future.cancel(mayInterruptIfRunning);
 		}
-		shutdownExecutor();
+		// If execute() has not submitted yet, its posted callback will see
+		// cancelled and shut down. If it already submitted, shut down now.
+		if (future != null) {
+			shutdownExecutor();
+		}
 	}
 
 	public boolean isCancelled() {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetSignalTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetSignalTask.java
@@ -1,0 +1,52 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.Signal;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+
+public class GetSignalTask extends AsyncHttpTaskBase<Void, String, Boolean> {
+	@Nullable
+	private Signal mSignal;
+
+	public GetSignalTask(GetSignalTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(Void unused) {
+		mSignal = null;
+		if (isCancelled()) {
+			return false;
+		}
+		mSignal = HttpFragmentHelper.fetchSignal(getHttpClient());
+		if (getHttpClient().hasError()) {
+			return false;
+		}
+		return mSignal != null && !mSignal.isEmpty();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetSignalTaskHandler handler = (GetSignalTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result) && mSignal != null;
+		String errorText = null;
+		if (!success) {
+			if (getHttpClient().hasError()) {
+				errorText = getErrorText();
+			} else {
+				errorText = handler.getString(net.reichholf.dreamdroid.R.string.error_parsing);
+			}
+		}
+		handler.onSignalReady(success, mSignal, errorText);
+	}
+
+	public interface GetSignalTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -54,6 +54,16 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getSignal(): Signal? {
+        return withContext(Dispatchers.IO) {
+            if (!http.fetchPageContent(URIStore.SIGNAL, ArrayList())) {
+                null
+            } else {
+                SignalParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
@@ -85,6 +95,13 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         fun getDeviceInfoBlocking(http: SimpleHttpClient): DeviceInfo? {
             return runBlocking {
                 EnigmaClient(http).getDeviceInfo()
+            }
+        }
+
+        @JvmStatic
+        fun getSignalBlocking(http: SimpleHttpClient): Signal? {
+            return runBlocking {
+                EnigmaClient(http).getSignal()
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/Signal.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Signal.kt
@@ -1,0 +1,42 @@
+package net.reichholf.dreamdroid.enigma
+
+import java.io.Serializable
+
+/**
+ * Typed `/web/signal` frontend status. Raw strings keep the box formatting for
+ * labels; [snrPercent] / [snrDb] are scrubbed for the gauge and acoustic feedback.
+ */
+data class Signal(
+    val snrDbRaw: String = "",
+    val snrRaw: String = "",
+    val berRaw: String = "",
+    val agcRaw: String = "",
+) : Serializable {
+    val snrPercent: Int
+        get() {
+            val scrubbed = snrRaw.replace("%", "").trim()
+            return try {
+                scrubbed.toInt()
+            } catch (e: NumberFormatException) {
+                0
+            }
+        }
+
+    val snrDb: Double
+        get() {
+            val scrubbed = snrDbRaw.replace(Regex("(?i)dB"), "").trim()
+            return try {
+                scrubbed.toDouble()
+            } catch (e: NumberFormatException) {
+                MIN_SNR_DB
+            }
+        }
+
+    fun isEmpty(): Boolean {
+        return snrDbRaw.isEmpty() && snrRaw.isEmpty() && berRaw.isEmpty() && agcRaw.isEmpty()
+    }
+
+    companion object {
+        const val MIN_SNR_DB = 5.0
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/SignalParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/SignalParser.kt
@@ -1,0 +1,96 @@
+package net.reichholf.dreamdroid.enigma
+
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object SignalParser {
+    fun parse(xml: String): Signal? {
+        if (xml.isEmpty()) {
+            return null
+        }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): Signal? {
+        return try {
+            val handler = SignalHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
+            handler.result
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+private class SignalHandler : DefaultHandler() {
+    var result: Signal? = null
+
+    private var inSnrDb = false
+    private var inSnr = false
+    private var inBer = false
+    private var inAgc = false
+
+    private val snrDb = StringBuilder()
+    private val snr = StringBuilder()
+    private val ber = StringBuilder()
+    private val agc = StringBuilder()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2snrdb" -> inSnrDb = true
+            "e2snr" -> inSnr = true
+            "e2ber" -> inBer = true
+            // OpenWebif historically emits the typo "e2acg"; accept both.
+            "e2acg", "e2agc" -> inAgc = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2snrdb" -> inSnrDb = false
+            "e2snr" -> inSnr = false
+            "e2ber" -> inBer = false
+            "e2acg", "e2agc" -> inAgc = false
+            "e2frontendstatus" -> finalizeResult()
+        }
+    }
+
+    override fun endDocument() {
+        if (result == null) {
+            finalizeResult()
+        }
+    }
+
+    private fun finalizeResult() {
+        val built = Signal(
+            snrDbRaw = snrDb.toString().trim(),
+            snrRaw = snr.toString().trim(),
+            berRaw = ber.toString().trim(),
+            agcRaw = agc.toString().trim(),
+        )
+        result = if (built.isEmpty()) null else built
+    }
+
+    override fun characters(ch: CharArray, startIdx: Int, length: Int) {
+        when {
+            inSnrDb -> snrDb.append(ch, startIdx, length)
+            inSnr -> snr.append(ch, startIdx, length)
+            inBer -> ber.append(ch, startIdx, length)
+            inAgc -> agc.append(ch, startIdx, length)
+        }
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
@@ -63,6 +63,9 @@ public class SignalFragment extends BaseHttpFragment
 
 	@Nullable
 	private GetSignalTask mSignalTask;
+	/** Strong ref so AsyncHttpTaskBase's WeakReference does not drop the callback. */
+	@Nullable
+	private GetSignalTask.GetSignalTaskHandler mSignalTaskHandler;
 
 	@NonNull
 	private Handler mHandler = new Handler();
@@ -234,13 +237,13 @@ public class SignalFragment extends BaseHttpFragment
 		if (mSignalTask != null) {
 			mSignalTask.cancel(true);
 		}
-		mSignalTask = new GetSignalTask(new GetSignalTask.GetSignalTaskHandler() {
+		mSignalTaskHandler = new GetSignalTask.GetSignalTaskHandler() {
 			@Override
 			public void onSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText) {
 				if (generation != mSignalGeneration) {
 					return;
 				}
-				SignalFragment.this.onSignalReady(success, signal, errorText);
+				handleSignalReady(success, signal, errorText);
 			}
 
 			@Nullable
@@ -254,16 +257,22 @@ public class SignalFragment extends BaseHttpFragment
 			public android.content.Context getContext() {
 				return SignalFragment.this.getContext();
 			}
-		});
+		};
+		mSignalTask = new GetSignalTask(mSignalTaskHandler);
 		mSignalTask.execute();
 	}
 
 	@Override
 	public void onSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText) {
+		handleSignalReady(success, signal, errorText);
+	}
+
+	private void handleSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText) {
 		mIsUpdating = false;
 		if (!isAdded()) {
 			return;
 		}
+		restoreTitle();
 		if (!mEnabled.isChecked()) {
 			return;
 		}
@@ -276,6 +285,13 @@ public class SignalFragment extends BaseHttpFragment
 		}
 		applySignal(signal);
 		reload();
+	}
+
+	private void restoreTitle() {
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
 	}
 
 	private void startPolling() {
@@ -297,11 +313,13 @@ public class SignalFragment extends BaseHttpFragment
 			mSignalTask.cancel(true);
 			mSignalTask = null;
 		}
+		mSignalTaskHandler = null;
 		mIsUpdating = false;
 		mSnr.setValue(0);
 		mSnrdb.setText("-");
 		mBer.setText("-");
 		mAgc.setText("-");
+		restoreTitle();
 	}
 
 	void playSound(double freqOfTone) {

--- a/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
@@ -58,6 +58,8 @@ public class SignalFragment extends BaseHttpFragment
 	private boolean mIsUpdating = false;
 	private double mSnrDb = sMinSnrDb;
 	private long mStartTime;
+	/** Bumped on each new fetch / stop so stale GetSignalTask callbacks are ignored. */
+	private int mSignalGeneration = 0;
 
 	@Nullable
 	private GetSignalTask mSignalTask;
@@ -228,10 +230,31 @@ public class SignalFragment extends BaseHttpFragment
 			return;
 		}
 		mIsUpdating = true;
+		final int generation = ++mSignalGeneration;
 		if (mSignalTask != null) {
 			mSignalTask.cancel(true);
 		}
-		mSignalTask = new GetSignalTask(this);
+		mSignalTask = new GetSignalTask(new GetSignalTask.GetSignalTaskHandler() {
+			@Override
+			public void onSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText) {
+				if (generation != mSignalGeneration) {
+					return;
+				}
+				SignalFragment.this.onSignalReady(success, signal, errorText);
+			}
+
+			@Nullable
+			@Override
+			public String getString(int resId) {
+				return SignalFragment.this.getString(resId);
+			}
+
+			@Nullable
+			@Override
+			public android.content.Context getContext() {
+				return SignalFragment.this.getContext();
+			}
+		});
 		mSignalTask.execute();
 	}
 
@@ -269,6 +292,7 @@ public class SignalFragment extends BaseHttpFragment
 	private void stopPolling() {
 		mHandler.removeCallbacks(mPlaySoundTask);
 		mHandler.removeCallbacks(mUpdateTask);
+		mSignalGeneration++;
 		if (mSignalTask != null) {
 			mSignalTask.cancel(true);
 			mSignalTask = null;

--- a/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/SignalFragment.java
@@ -20,6 +20,7 @@ import android.widget.CheckBox;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.loader.content.Loader;
 
@@ -28,15 +29,19 @@ import com.ekndev.gaugelibrary.Range;
 import com.google.android.material.color.MaterialColors;
 
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.asynctask.GetSignalTask;
+import net.reichholf.dreamdroid.enigma.Signal;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
-import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
-import net.reichholf.dreamdroid.helpers.enigma2.Signal;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SignalRequestHandler;
 import net.reichholf.dreamdroid.loader.AsyncSimpleLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
 
-public class SignalFragment extends BaseHttpFragment {
+/**
+ * Live tuner signal meter. Typed {@link Signal}; XML gauge UI stays until signal Compose.
+ */
+public class SignalFragment extends BaseHttpFragment
+		implements GetSignalTask.GetSignalTaskHandler {
 	private static final String TAG = SignalFragment.class.getSimpleName();
 
 	private static int sMaxSnrDb = 20;
@@ -53,6 +58,9 @@ public class SignalFragment extends BaseHttpFragment {
 	private boolean mIsUpdating = false;
 	private double mSnrDb = sMinSnrDb;
 	private long mStartTime;
+
+	@Nullable
+	private GetSignalTask mSignalTask;
 
 	@NonNull
 	private Handler mHandler = new Handler();
@@ -90,6 +98,15 @@ public class SignalFragment extends BaseHttpFragment {
 	}
 
 	@Override
+	public void onDestroy() {
+		if (mSignalTask != null) {
+			mSignalTask.cancel(true);
+			mSignalTask = null;
+		}
+		super.onDestroy();
+	}
+
+	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.signal, container, false);
 
@@ -119,13 +136,11 @@ public class SignalFragment extends BaseHttpFragment {
 		range4.setFrom(80.0);
 		range4.setTo(100.0);
 
-		//add color ranges to gauge
 		mSnr.addRange(range);
 		mSnr.addRange(range2);
 		mSnr.addRange(range3);
 		mSnr.addRange(range4);
 
-		//set min max and current value
 		mSnr.setMinValue(0.0);
 		mSnr.setMaxValue(100.0);
 		mSnr.setValue(0.0);
@@ -164,65 +179,86 @@ public class SignalFragment extends BaseHttpFragment {
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ExtendedHashMap>> onCreateLoader(int id, Bundle args) {
-		AsyncSimpleLoader loader = new AsyncSimpleLoader(getAppCompatActivity(), new SignalRequestHandler(), args);
-		mIsUpdating = true;
-		return loader;
+		// Unused: content comes from GetSignalTask / EnigmaClient.
+		return new AsyncSimpleLoader(getAppCompatActivity(), new SignalRequestHandler(), args);
 	}
 
 	@Override
-	public void onLoadFinished(@NonNull Loader<LoaderResult<ExtendedHashMap>> loader, @NonNull LoaderResult<ExtendedHashMap> result) {
-		if (result.isError()) {
-			mEnabled.setChecked(false);
-		}
-		super.onLoadFinished(loader, result);
+	public void applyData(int loaderId, @Nullable ExtendedHashMap content) {
+		// Unused: content comes from GetSignalTask / EnigmaClient.
 	}
 
-	@Override
-	public void applyData(int loaderId, @NonNull ExtendedHashMap content) {
+	private void applySignal(@NonNull Signal signal) {
 		long stopTime = System.currentTimeMillis();
 		long time = stopTime - mStartTime;
-		Log.w(TAG, "requets & parsing took: " + time + "ms");
+		Log.w(TAG, "request & parsing took: " + time + "ms");
 
-		if (!mEnabled.isChecked())
-			return;
-		String _snr = content.getString(Signal.KEY_SNR).replace("%", "").trim();
-
-		int snr = 0;
-		try {
-			snr = Integer.parseInt(_snr);
-		} catch (NumberFormatException ex) {
-		}
-
-		try {
-			mSnrDb = Double.parseDouble(content.getString(Signal.KEY_SNRDB, "7").replaceAll("(?i)dB", "").trim());
-		} catch (NumberFormatException ex) {
+		mSnrDb = signal.getSnrDb();
+		if (mSnrDb < sMinSnrDb) {
 			mSnrDb = sMinSnrDb;
 		}
-
-		mSnr.setValue(snr);
-		mSnrdb.setText(content.getString(Signal.KEY_SNRDB, "-").trim());
-		mBer.setText(content.getString(Signal.KEY_BER, "-").trim());
-		mAgc.setText(content.getString(Signal.KEY_AGC, "-").trim());
-
-		mIsUpdating = false;
-		reload();
+		mSnr.setValue(signal.getSnrPercent());
+		mSnrdb.setText(displayOrDash(signal.getSnrDbRaw()));
+		mBer.setText(displayOrDash(signal.getBerRaw()));
+		mAgc.setText(displayOrDash(signal.getAgcRaw()));
 	}
 
+	@NonNull
+	private static String displayOrDash(@Nullable String raw) {
+		if (raw == null || raw.trim().isEmpty()) {
+			return "-";
+		}
+		return raw.trim();
+	}
+
+	@Override
 	protected void reload() {
 		mStartTime = System.currentTimeMillis();
 		if (!"".equals(getBaseTitle().trim()))
 			setCurrentTitle(getBaseTitle() + " - " + getString(R.string.loading));
 
-		getAppCompatActivity().setTitle(getCurrentTitle());
-		getLoaderManager().restartLoader(0, getLoaderBundle(HttpFragmentHelper.LOADER_DEFAULT_ID), this);
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		loadSignal();
+	}
+
+	private void loadSignal() {
+		if (!isAdded() || mIsUpdating) {
+			return;
+		}
+		mIsUpdating = true;
+		if (mSignalTask != null) {
+			mSignalTask.cancel(true);
+		}
+		mSignalTask = new GetSignalTask(this);
+		mSignalTask.execute();
+	}
+
+	@Override
+	public void onSignalReady(boolean success, @Nullable Signal signal, @Nullable String errorText) {
+		mIsUpdating = false;
+		if (!isAdded()) {
+			return;
+		}
+		if (!mEnabled.isChecked()) {
+			return;
+		}
+		if (!success || signal == null) {
+			mEnabled.setChecked(false);
+			if (errorText != null && !errorText.isEmpty()) {
+				showToast(errorText);
+			}
+			return;
+		}
+		applySignal(signal);
+		reload();
 	}
 
 	private void startPolling() {
 		mIsUpdating = false;
 		if (mEnabled.isChecked()) {
 			reload();
-			// mHandler.removeCallbacks(mUpdateTask);
-			// mHandler.post(mUpdateTask);
 			if (mSound.isChecked()) {
 				mHandler.removeCallbacks(mPlaySoundTask);
 				mHandler.post(mPlaySoundTask);
@@ -233,6 +269,11 @@ public class SignalFragment extends BaseHttpFragment {
 	private void stopPolling() {
 		mHandler.removeCallbacks(mPlaySoundTask);
 		mHandler.removeCallbacks(mUpdateTask);
+		if (mSignalTask != null) {
+			mSignalTask.cancel(true);
+			mSignalTask = null;
+		}
+		mIsUpdating = false;
 		mSnr.setValue(0);
 		mSnrdb.setText("-");
 		mBer.setText("-");

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -313,8 +313,14 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
     }
 
     @Nullable
+    @Nullable
     public static net.reichholf.dreamdroid.enigma.DeviceInfo fetchDeviceInfo(@NonNull SimpleHttpClient shc) {
         return EnigmaClient.getDeviceInfoBlocking(shc);
+    }
+
+    @Nullable
+    public static net.reichholf.dreamdroid.enigma.Signal fetchSignal(@NonNull SimpleHttpClient shc) {
+        return EnigmaClient.getSignalBlocking(shc);
     }
 
     public void onLoadStarted() {

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -313,7 +313,6 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
     }
 
     @Nullable
-    @Nullable
     public static net.reichholf.dreamdroid.enigma.DeviceInfo fetchDeviceInfo(@NonNull SimpleHttpClient shc) {
         return EnigmaClient.getDeviceInfoBlocking(shc);
     }

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/SignalParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/SignalParserTest.java
@@ -1,0 +1,57 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class SignalParserTest {
+    @Test
+    public void parsesSignalFixtureWithTypoAgcTag() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/signal.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        Signal signal = SignalParser.INSTANCE.parse(xml);
+        assertNotNull(signal);
+        assertFalse(signal.isEmpty());
+
+        assertEquals("12.50 dB", signal.getSnrDbRaw());
+        assertEquals("63 %", signal.getSnrRaw());
+        assertEquals("0", signal.getBerRaw());
+        assertEquals("73 %", signal.getAgcRaw());
+        assertEquals(63, signal.getSnrPercent());
+        assertEquals(12.50, signal.getSnrDb(), 0.001);
+    }
+
+    @Test
+    public void acceptsCorrectedAgcTag() {
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2frontendstatus>"
+                + "<e2snrdb>8.0 dB</e2snrdb>"
+                + "<e2snr>40 %</e2snr>"
+                + "<e2ber>1</e2ber>"
+                + "<e2agc>50 %</e2agc>"
+                + "</e2frontendstatus>";
+        Signal signal = SignalParser.INSTANCE.parse(xml);
+        assertNotNull(signal);
+        assertEquals("50 %", signal.getAgcRaw());
+        assertEquals(40, signal.getSnrPercent());
+    }
+
+    @Test
+    public void emptyXmlYieldsNull() {
+        assertNull(SignalParser.INSTANCE.parse(""));
+    }
+
+    @Test
+    public void emptyFrontendStatusYieldsNull() {
+        assertNull(SignalParser.INSTANCE.parse(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><e2frontendstatus></e2frontendstatus>"));
+    }
+}

--- a/app/src/test/resources/web/signal.xml
+++ b/app/src/test/resources/web/signal.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2frontendstatus>
+	<e2snrdb>12.50 dB</e2snrdb>
+	<e2snr>63 %</e2snr>
+	<e2ber>0</e2ber>
+	<e2acg>73 %</e2acg>
+</e2frontendstatus>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -67,11 +67,11 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Swarm live lanes, perf probes, and `media/pr-*-review.*` videos were **not** run. The operator accepted connectedAndroidTest and landed.
 - Hub + rows are Compose on `main` (#169/#170). `ServiceAdapter` remains for video overlay; a hidden RecyclerView may remain for `BaseRecyclerFragment`.
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
-- Wave 3 Compose landed through #197: profile-edit #184 … service EPG #194, Share #196, EPG detail #197. Open: drawer dialogs #198.
+- Wave 3 Compose landed through #198: profile-edit #184 … service EPG #194, Share #196, EPG detail #197, drawer dialogs #198. Typed device-info #199 on `main`.
 - Share profiles Compose merged as [#196](https://github.com/sreichholf/dreamDroid/pull/196) (dropped `ProfileAdapter`).
 - EPG detail Compose merged as [#197](https://github.com/sreichholf/dreamDroid/pull/197).
-- Appendix G still open: device-info, signal, timer-edit, movie detail, timer service pick; plus open drawer dialogs #198.
-- Remaining typed API: hub now/next, movies, timers, device info, signal.
+- Appendix G still open: device-info Compose #201, signal Compose (typed first — this PR #200), timer-edit, movie detail, timer service pick.
+- Remaining typed API: hub now/next, movies, timers.
 - Out of wave: drawer shell, Leanback `tv/`, VLC, widgets. See Appendix H for the one-by-one plan after Wave 3.
 
 ## How to read this

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -43,13 +43,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | share-profiles-compose | [#196](https://github.com/sreichholf/dreamDroid/pull/196) | merged | `ShareActivity` Compose list + `ShareProfilesScreenTest`; dropped `ProfileAdapter`.
 | epg-detail-compose | [#197](https://github.com/sreichholf/dreamDroid/pull/197) | merged | `EpgDetailBottomSheet` Compose + typed `Event`; pinned actions outside scroll.
 | drawer-dialogs-compose | [#198](https://github.com/sreichholf/dreamDroid/pull/198) | merged | Sleep timer / send message / power / changelog / connection error → Compose; drop sleeptimer/send_message XML. |
-| device-info-typed | [#199](https://github.com/sreichholf/dreamDroid/pull/199) | open | typed `enigma.DeviceInfo` for `/web/deviceinfo`; XML UI stays; CheckProfile uses typed parse. |
+| device-info-typed | [#199](https://github.com/sreichholf/dreamDroid/pull/199) | merged | typed `enigma.DeviceInfo` for `/web/deviceinfo`; XML UI stays; CheckProfile uses typed parse. |
+| signal-typed | [#200](https://github.com/sreichholf/dreamDroid/pull/200) | open | typed `enigma.Signal` for `/web/signal`; poll via `GetSignalTask`; async cancel fixes. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers, signal (device info typed in this PR). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers (device info #199 + signal typed in this PR). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #198** (Share #196, EPG detail #197, drawer dialogs #198). Still open in G: device-info Compose (after this typed PR), signal, timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #199**. Still open in G: device-info Compose #201, signal Compose #202, timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
 
 ### Operator overrides (this program)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Typed `enigma.Signal` + `SignalParser`, `EnigmaClient.getSignal`, `GetSignalTask`.
- Stale-poll generation guard; strong handler ref; AsyncTask executor shutdown / cancel race fixes.
- Rebased onto `main` after device-info typed (#199).

## Test plan
- [x] Unit test fixture for signal XML
- [x] Compile googleDebug after rebase
- [ ] Bugbot before land
- [ ] Land when authorized (unblocks #202 Compose)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

