### PR TITLE
feat(client): typed Timer for /web/timerlist

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/GetTimerListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetTimerListTask.java
@@ -7,9 +7,11 @@ import net.reichholf.dreamdroid.enigma.Timer;
 import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GetTimerListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
+	@Nullable
 	private ArrayList<Timer> mTimers;
 
 	public GetTimerListTask(GetTimerListTaskHandler taskHandler) {
@@ -19,12 +21,22 @@ public class GetTimerListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
 	@NonNull
 	@Override
 	protected Boolean doInBackground(Void unused) {
-		mTimers = new ArrayList<>();
+		mTimers = null;
 		if (isCancelled()) {
 			return false;
 		}
-		mTimers.addAll(HttpFragmentHelper.fetchTimers(getHttpClient()));
-		return !getHttpClient().hasError();
+		List<Timer> fetched = HttpFragmentHelper.fetchTimers(getHttpClient());
+		if (getHttpClient().hasError()) {
+			mTimers = new ArrayList<>();
+			return false;
+		}
+		// Successful HTTP can still fail SAX; null means parse failure (not an empty timer list).
+		if (fetched == null) {
+			mTimers = new ArrayList<>();
+			return false;
+		}
+		mTimers = new ArrayList<>(fetched);
+		return true;
 	}
 
 	@Override
@@ -33,8 +45,17 @@ public class GetTimerListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
 		if (isInvalid(handler)) {
 			return;
 		}
-		boolean success = Boolean.TRUE.equals(result);
-		handler.onTimerListReady(success, mTimers, success ? null : getErrorText());
+		boolean success = Boolean.TRUE.equals(result) && mTimers != null;
+		List<Timer> timers = mTimers != null ? mTimers : Collections.emptyList();
+		String errorText = null;
+		if (!success) {
+			if (getHttpClient().hasError()) {
+				errorText = getErrorText();
+			} else {
+				errorText = handler.getString(net.reichholf.dreamdroid.R.string.error_parsing);
+			}
+		}
+		handler.onTimerListReady(success, timers, errorText);
 	}
 
 	public interface GetTimerListTaskHandler extends AsyncHttpTaskBaseHandler {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetTimerListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetTimerListTask.java
@@ -1,0 +1,43 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.Timer;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetTimerListTask extends AsyncHttpTaskBase<Void, String, Boolean> {
+	private ArrayList<Timer> mTimers;
+
+	public GetTimerListTask(GetTimerListTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(Void unused) {
+		mTimers = new ArrayList<>();
+		if (isCancelled()) {
+			return false;
+		}
+		mTimers.addAll(HttpFragmentHelper.fetchTimers(getHttpClient()));
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetTimerListTaskHandler handler = (GetTimerListTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onTimerListReady(success, mTimers, success ? null : getErrorText());
+	}
+
+	public interface GetTimerListTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onTimerListReady(boolean success, @NonNull List<Timer> timers, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -64,10 +64,10 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
-    suspend fun getTimers(): List<Timer> {
+    suspend fun getTimers(): List<Timer>? {
         return withContext(Dispatchers.IO) {
             if (!http.fetchPageContent(URIStore.TIMER_LIST, ArrayList())) {
-                emptyList()
+                null
             } else {
                 TimerParser.parse(http.pageContentString)
             }
@@ -116,7 +116,7 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
 
         @JvmStatic
-        fun getTimersBlocking(http: SimpleHttpClient): List<Timer> {
+        fun getTimersBlocking(http: SimpleHttpClient): List<Timer>? {
             return runBlocking {
                 EnigmaClient(http).getTimers()
             }

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -64,6 +64,16 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getTimers(): List<Timer> {
+        return withContext(Dispatchers.IO) {
+            if (!http.fetchPageContent(URIStore.TIMER_LIST, ArrayList())) {
+                emptyList()
+            } else {
+                TimerParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
@@ -102,6 +112,13 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         fun getSignalBlocking(http: SimpleHttpClient): Signal? {
             return runBlocking {
                 EnigmaClient(http).getSignal()
+            }
+        }
+
+        @JvmStatic
+        fun getTimersBlocking(http: SimpleHttpClient): List<Timer> {
+            return runBlocking {
+                EnigmaClient(http).getTimers()
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/Timer.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/Timer.kt
@@ -1,5 +1,10 @@
 package net.reichholf.dreamdroid.enigma
 
+import java.io.Serializable
+
+/**
+ * Typed `/web/timerlist` row (`e2timer`).
+ */
 data class Timer(
     val reference: String = "",
     val serviceName: String = "",
@@ -11,11 +16,22 @@ data class Timer(
     val begin: String = "",
     val end: String = "",
     val duration: String = "",
+    val beginReadable: String = "",
+    val endReadable: String = "",
+    val durationReadable: String = "",
+    val startPrepare: String = "",
     val justPlay: String = "",
     val afterEvent: String = "",
     val location: String = "",
     val tags: String = "",
+    val logEntries: String = "",
     val fileName: String = "",
+    val backOff: String = "",
+    val nextActivation: String = "",
+    val firstTryPrepare: String = "",
     val state: String = "",
-    val repeated: String = ""
-)
+    val repeated: String = "",
+    val dontSave: String = "",
+    val canceled: String = "",
+    val toggleDisabled: String = "",
+) : Serializable

--- a/app/src/net/reichholf/dreamdroid/enigma/TimerParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/TimerParser.kt
@@ -9,13 +9,15 @@ import java.io.StringReader
 import javax.xml.parsers.SAXParserFactory
 
 object TimerParser {
-    fun parse(xml: String): List<Timer> {
+    /**
+     * @return parsed timers, or null when XML cannot be parsed (distinct from a valid empty list).
+     */
+    fun parse(xml: String): List<Timer>? {
         if (xml.isEmpty()) {
-            return emptyList()
+            return null
         }
         return parseSanitized(xml, aggressive = false)
             ?: parseSanitized(xml, aggressive = true)
-            ?: emptyList()
     }
 
     private fun parseSanitized(xml: String, aggressive: Boolean): List<Timer>? {

--- a/app/src/net/reichholf/dreamdroid/enigma/TimerParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/TimerParser.kt
@@ -1,0 +1,280 @@
+package net.reichholf.dreamdroid.enigma
+
+import net.reichholf.dreamdroid.helpers.DateTime
+import net.reichholf.dreamdroid.helpers.Python
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object TimerParser {
+    fun parse(xml: String): List<Timer> {
+        if (xml.isEmpty()) {
+            return emptyList()
+        }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+            ?: emptyList()
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): List<Timer>? {
+        return try {
+            val handler = TimerListHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
+            handler.timers
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+private class TimerListHandler : DefaultHandler() {
+    val timers = ArrayList<Timer>()
+
+    private var inTimer = false
+    private var inReference = false
+    private var inServiceName = false
+    private var inEit = false
+    private var inName = false
+    private var inDescription = false
+    private var inDescriptionEx = false
+    private var inDisabled = false
+    private var inBegin = false
+    private var inEnd = false
+    private var inDuration = false
+    private var inStartPrepare = false
+    private var inJustPlay = false
+    private var inAfterEvent = false
+    private var inLocation = false
+    private var inTags = false
+    private var inLogEntries = false
+    private var inFileName = false
+    private var inBackOff = false
+    private var inNextActivation = false
+    private var inFirstTryPrepare = false
+    private var inState = false
+    private var inRepeated = false
+    private var inDontSave = false
+    private var inCanceled = false
+    private var inToggleDisabled = false
+
+    private val reference = StringBuilder()
+    private val serviceName = StringBuilder()
+    private val eit = StringBuilder()
+    private val name = StringBuilder()
+    private val description = StringBuilder()
+    private val descriptionExtended = StringBuilder()
+    private val disabled = StringBuilder()
+    private val begin = StringBuilder()
+    private val end = StringBuilder()
+    private val duration = StringBuilder()
+    private val startPrepare = StringBuilder()
+    private val justPlay = StringBuilder()
+    private val afterEvent = StringBuilder()
+    private val location = StringBuilder()
+    private val tags = StringBuilder()
+    private val logEntries = StringBuilder()
+    private val fileName = StringBuilder()
+    private val backOff = StringBuilder()
+    private val nextActivation = StringBuilder()
+    private val firstTryPrepare = StringBuilder()
+    private val state = StringBuilder()
+    private val repeated = StringBuilder()
+    private val dontSave = StringBuilder()
+    private val canceled = StringBuilder()
+    private val toggleDisabled = StringBuilder()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2timer" -> {
+                inTimer = true
+                clearBuilders()
+            }
+            "e2servicereference" -> inReference = true
+            "e2servicename" -> inServiceName = true
+            "e2eit" -> inEit = true
+            "e2name" -> inName = true
+            "e2description" -> inDescription = true
+            "e2descriptionextended" -> inDescriptionEx = true
+            "e2disabled" -> inDisabled = true
+            "e2timebegin" -> inBegin = true
+            "e2timeend" -> inEnd = true
+            "e2duration" -> inDuration = true
+            "e2startprepare" -> inStartPrepare = true
+            "e2justplay" -> inJustPlay = true
+            "e2afterevent" -> inAfterEvent = true
+            "e2location" -> inLocation = true
+            "e2tags" -> inTags = true
+            "e2logentries" -> inLogEntries = true
+            "e2filename" -> inFileName = true
+            "e2backoff" -> inBackOff = true
+            "e2nextactivation" -> inNextActivation = true
+            "e2firsttryprepare" -> inFirstTryPrepare = true
+            "e2state" -> inState = true
+            "e2repeated" -> inRepeated = true
+            "e2dontsave" -> inDontSave = true
+            "e2cancled" -> inCanceled = true
+            "e2toggledisabled" -> inToggleDisabled = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2timer" -> {
+                inTimer = false
+                timers.add(buildTimer())
+            }
+            "e2servicereference" -> inReference = false
+            "e2servicename" -> inServiceName = false
+            "e2eit" -> inEit = false
+            "e2name" -> inName = false
+            "e2description" -> inDescription = false
+            "e2descriptionextended" -> inDescriptionEx = false
+            "e2disabled" -> inDisabled = false
+            "e2timebegin" -> inBegin = false
+            "e2timeend" -> inEnd = false
+            "e2duration" -> inDuration = false
+            "e2startprepare" -> inStartPrepare = false
+            "e2justplay" -> inJustPlay = false
+            "e2afterevent" -> inAfterEvent = false
+            "e2location" -> inLocation = false
+            "e2tags" -> inTags = false
+            "e2logentries" -> inLogEntries = false
+            "e2filename" -> inFileName = false
+            "e2backoff" -> inBackOff = false
+            "e2nextactivation" -> inNextActivation = false
+            "e2firsttryprepare" -> inFirstTryPrepare = false
+            "e2state" -> inState = false
+            "e2repeated" -> inRepeated = false
+            "e2dontsave" -> inDontSave = false
+            "e2cancled" -> inCanceled = false
+            "e2toggledisabled" -> inToggleDisabled = false
+        }
+    }
+
+    override fun characters(ch: CharArray, startIdx: Int, length: Int) {
+        if (!inTimer) {
+            return
+        }
+        when {
+            inReference -> reference.append(ch, startIdx, length)
+            inServiceName -> serviceName.append(ch, startIdx, length)
+            inEit -> eit.append(ch, startIdx, length)
+            inName -> name.append(ch, startIdx, length)
+            inDescription -> description.append(ch, startIdx, length)
+            inDescriptionEx -> descriptionExtended.append(ch, startIdx, length)
+            inDisabled -> disabled.append(ch, startIdx, length)
+            inBegin -> begin.append(ch, startIdx, length)
+            inEnd -> end.append(ch, startIdx, length)
+            inDuration -> duration.append(ch, startIdx, length)
+            inStartPrepare -> startPrepare.append(ch, startIdx, length)
+            inJustPlay -> justPlay.append(ch, startIdx, length)
+            inAfterEvent -> afterEvent.append(ch, startIdx, length)
+            inLocation -> location.append(ch, startIdx, length)
+            inTags -> tags.append(ch, startIdx, length)
+            inLogEntries -> logEntries.append(ch, startIdx, length)
+            inFileName -> fileName.append(ch, startIdx, length)
+            inBackOff -> backOff.append(ch, startIdx, length)
+            inNextActivation -> nextActivation.append(ch, startIdx, length)
+            inFirstTryPrepare -> firstTryPrepare.append(ch, startIdx, length)
+            inState -> state.append(ch, startIdx, length)
+            inRepeated -> repeated.append(ch, startIdx, length)
+            inDontSave -> dontSave.append(ch, startIdx, length)
+            inCanceled -> canceled.append(ch, startIdx, length)
+            inToggleDisabled -> toggleDisabled.append(ch, startIdx, length)
+        }
+    }
+
+    private fun clearBuilders() {
+        reference.setLength(0)
+        serviceName.setLength(0)
+        eit.setLength(0)
+        name.setLength(0)
+        description.setLength(0)
+        descriptionExtended.setLength(0)
+        disabled.setLength(0)
+        begin.setLength(0)
+        end.setLength(0)
+        duration.setLength(0)
+        startPrepare.setLength(0)
+        justPlay.setLength(0)
+        afterEvent.setLength(0)
+        location.setLength(0)
+        tags.setLength(0)
+        logEntries.setLength(0)
+        fileName.setLength(0)
+        backOff.setLength(0)
+        nextActivation.setLength(0)
+        firstTryPrepare.setLength(0)
+        state.setLength(0)
+        repeated.setLength(0)
+        dontSave.setLength(0)
+        canceled.setLength(0)
+        toggleDisabled.setLength(0)
+    }
+
+    private fun buildTimer(): Timer {
+        val beginRaw = begin.toString().trim()
+        val endRaw = end.toString().trim()
+        val durationRaw = duration.toString().trim()
+
+        var beginReadable = ""
+        var endReadable = ""
+        var durationReadable = ""
+        if (beginRaw.isNotEmpty() && Python.NONE != beginRaw) {
+            beginReadable = DateTime.getYearDateTimeString(beginRaw)
+        }
+        if (endRaw.isNotEmpty() && Python.NONE != endRaw) {
+            endReadable = DateTime.getYearDateTimeString(endRaw)
+        }
+        if (durationRaw.isNotEmpty() && Python.NONE != durationRaw) {
+            durationReadable = try {
+                DateTime.getDurationString(durationRaw, null) ?: durationRaw
+            } catch (e: NumberFormatException) {
+                durationRaw
+            }
+        }
+
+        return Timer(
+            reference = reference.toString().trim(),
+            serviceName = serviceName.toString().replace("\\p{Cntrl}".toRegex(), "").trim(),
+            eit = eit.toString().trim(),
+            name = name.toString().trim(),
+            description = description.toString(),
+            descriptionExtended = descriptionExtended.toString(),
+            disabled = disabled.toString().trim(),
+            begin = beginRaw,
+            end = endRaw,
+            duration = durationRaw,
+            beginReadable = beginReadable,
+            endReadable = endReadable,
+            durationReadable = durationReadable,
+            startPrepare = startPrepare.toString().trim(),
+            justPlay = justPlay.toString().trim(),
+            afterEvent = afterEvent.toString().trim(),
+            location = location.toString().trim(),
+            tags = tags.toString().trim(),
+            logEntries = logEntries.toString(),
+            fileName = fileName.toString().trim(),
+            backOff = backOff.toString().trim(),
+            nextActivation = nextActivation.toString().trim(),
+            firstTryPrepare = firstTryPrepare.toString().trim(),
+            state = state.toString().trim(),
+            repeated = repeated.toString().trim(),
+            dontSave = dontSave.toString().trim(),
+            canceled = canceled.toString().trim(),
+            toggleDisabled = toggleDisabled.toString().trim(),
+        )
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -29,12 +29,13 @@ import com.evernote.android.state.State;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.TimerAdapter;
+import net.reichholf.dreamdroid.asynctask.GetTimerListTask;
+import net.reichholf.dreamdroid.enigma.Timer;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.PositiveNegativeDialog;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Timer;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerChangeRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerCleanupRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerDeleteRequestHandler;
@@ -42,19 +43,24 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerListRequestH
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
 import net.reichholf.dreamdroid.ui.services.TimerListItem;
+import net.reichholf.dreamdroid.ui.services.TimerListMapper;
 import net.reichholf.dreamdroid.ui.services.TimerListMapperKt;
 import net.reichholf.dreamdroid.ui.services.TimerListState;
 import net.reichholf.dreamdroid.ui.services.TimerListStateKt;
 import net.reichholf.dreamdroid.widget.helper.ItemSelectionSupport;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Activity to show a List of all existing timers of the target device
+ * Activity to show a List of all existing timers of the target device.
+ * Compose list of typed {@link Timer}; edit/delete still take ExtendedHashMap at the edge.
  *
  * @author sreichholf
  */
-public class TimerListFragment extends BaseHttpRecyclerFragment {
+public class TimerListFragment extends BaseHttpRecyclerFragment
+		implements GetTimerListTask.GetTimerListTaskHandler {
 	@NonNull
 	private ActionMode.Callback mActionModeCallback = new ActionMode.Callback() {
 
@@ -74,7 +80,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		@Override
 		public boolean onPrepareActionMode(ActionMode mode, @NonNull Menu menu) {
 			MenuItem toggle = menu.findItem(R.id.menu_toggle_enabled);
-			if (mTimer.getString(Timer.KEY_DISABLED).equals("0"))
+			if (mTimer.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DISABLED).equals("0"))
 				toggle.setTitle(R.string.disable);
 			else
 				toggle.setTitle(R.string.enable);
@@ -105,6 +111,9 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	private ProgressDialog mProgress;
 	protected int mCurrentPos;
 	private TimerListState mListState;
+	private final ArrayList<Timer> mTimers = new ArrayList<>();
+	@Nullable
+	private GetTimerListTask mTimerListTask;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -146,6 +155,14 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		);
 	}
 
+	@Override
+	public void onDestroy() {
+		if (mTimerListTask != null) {
+			mTimerListTask.cancel(true);
+		}
+		super.onDestroy();
+	}
+
 	protected void startActionMode() {
 		mTimer = mMapList.get(mCurrentPos);
 		mActionMode = getAppCompatActivity().startSupportActionMode(mActionModeCallback);
@@ -185,7 +202,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	public boolean onItemSelected(int id) {
 		switch (id) {
 			case (Statics.ITEM_NEW_TIMER):
-				mTimer = Timer.getInitialTimer();
+				mTimer = net.reichholf.dreamdroid.helpers.enigma2.Timer.getInitialTimer();
 				editTimer(mTimer, true);
 				return true;
 			case (Statics.ITEM_CLEANUP):
@@ -208,7 +225,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	 * @param timer The timer to be edited
 	 */
 	private void editTimer(ExtendedHashMap timer, boolean create) {
-		Timer.edit(getMultiPaneHandler(), timer, this, create);
+		net.reichholf.dreamdroid.helpers.enigma2.Timer.edit(getMultiPaneHandler(), timer, this, create);
 	}
 
 	/**
@@ -219,12 +236,76 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		getRecyclerView().setAdapter(mAdapter);
 	}
 
+	@NonNull
+	@Override
+	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
+		// Timer list no longer starts this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
+		return new AsyncListLoader(getAppCompatActivity(), new TimerListRequestHandler(), false, args);
+	}
+
 	@Override
 	public void onLoadFinished(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
 							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
-		super.onLoadFinished(loader, result);
+		// Unused: rows come from GetTimerListTask / EnigmaClient.
+	}
+
+	@Override
+	protected void reload() {
+		mReload = false;
+		if (mTimers.isEmpty())
+			setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+		else
+			setEmptyText(null);
+		loadTimers();
+	}
+
+	private void loadTimers() {
+		mHttpHelper.onLoadStarted();
+		if (!"".equals(getBaseTitle().trim())) {
+			setCurrentTitle(getString(R.string.loading));
+		}
 		if (getAppCompatActivity() != null) {
-			mListState.replaceAll(TimerListMapperKt.timerListItemsFrom(getAppCompatActivity(), mMapList));
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+		if (mTimerListTask != null) {
+			mTimerListTask.cancel(true);
+		}
+		mTimerListTask = new GetTimerListTask(this);
+		mTimerListTask.execute((Void) null);
+	}
+
+	@Override
+	public void onTimerListReady(boolean success, @NonNull List<Timer> timers, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		mTimers.clear();
+		mMapList.clear();
+		mListState.replaceAll(Collections.emptyList());
+		if (mAdapter != null) {
+			mAdapter.notifyDataSetChanged();
+		}
+		if (!success) {
+			setEmptyText(errorText);
+			return;
+		}
+		setEmptyText(null);
+		setCurrentTitle(getLoadFinishedTitle());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getCurrentTitle());
+		}
+
+		if (timers.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mTimers.addAll(timers);
+			for (Timer timer : timers) {
+				mMapList.add(TimerListMapper.toExtendedHashMap(timer));
+			}
+			if (getAppCompatActivity() != null) {
+				mListState.replaceAll(TimerListMapperKt.timerListItemsFrom(getAppCompatActivity(), mTimers));
+			}
+			if (mAdapter != null) {
+				mAdapter.notifyDataSetChanged();
+			}
 		}
 	}
 
@@ -241,7 +322,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	 * Confirmation dialog before timer deletion
 	 */
 	private void deleteTimerConfirm() {
-		PositiveNegativeDialog dia = PositiveNegativeDialog.newInstance(mTimer.getString(Timer.KEY_NAME),
+		PositiveNegativeDialog dia = PositiveNegativeDialog.newInstance(mTimer.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_NAME),
 				R.string.delete_confirm, android.R.string.yes, Statics.ACTION_DELETE_CONFIRMED, android.R.string.no,
 				Statics.ACTION_NONE);
 
@@ -259,7 +340,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 				mProgress.dismiss();
 			}
 		}
-		ArrayList<NameValuePair> params = Timer.getDeleteParams(timer);
+		ArrayList<NameValuePair> params = net.reichholf.dreamdroid.helpers.enigma2.Timer.getDeleteParams(timer);
 		mProgress = ProgressDialog.show(getAppCompatActivity(), "", getText(R.string.deleting), true);
 		execSimpleResultTask(new TimerDeleteRequestHandler(), params);
 	}
@@ -267,12 +348,12 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	private void toggleTimerEnabled(@NonNull ExtendedHashMap timer) {
 		ExtendedHashMap timerNew = timer.clone();
 
-		if (timerNew.getString(Timer.KEY_DISABLED).equals("1"))
-			timerNew.put(Timer.KEY_DISABLED, "0");
+		if (timerNew.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DISABLED).equals("1"))
+			timerNew.put(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DISABLED, "0");
 		else
-			timerNew.put(Timer.KEY_DISABLED, "1");
+			timerNew.put(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DISABLED, "1");
 
-		ArrayList<NameValuePair> params = Timer.getSaveParams(timerNew, timer);
+		ArrayList<NameValuePair> params = net.reichholf.dreamdroid.helpers.enigma2.Timer.getSaveParams(timerNew, timer);
 		mProgress = ProgressDialog.show(getAppCompatActivity(), "", getText(R.string.saving), true);
 		execSimpleResultTask(new TimerChangeRequestHandler(), params);
 	}
@@ -300,12 +381,6 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		super.onSimpleResult(success, result);
 
 		reload();
-	}
-
-	@NonNull
-	@Override
-	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
-		return new AsyncListLoader(getAppCompatActivity(), new TimerListRequestHandler(), false, args);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -114,6 +114,8 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 	private final ArrayList<Timer> mTimers = new ArrayList<>();
 	@Nullable
 	private GetTimerListTask mTimerListTask;
+	@Nullable
+	private GetTimerListTask.GetTimerListTaskHandler mTimerListTaskHandler;
 	/** Bumped on each new fetch so stale GetTimerListTask callbacks are ignored. */
 	private int mTimerListGeneration = 0;
 
@@ -274,7 +276,8 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 		if (mTimerListTask != null) {
 			mTimerListTask.cancel(true);
 		}
-		mTimerListTask = new GetTimerListTask(new GetTimerListTask.GetTimerListTaskHandler() {
+		// Keep a strong ref: GetTimerListTask only holds WeakReference to the handler.
+		mTimerListTaskHandler = new GetTimerListTask.GetTimerListTaskHandler() {
 			@Nullable
 			@Override
 			public String getString(int resId) {
@@ -294,7 +297,8 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 				}
 				handleTimerListReady(success, timers, errorText);
 			}
-		});
+		};
+		mTimerListTask = new GetTimerListTask(mTimerListTaskHandler);
 		mTimerListTask.execute((Void) null);
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -114,6 +114,8 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 	private final ArrayList<Timer> mTimers = new ArrayList<>();
 	@Nullable
 	private GetTimerListTask mTimerListTask;
+	/** Bumped on each new fetch so stale GetTimerListTask callbacks are ignored. */
+	private int mTimerListGeneration = 0;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -157,6 +159,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 
 	@Override
 	public void onDestroy() {
+		mTimerListGeneration++;
 		if (mTimerListTask != null) {
 			mTimerListTask.cancel(true);
 		}
@@ -267,15 +270,40 @@ public class TimerListFragment extends BaseHttpRecyclerFragment
 		if (getAppCompatActivity() != null) {
 			getAppCompatActivity().setTitle(getCurrentTitle());
 		}
+		final int generation = ++mTimerListGeneration;
 		if (mTimerListTask != null) {
 			mTimerListTask.cancel(true);
 		}
-		mTimerListTask = new GetTimerListTask(this);
+		mTimerListTask = new GetTimerListTask(new GetTimerListTask.GetTimerListTaskHandler() {
+			@Nullable
+			@Override
+			public String getString(int resId) {
+				return TimerListFragment.this.getString(resId);
+			}
+
+			@Nullable
+			@Override
+			public android.content.Context getContext() {
+				return TimerListFragment.this.getContext();
+			}
+
+			@Override
+			public void onTimerListReady(boolean success, @NonNull List<Timer> timers, @Nullable String errorText) {
+				if (generation != mTimerListGeneration) {
+					return;
+				}
+				handleTimerListReady(success, timers, errorText);
+			}
+		});
 		mTimerListTask.execute((Void) null);
 	}
 
 	@Override
 	public void onTimerListReady(boolean success, @NonNull List<Timer> timers, @Nullable String errorText) {
+		handleTimerListReady(success, timers, errorText);
+	}
+
+	private void handleTimerListReady(boolean success, @NonNull List<Timer> timers, @Nullable String errorText) {
 		mHttpHelper.onLoadFinished();
 		mTimers.clear();
 		mMapList.clear();

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -322,12 +322,12 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getSignalBlocking(shc);
     }
 
-    @NonNull
+    @Nullable
     public List<net.reichholf.dreamdroid.enigma.Timer> fetchTimers() {
         return fetchTimers(mShc);
     }
 
-    @NonNull
+    @Nullable
     public static List<net.reichholf.dreamdroid.enigma.Timer> fetchTimers(@NonNull SimpleHttpClient shc) {
         return EnigmaClient.getTimersBlocking(shc);
     }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -322,6 +322,16 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getSignalBlocking(shc);
     }
 
+    @NonNull
+    public List<net.reichholf.dreamdroid.enigma.Timer> fetchTimers() {
+        return fetchTimers(mShc);
+    }
+
+    @NonNull
+    public static List<net.reichholf.dreamdroid.enigma.Timer> fetchTimers(@NonNull SimpleHttpClient shc) {
+        return EnigmaClient.getTimersBlocking(shc);
+    }
+
     public void onLoadStarted() {
         if (mIsReloading)
             return;

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListMapper.kt
@@ -4,24 +4,65 @@ import android.content.Context
 import android.util.Log
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.enigma.Timer
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
-import net.reichholf.dreamdroid.helpers.enigma2.Timer
+import net.reichholf.dreamdroid.helpers.enigma2.Timer as TimerKeys
 
-fun timerListItemsFrom(context: Context, maps: List<ExtendedHashMap>): List<TimerListItem> {
+/**
+ * Timer hub list holds typed [Timer] rows. Edit / delete / toggle still take
+ * [ExtendedHashMap]; convert only at that fragment boundary.
+ */
+object TimerListMapper {
+    @JvmStatic
+    fun toExtendedHashMap(timer: Timer): ExtendedHashMap {
+        val map = ExtendedHashMap()
+        map.put(TimerKeys.KEY_REFERENCE, timer.reference)
+        map.put(TimerKeys.KEY_SERVICE_NAME, timer.serviceName)
+        map.put(TimerKeys.KEY_EIT, timer.eit)
+        map.put(TimerKeys.KEY_NAME, timer.name)
+        map.put(TimerKeys.KEY_DESCRIPTION, timer.description)
+        map.put(TimerKeys.KEY_DESCRIPTION_EXTENDED, timer.descriptionExtended)
+        map.put(TimerKeys.KEY_DISABLED, timer.disabled)
+        map.put(TimerKeys.KEY_BEGIN, timer.begin)
+        map.put(TimerKeys.KEY_BEGIN_READEABLE, timer.beginReadable)
+        map.put(TimerKeys.KEY_END, timer.end)
+        map.put(TimerKeys.KEY_END_READABLE, timer.endReadable)
+        map.put(TimerKeys.KEY_DURATION, timer.duration)
+        map.put(TimerKeys.KEY_DURATION_READABLE, timer.durationReadable)
+        map.put(TimerKeys.KEY_START_PREPARE, timer.startPrepare)
+        map.put(TimerKeys.KEY_JUST_PLAY, timer.justPlay)
+        map.put(TimerKeys.KEY_AFTER_EVENT, timer.afterEvent)
+        map.put(TimerKeys.KEY_LOCATION, timer.location)
+        map.put(TimerKeys.KEY_TAGS, timer.tags)
+        map.put(TimerKeys.KEY_LOG_ENTRIES, timer.logEntries)
+        map.put(TimerKeys.KEY_FILE_NAME, timer.fileName)
+        map.put(TimerKeys.KEY_BACK_OFF, timer.backOff)
+        map.put(TimerKeys.KEY_NEXT_ACTIVATION, timer.nextActivation)
+        map.put(TimerKeys.KEY_FIRST_TRY_PREPARE, timer.firstTryPrepare)
+        map.put(TimerKeys.KEY_STATE, timer.state)
+        map.put(TimerKeys.KEY_REPEATED, timer.repeated)
+        map.put(TimerKeys.KEY_DONT_SAVE, timer.dontSave)
+        map.put(TimerKeys.KEY_CANCELED, timer.canceled)
+        map.put(TimerKeys.KEY_TOGGLE_DISABLED, timer.toggleDisabled)
+        return map
+    }
+}
+
+fun timerListItemsFrom(context: Context, timers: List<Timer>): List<TimerListItem> {
     val states = context.resources.getTextArray(R.array.timer_state)
     val actions = context.resources.getTextArray(R.array.timer_action)
     val colors = context.resources.getIntArray(R.array.timer_state_color)
-    return maps.mapIndexed { index, map ->
+    return timers.mapIndexed { index, timer ->
         var actionId = 0
         try {
-            actionId = Integer.parseInt(map.getString(Timer.KEY_JUST_PLAY) ?: "0")
+            actionId = Integer.parseInt(timer.justPlay.ifEmpty { "0" })
         } catch (e: Exception) {
             Log.e(DreamDroid.LOG_TAG, e.toString())
         }
         var stateId = 0
         try {
-            stateId = Integer.parseInt(map.getString(Timer.KEY_STATE) ?: "0")
-            stateId += Integer.parseInt(map.getString(Timer.KEY_DISABLED) ?: "0")
+            stateId = Integer.parseInt(timer.state.ifEmpty { "0" })
+            stateId += Integer.parseInt(timer.disabled.ifEmpty { "0" })
         } catch (e: Exception) {
             Log.e(DreamDroid.LOG_TAG, e.toString())
         }
@@ -30,10 +71,10 @@ fun timerListItemsFrom(context: Context, maps: List<ExtendedHashMap>): List<Time
         val color = if (stateId in colors.indices) colors[stateId] else 0
         TimerListItem(
             index = index,
-            name = map.getString(Timer.KEY_NAME).orEmpty(),
-            serviceName = map.getString(Timer.KEY_SERVICE_NAME).orEmpty(),
-            begin = map.getString(Timer.KEY_BEGIN_READEABLE).orEmpty(),
-            end = map.getString(Timer.KEY_END_READABLE).orEmpty(),
+            name = timer.name,
+            serviceName = timer.serviceName,
+            begin = timer.beginReadable,
+            end = timer.endReadable,
             action = action,
             state = state,
             stateColor = color,

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/TimerParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/TimerParserTest.java
@@ -1,0 +1,102 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class TimerParserTest {
+    @Test
+    public void parsesTimerlistFixtureIntoTimerValues() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/timerlist.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        long started = System.nanoTime();
+        List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        long elapsedNanos = System.nanoTime() - started;
+        System.out.println("TimerParser.parse nanos=" + elapsedNanos);
+
+        assertEquals(2, timers.size());
+
+        Timer first = timers.get(0);
+        assertEquals("1:0:19:EF74:3F9:1:C00000:0:0:0:", first.getReference());
+        assertEquals("SAT.1 HD", first.getServiceName());
+        assertEquals("39350", first.getEit());
+        assertEquals("Navy CIS: L.A.", first.getName());
+        assertEquals("Kein Rauch ohne Feuer", first.getDescription());
+        assertTrue(first.getDescriptionExtended().contains("Feuerwehrmann"));
+        assertEquals("0", first.getDisabled());
+        assertEquals("1476644933", first.getBegin());
+        assertEquals("1476649083", first.getEnd());
+        assertEquals("4150", first.getDuration());
+        assertFalse(first.getBeginReadable().isEmpty());
+        assertFalse(first.getEndReadable().isEmpty());
+        assertEquals("69", first.getDurationReadable());
+        assertEquals("1476644913", first.getStartPrepare());
+        assertEquals("0", first.getJustPlay());
+        assertEquals("3", first.getAfterEvent());
+        assertEquals("None", first.getLocation());
+        assertEquals("", first.getTags());
+        assertTrue(first.getLogEntries().contains("record time changed"));
+        assertEquals("0", first.getState());
+        assertEquals("0", first.getRepeated());
+        assertEquals("False", first.getCanceled());
+        assertEquals("1", first.getToggleDisabled());
+
+        Timer second = timers.get(1);
+        assertEquals("Tagesschau", second.getName());
+        assertEquals("1", second.getDisabled());
+        assertEquals("1", second.getJustPlay());
+        assertEquals("127", second.getRepeated());
+        assertEquals("news", second.getTags());
+        assertEquals("/hdd/movie/", second.getLocation());
+        assertEquals("60", second.getDurationReadable());
+    }
+
+    @Test
+    public void emptyXmlYieldsNoTimers() {
+        assertEquals(0, TimerParser.INSTANCE.parse("").size());
+    }
+
+    @Test
+    public void malformedXmlYieldsNoTimers() {
+        assertEquals(0, TimerParser.INSTANCE.parse("<e2timerlist><e2timer>").size());
+    }
+
+    @Test
+    public void stripsIllegalControlCharactersBeforeParse() {
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2timerlist>"
+                + "<e2timer>"
+                + "<e2servicereference>1:0:1:1:1:1:0:0:0:0:</e2servicereference>"
+                + "<e2servicename>TV\u0001Channel</e2servicename>"
+                + "<e2eit>1</e2eit>"
+                + "<e2name>News</e2name>"
+                + "<e2description>Has\u0001control</e2description>"
+                + "<e2descriptionextended>More</e2descriptionextended>"
+                + "<e2disabled>0</e2disabled>"
+                + "<e2timebegin>1893456000</e2timebegin>"
+                + "<e2timeend>1893459600</e2timeend>"
+                + "<e2duration>3600</e2duration>"
+                + "<e2justplay>0</e2justplay>"
+                + "<e2afterevent>3</e2afterevent>"
+                + "<e2state>0</e2state>"
+                + "<e2repeated>0</e2repeated>"
+                + "</e2timer>"
+                + "</e2timerlist>";
+        List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        assertEquals(1, timers.size());
+        assertEquals("News", timers.get(0).getName());
+        assertEquals("TVChannel", timers.get(0).getServiceName());
+        assertTrue(timers.get(0).getDescription().contains("Has"));
+        assertTrue(timers.get(0).getDescription().contains("control"));
+        assertFalse(timers.get(0).getDescription().contains("\u0001"));
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/TimerParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/TimerParserTest.java
@@ -19,6 +19,7 @@ public class TimerParserTest {
         String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         long started = System.nanoTime();
         List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        assertNotNull(timers);
         long elapsedNanos = System.nanoTime() - started;
         System.out.println("TimerParser.parse nanos=" + elapsedNanos);
 
@@ -60,13 +61,21 @@ public class TimerParserTest {
     }
 
     @Test
-    public void emptyXmlYieldsNoTimers() {
-        assertEquals(0, TimerParser.INSTANCE.parse("").size());
+    public void emptyXmlYieldsNull() {
+        assertEquals(null, TimerParser.INSTANCE.parse(""));
     }
 
     @Test
-    public void malformedXmlYieldsNoTimers() {
-        assertEquals(0, TimerParser.INSTANCE.parse("<e2timerlist><e2timer>").size());
+    public void malformedXmlYieldsNull() {
+        assertEquals(null, TimerParser.INSTANCE.parse("<e2timerlist><e2timer>"));
+    }
+
+    @Test
+    public void emptyTimerListYieldsEmptyList() {
+        List<Timer> timers = TimerParser.INSTANCE.parse(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><e2timerlist></e2timerlist>");
+        assertNotNull(timers);
+        assertEquals(0, timers.size());
     }
 
     @Test
@@ -92,6 +101,7 @@ public class TimerParserTest {
                 + "</e2timer>"
                 + "</e2timerlist>";
         List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        assertNotNull(timers);
         assertEquals(1, timers.size());
         assertEquals("News", timers.get(0).getName());
         assertEquals("TVChannel", timers.get(0).getServiceName());

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/TimerListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/TimerListMapperTest.java
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.ui.services;
+
+import net.reichholf.dreamdroid.enigma.Timer;
+import net.reichholf.dreamdroid.enigma.TimerParser;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TimerListMapperTest {
+    @Test
+    public void toExtendedHashMapCopiesTimerFields() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/timerlist.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        Timer timer = timers.get(0);
+
+        ExtendedHashMap map = TimerListMapper.toExtendedHashMap(timer);
+        assertEquals(timer.getReference(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_REFERENCE));
+        assertEquals(timer.getServiceName(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_SERVICE_NAME));
+        assertEquals(timer.getEit(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_EIT));
+        assertEquals(timer.getName(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_NAME));
+        assertEquals(timer.getDescription(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DESCRIPTION));
+        assertEquals(timer.getDescriptionExtended(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DESCRIPTION_EXTENDED));
+        assertEquals(timer.getDisabled(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DISABLED));
+        assertEquals(timer.getBegin(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_BEGIN));
+        assertEquals(timer.getBeginReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_BEGIN_READEABLE));
+        assertEquals(timer.getEnd(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_END));
+        assertEquals(timer.getEndReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_END_READABLE));
+        assertEquals(timer.getDuration(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DURATION));
+        assertEquals(timer.getDurationReadable(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_DURATION_READABLE));
+        assertEquals(timer.getJustPlay(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_JUST_PLAY));
+        assertEquals(timer.getAfterEvent(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_AFTER_EVENT));
+        assertEquals(timer.getLocation(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_LOCATION));
+        assertEquals(timer.getState(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_STATE));
+        assertEquals(timer.getRepeated(), map.getString(net.reichholf.dreamdroid.helpers.enigma2.Timer.KEY_REPEATED));
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/TimerListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/TimerListMapperTest.java
@@ -20,6 +20,7 @@ public class TimerListMapperTest {
         assertNotNull(in);
         String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         List<Timer> timers = TimerParser.INSTANCE.parse(xml);
+        assertNotNull(timers);
         Timer timer = timers.get(0);
 
         ExtendedHashMap map = TimerListMapper.toExtendedHashMap(timer);

--- a/app/src/test/resources/web/timerlist.xml
+++ b/app/src/test/resources/web/timerlist.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2timerlist>
+	<e2timer>
+		<e2servicereference>1:0:19:EF74:3F9:1:C00000:0:0:0:</e2servicereference>
+		<e2servicename>SAT.1 HD</e2servicename>
+		<e2eit>39350</e2eit>
+		<e2name>Navy CIS: L.A.</e2name>
+		<e2description>Kein Rauch ohne Feuer</e2description>
+		<e2descriptionextended>Ein Feuerwehrmann stirbt bei einem Brand.</e2descriptionextended>
+		<e2disabled>0</e2disabled>
+		<e2timebegin>1476644933</e2timebegin>
+		<e2timeend>1476649083</e2timeend>
+		<e2duration>4150</e2duration>
+		<e2startprepare>1476644913</e2startprepare>
+		<e2justplay>0</e2justplay>
+		<e2afterevent>3</e2afterevent>
+		<e2location>None</e2location>
+		<e2tags></e2tags>
+		<e2logentries>[(1476254301, 15, 'record time changed')]</e2logentries>
+		<e2filename></e2filename>
+		<e2backoff>0</e2backoff>
+		<e2nextactivation></e2nextactivation>
+		<e2firsttryprepare>True</e2firsttryprepare>
+		<e2state>0</e2state>
+		<e2repeated>0</e2repeated>
+		<e2dontsave>0</e2dontsave>
+		<e2cancled>False</e2cancled>
+		<e2toggledisabled>1</e2toggledisabled>
+	</e2timer>
+	<e2timer>
+		<e2servicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2servicereference>
+		<e2servicename>Das Erste HD</e2servicename>
+		<e2eit>1</e2eit>
+		<e2name>Tagesschau</e2name>
+		<e2description>Nachrichten</e2description>
+		<e2descriptionextended/>
+		<e2disabled>1</e2disabled>
+		<e2timebegin>1893456000</e2timebegin>
+		<e2timeend>1893459600</e2timeend>
+		<e2duration>3600</e2duration>
+		<e2startprepare>1893455980</e2startprepare>
+		<e2justplay>1</e2justplay>
+		<e2afterevent>0</e2afterevent>
+		<e2location>/hdd/movie/</e2location>
+		<e2tags>news</e2tags>
+		<e2logentries/>
+		<e2filename/>
+		<e2backoff>0</e2backoff>
+		<e2nextactivation/>
+		<e2firsttryprepare>False</e2firsttryprepare>
+		<e2state>0</e2state>
+		<e2repeated>127</e2repeated>
+		<e2dontsave>0</e2dontsave>
+		<e2cancled>False</e2cancled>
+		<e2toggledisabled>0</e2toggledisabled>
+	</e2timer>
+</e2timerlist>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -46,13 +46,14 @@ Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap l
 | device-info-typed | [#199](https://github.com/sreichholf/dreamDroid/pull/199) | merged | typed `enigma.DeviceInfo` for `/web/deviceinfo`; XML UI stays; CheckProfile uses typed parse. |
 | signal-typed | [#200](https://github.com/sreichholf/dreamDroid/pull/200) | merged | typed `enigma.Signal` for `/web/signal`; poll via `GetSignalTask`; async cancel fixes. |
 | device-info-compose | [#201](https://github.com/sreichholf/dreamDroid/pull/201) | merged | `DeviceInfoFragment` Compose UI + `DeviceInfoScreenTest`; keep last-good on failed refresh.
-| signal-compose | [#202](https://github.com/sreichholf/dreamDroid/pull/202) | open | `SignalFragment` Compose + HalfGauge `AndroidView` + `SignalScreenTest`.
+| signal-compose | [#202](https://github.com/sreichholf/dreamDroid/pull/202) | merged | `SignalFragment` Compose + HalfGauge `AndroidView` + `SignalScreenTest`.
+| timers-typed | [#203](https://github.com/sreichholf/dreamDroid/pull/203) | open | typed `enigma.Timer` for `/web/timerlist`; Compose list via typed model; edit/delete hash at edge.
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
 Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183) are on `main`. Remaining typed API: hub now/next, movies, timers. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #200**. Open: device-info Compose #201, signal Compose #202, timers typed #203. Still open after those: timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Landed on `main` through #202**. Open: timers typed #203. Still open after that: timer-edit, movie detail, timer service pick. Drawer shell and Leanback TV are later programs (Appendix H).
 
 ### Operator overrides (this program)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add typed `enigma.Timer` + `TimerParser`, `EnigmaClient.getTimers`, and `GetTimerListTask`.
- Wire `TimerListFragment` Compose rows to the typed list; keep `ExtendedHashMap` only at edit/delete/toggle.
- Generation guard against stale reloads; SAX parse failure surfaces `error_parsing` (null ≠ empty list).
- Rebased onto `main` after #196–#202.

## Test plan
- [x] `TimerParserTest` + `TimerListMapperTest` (JDK 17)
- [x] Compile googleDebug after rebase with DeviceInfo/Signal client methods kept
- [x] Bugbot findings fixed earlier; re-review after rebase
- [ ] Land when authorized (unblocks `timer-edit-compose`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

