### PR TITLE
feat(client): typed ServiceNowNext for hub TV/Radio pages

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/GetEpgNowNextTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetEpgNowNextTask.java
@@ -1,0 +1,48 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.DreamDroid;
+import net.reichholf.dreamdroid.enigma.ServiceNowNext;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+import net.reichholf.dreamdroid.helpers.NameValuePair;
+import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetEpgNowNextTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	private ArrayList<ServiceNowNext> mRows;
+
+	public GetEpgNowNextTask(GetEpgNowNextTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(ArrayList<NameValuePair> params) {
+		mRows = new ArrayList<>();
+		if (isCancelled()) {
+			return false;
+		}
+		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
+		String uri = DreamDroid.featureNowNext() ? URIStore.EPG_NOWNEXT : URIStore.EPG_NOW;
+		mRows.addAll(HttpFragmentHelper.fetchEpgNowNext(getHttpClient(), requestParams, uri));
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetEpgNowNextTaskHandler handler = (GetEpgNowNextTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onEpgNowNextReady(success, mRows, success ? null : getErrorText());
+	}
+
+	public interface GetEpgNowNextTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onEpgNowNextReady(boolean success, @NonNull List<ServiceNowNext> rows, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -43,7 +43,20 @@ class EnigmaClient(private val http: SimpleHttpClient) {
             if (!http.fetchPageContent(uri, requestParams)) {
                 emptyList()
             } else {
-                EpgNowNextParser.parse(http.pageContentString)
+                val xml = http.pageContentString
+                if (uri == URIStore.EPG_NOWNEXT) {
+                    EpgNowNextParser.parse(xml)
+                } else {
+                    // /web/epgnow (and other flat event lists): one service row per event, no pairing.
+                    EventParser.parse(xml).map { event ->
+                        ServiceNowNext(
+                            serviceReference = event.serviceReference,
+                            serviceName = event.serviceName,
+                            now = event,
+                            next = null,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -34,6 +34,20 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getEpgNowNext(
+        params: List<NameValuePair> = emptyList(),
+        uri: String = URIStore.EPG_NOWNEXT
+    ): List<ServiceNowNext> {
+        return withContext(Dispatchers.IO) {
+            val requestParams = ArrayList(params)
+            if (!http.fetchPageContent(uri, requestParams)) {
+                emptyList()
+            } else {
+                EpgNowNextParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     suspend fun getCurrent(): CurrentService? {
         return withContext(Dispatchers.IO) {
             if (!http.fetchPageContent(URIStore.CURRENT, ArrayList())) {
@@ -91,6 +105,18 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         ): List<Event> {
             return runBlocking {
                 EnigmaClient(http).getEvents(params, uri)
+            }
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun getEpgNowNextBlocking(
+            http: SimpleHttpClient,
+            params: List<NameValuePair>,
+            uri: String = URIStore.EPG_NOWNEXT
+        ): List<ServiceNowNext> {
+            return runBlocking {
+                EnigmaClient(http).getEpgNowNext(params, uri)
             }
         }
 

--- a/app/src/net/reichholf/dreamdroid/enigma/EpgNowNextParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EpgNowNextParser.kt
@@ -1,0 +1,36 @@
+package net.reichholf.dreamdroid.enigma
+
+/**
+ * Parses `/web/epgnownext` XML into paired [ServiceNowNext] rows.
+ *
+ * Matches legacy [net.reichholf.dreamdroid.parsers.enigma2.saxhandler.E2EpgNowNextListHandler]:
+ * consecutive `<e2event>` elements are positional now/next pairs. A trailing odd event becomes a
+ * now-only row. Flat `/web/epgnow` lists are one event per row (next = null).
+ */
+object EpgNowNextParser {
+    fun parse(xml: String): List<ServiceNowNext> {
+        return pairEvents(EventParser.parse(xml))
+    }
+
+    fun pairEvents(events: List<Event>): List<ServiceNowNext> {
+        if (events.isEmpty()) {
+            return emptyList()
+        }
+        val rows = ArrayList<ServiceNowNext>((events.size + 1) / 2)
+        var i = 0
+        while (i < events.size) {
+            val now = events[i]
+            val next = if (i + 1 < events.size) events[i + 1] else null
+            rows.add(
+                ServiceNowNext(
+                    serviceReference = now.serviceReference,
+                    serviceName = now.serviceName,
+                    now = now,
+                    next = next,
+                )
+            )
+            i += if (next != null) 2 else 1
+        }
+        return rows
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EpgNowNextParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EpgNowNextParser.kt
@@ -5,7 +5,10 @@ package net.reichholf.dreamdroid.enigma
  *
  * Matches legacy [net.reichholf.dreamdroid.parsers.enigma2.saxhandler.E2EpgNowNextListHandler]:
  * consecutive `<e2event>` elements are positional now/next pairs. A trailing odd event becomes a
- * now-only row. Flat `/web/epgnow` lists are one event per row (next = null).
+ * now-only row.
+ *
+ * Do **not** use [parse] for flat `/web/epgnow` responses — [EnigmaClient.getEpgNowNext] maps those
+ * one event per row without pairing.
  */
 object EpgNowNextParser {
     fun parse(xml: String): List<ServiceNowNext> {

--- a/app/src/net/reichholf/dreamdroid/enigma/ServiceNowNext.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/ServiceNowNext.kt
@@ -1,0 +1,13 @@
+package net.reichholf.dreamdroid.enigma
+
+import java.io.Serializable
+
+/**
+ * One hub TV/Radio row from `/web/epgnownext` (or epgnow fallback): service plus now/next [Event]s.
+ */
+data class ServiceNowNext(
+    val serviceReference: String = "",
+    val serviceName: String = "",
+    val now: Event? = null,
+    val next: Event? = null
+) : Serializable

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -29,48 +29,42 @@ import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.ServiceAdapter;
+import net.reichholf.dreamdroid.asynctask.GetEpgNowNextTask;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.enigma.ServiceNowNext;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerEventFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailBottomSheet;
 import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.AbstractListRequestHandler;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EpgNowNextListRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EventListRequestHandler;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ServiceListRequestHandler;
 import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.loader.AsyncListLoader;
 import net.reichholf.dreamdroid.loader.LoaderResult;
 import net.reichholf.dreamdroid.room.AppDatabase;
+import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 import net.reichholf.dreamdroid.ui.services.ServiceListItem;
 import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
 import net.reichholf.dreamdroid.ui.services.ServiceListState;
 import net.reichholf.dreamdroid.ui.services.ServiceListStateKt;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * Handles ServiceLists of (based on service references).
  * <p/>
- * If called with Intent.ACTION_PICK it can be used for selecting services (e.g.
- * to set a timer).<br/>
- * In Pick-Mode no EPG will be loaded/shown.<br/>
- * For any other action it will be a full-featured ServiceList Browser capable
- * of showing EPG of running events or calling a
- * <code>ServiceEpgListActivity</code> to show the whole EPG of a service
+ * Compose Material 3 list of typed {@link ServiceNowNext} for TV/Radio hub pages.
+ * Detail/timer/stream still take ExtendedHashMap at the edge.
  *
  * @author sreichholf
  */
-public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
-	@Nullable
-	private static final String TAG = ServiceListPageFragment.class.getCanonicalName();
-	private static final int LOADER_BOUQUETLIST_ID = 1;
-
+public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment
+		implements GetEpgNowNextTask.GetEpgNowNextTaskHandler {
 	@Nullable
 	@State
 	public String mName;
@@ -79,7 +73,10 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public String mRef;
 
 	private ArrayList<ExtendedHashMap> mHistory;
+	private final ArrayList<ServiceNowNext> mRows = new ArrayList<>();
 	private ServiceListState mListState;
+	@Nullable
+	private GetEpgNowNextTask mEpgNowNextTask;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -148,13 +145,20 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	}
 
 	@Override
+	public void onDestroy() {
+		if (mEpgNowNextTask != null) {
+			mEpgNowNextTask.cancel(true);
+		}
+		super.onDestroy();
+	}
+
+	@Override
 	public void onItemClick(RecyclerView parent, @NonNull View view, int position, long id) {
-		onItemClick(parent, view, position, false);
+		// Compose owns clicks.
 	}
 
 	@Override
 	public boolean onItemLongClick(RecyclerView parent, @NonNull View view, int position, long id) {
-		onItemClick(parent, view, position, true);
 		return true;
 	}
 
@@ -163,14 +167,18 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		if (host == null) {
 			return;
 		}
-		onItemClick(host, host, item.getIndex(), isLong);
+		onItemClick(host, item.getIndex(), isLong);
 	}
 
-	private void onItemClick(View l, @NonNull View v, int position, boolean isLong) {
+	private void onItemClick(@NonNull View v, int position, boolean isLong) {
+		if (position < 0 || position >= mRows.size()) {
+			return;
+		}
+		ServiceNowNext row = mRows.get(position);
 		ExtendedHashMap previousItem = mCurrentItem;
-		mCurrentItem = mMapList.get(position);
-		final String ref = mCurrentItem.getString(Event.KEY_SERVICE_REFERENCE);
-		final String name = mCurrentItem.getString(Event.KEY_SERVICE_NAME);
+		mCurrentItem = ServiceListMapperKt.serviceNowNextToExtendedHashMap(row);
+		final String ref = row.getServiceReference();
+		final String name = row.getServiceName();
 		if (Service.isMarker(ref))
 			return;
 
@@ -187,7 +195,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		if ((instantZap && !isLong) || (!instantZap && isLong)) {
 			zapTo(ref);
 		} else {
-			showPopupMenu(v);
+			showPopupMenu(v, row);
 		}
 	}
 
@@ -246,43 +254,70 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 
 	@Override
 	public ArrayList<NameValuePair> getHttpParams(int loader) {
-		switch (loader) {
-			case HttpFragmentHelper.LOADER_DEFAULT_ID:
-				ArrayList<NameValuePair> params = new ArrayList();
-				String param = "bRef";
-				if (!Service.isBouquet(mRef))
-					param = "sRef";
-				params.add(new NameValuePair(param, mRef));
-				return params;
-			default:
-				return super.getHttpParams(loader);
-		}
+		ArrayList<NameValuePair> params = new ArrayList<>();
+		String param = "bRef";
+		if (!Service.isBouquet(mRef))
+			param = "sRef";
+		params.add(new NameValuePair(param, mRef));
+		return params;
 	}
 
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
-		AbstractListRequestHandler handler;
-		if (id == LOADER_BOUQUETLIST_ID) {
-			handler = new ServiceListRequestHandler();
-		} else {
-			if (DreamDroid.featureNowNext())
-				handler = new EpgNowNextListRequestHandler();
-			else
-				handler = new EventListRequestHandler(URIStore.EPG_NOW);
-		}
-		return new AsyncListLoader(getAppCompatActivity(), handler, true, args);
+		// Hub pages no longer start this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
+		return new AsyncListLoader(getAppCompatActivity(), new EventListRequestHandler(URIStore.EPG_NOW), false, args);
 	}
 
 	@Override
 	public void onLoadFinished(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
 							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
-		getAppCompatActivity().supportInvalidateOptionsMenu();
+		// Unused: rows come from GetEpgNowNextTask / EnigmaClient.
+	}
 
-		if (!isResumed())
+	@Override
+	protected void reload() {
+		mReload = false;
+		if (mRows.isEmpty())
+			setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+		else
+			setEmptyText(null);
+		loadEpgNowNext();
+	}
+
+	private void loadEpgNowNext() {
+		mHttpHelper.onLoadStarted();
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getString(R.string.loading));
+		}
+		if (mEpgNowNextTask != null) {
+			mEpgNowNextTask.cancel(true);
+		}
+		mEpgNowNextTask = new GetEpgNowNextTask(this);
+		mEpgNowNextTask.execute(getHttpParams(HttpFragmentHelper.LOADER_DEFAULT_ID));
+	}
+
+	@Override
+	public void onEpgNowNextReady(boolean success, @NonNull List<ServiceNowNext> rows, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		getAppCompatActivity().supportInvalidateOptionsMenu();
+		mRows.clear();
+		mListState.replaceAll(java.util.Collections.emptyList());
+		if (!success) {
+			setEmptyText(errorText);
 			return;
-		super.onLoadFinished(loader, result);
-		mListState.replaceAll(ServiceListMapperKt.serviceListItemsFrom(mMapList));
+		}
+		setEmptyText(null);
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(mName);
+		}
+
+		if (rows.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mRows.addAll(rows);
+			mListState.replaceAll(ServiceListMapperKt.serviceListItemsFromNowNext(mRows));
+		}
 	}
 
 	public void upOrReload() {
@@ -304,30 +339,41 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public void openEpg(String ref, String nam) {
 		ServiceEpgListFragment f = new ServiceEpgListFragment();
 		ExtendedHashMap map = new ExtendedHashMap();
-		map.put(Event.KEY_SERVICE_REFERENCE, ref);
-		map.put(Event.KEY_SERVICE_NAME, nam);
+		map.put(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE, ref);
+		map.put(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME, nam);
 		Bundle args = new Bundle();
 		args.putSerializable(sData, map);
 		f.setArguments(args);
 		getMultiPaneHandler().showDetails(f, true);
 	}
 
-	public void showPopupMenu(@NonNull View v) {
+	public void showPopupMenu(@NonNull View v, @NonNull ServiceNowNext row) {
 		PopupMenu menu = new PopupMenu(getAppCompatActivity(), v);
 		menu.getMenuInflater().inflate(R.menu.popup_servicelist, menu.getMenu());
-		menu.getMenu().findItem(R.id.menu_next_event).setVisible(DreamDroid.featureNowNext());
+		menu.getMenu().findItem(R.id.menu_next_event).setVisible(DreamDroid.featureNowNext() && row.getNext() != null);
 
 		menu.setOnMenuItemClickListener(menuItem -> {
-			String ref = mCurrentItem.getString(Service.KEY_REFERENCE);
-			String name = mCurrentItem.getString(Service.KEY_NAME);
-			boolean showNext = false;
+			String ref = row.getServiceReference();
+			String name = row.getServiceName();
 			switch (menuItem.getItemId()) {
-				case R.id.menu_next_event:
-					showNext = true;
-				case R.id.menu_current_event:
-					EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(mCurrentItem, showNext);
-					getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+				case R.id.menu_next_event: {
+					Event next = row.getNext();
+					if (next != null) {
+						mCurrentItem = EpgListMapper.toExtendedHashMap(next);
+						EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(next);
+						getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+					}
 					break;
+				}
+				case R.id.menu_current_event: {
+					Event now = row.getNow();
+					if (now != null) {
+						mCurrentItem = EpgListMapper.toExtendedHashMap(now);
+						EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(now);
+						getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+					}
+					break;
+				}
 				case R.id.menu_browse_epg:
 					openEpg(ref, name);
 					break;
@@ -336,7 +382,12 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 					break;
 				case R.id.menu_stream:
 					try {
-						startActivity(IntentFactory.getStreamServiceIntent(getAppCompatActivity(), ref, name, mRef, mCurrentItem));
+						startActivity(IntentFactory.getStreamServiceIntent(
+								getAppCompatActivity(),
+								ref,
+								name,
+								mRef,
+								ServiceListMapperKt.serviceNowNextToExtendedHashMap(row)));
 					} catch (ActivityNotFoundException e) {
 						showToast(getText(R.string.missing_stream_player));
 					}
@@ -353,8 +404,8 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public void onDialogAction(int action, Object details, String dialogTag) {
 		if (action < Statics.ACTION_SET_TIMER || action > Statics.ACTION_FIND_SIMILAR)
 			return;
-		boolean isNext = (Boolean) details;
-		ExtendedHashMap event = isNext ? Event.fromNext(mCurrentItem) : mCurrentItem;
+		// Typed detail opens with mCurrentItem already set to the selected event hash.
+		ExtendedHashMap event = mCurrentItem;
 		switch (action) {
 			case Statics.ACTION_SET_TIMER:
 				setTimerById(event);

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -300,6 +300,9 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment
 	@Override
 	public void onEpgNowNextReady(boolean success, @NonNull List<ServiceNowNext> rows, @Nullable String errorText) {
 		mHttpHelper.onLoadFinished();
+		if (!isResumed()) {
+			return;
+		}
 		getAppCompatActivity().supportInvalidateOptionsMenu();
 		mRows.clear();
 		mListState.replaceAll(java.util.Collections.emptyList());

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -302,6 +302,14 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getEventsBlocking(shc, params, uri);
     }
 
+    @NonNull
+    public static List<net.reichholf.dreamdroid.enigma.ServiceNowNext> fetchEpgNowNext(
+            @NonNull SimpleHttpClient shc,
+            @NonNull List<NameValuePair> params,
+            @NonNull String uri) {
+        return EnigmaClient.getEpgNowNextBlocking(shc, params, uri);
+    }
+
     @Nullable
     public net.reichholf.dreamdroid.enigma.CurrentService fetchCurrentService() {
         return fetchCurrentService(mShc);

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
@@ -2,27 +2,29 @@ package net.reichholf.dreamdroid.ui.services
 
 import android.util.Log
 import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.enigma.ServiceNowNext
 import net.reichholf.dreamdroid.helpers.DateTime
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Python
-import net.reichholf.dreamdroid.helpers.enigma2.Event
+import net.reichholf.dreamdroid.helpers.enigma2.Event as EventKeys
 import net.reichholf.dreamdroid.helpers.enigma2.Service
 
 fun serviceListItemsFrom(maps: List<ExtendedHashMap>): List<ServiceListItem> {
     return maps.mapIndexed { index, map ->
-        Event.supplementReadables(map)
+        EventKeys.supplementReadables(map)
         val ref = map.getString(Service.KEY_REFERENCE) ?: ""
-        val name = map.getString(Event.KEY_SERVICE_NAME) ?: ""
+        val name = map.getString(EventKeys.KEY_SERVICE_NAME) ?: ""
         when {
             Service.isMarker(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.MARKER)
             Service.isDirectory(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.DIRECTORY)
             else -> {
-                val nextTitle = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_TITLE).orEmpty()
+                val nextTitle = map.getString(EventKeys.PREFIX_NEXT + EventKeys.KEY_EVENT_TITLE).orEmpty()
                 var max = 0
                 var cur = 0
-                val nowTime = map.getString(Event.KEY_CURRENT_TIME)
-                val duration = map.getString(Event.KEY_EVENT_DURATION)
-                val start = map.getString(Event.KEY_EVENT_START)
+                val nowTime = map.getString(EventKeys.KEY_CURRENT_TIME)
+                val duration = map.getString(EventKeys.KEY_EVENT_DURATION)
+                val start = map.getString(EventKeys.KEY_EVENT_START)
                 if (duration != null && start != null && duration != Python.NONE && start != Python.NONE) {
                     try {
                         max = (duration.toDouble() / 60).toLong().toInt()
@@ -36,16 +38,92 @@ fun serviceListItemsFrom(maps: List<ExtendedHashMap>): List<ServiceListItem> {
                     reference = ref,
                     name = name,
                     kind = ServiceRowKind.CHANNEL,
-                    nowTitle = map.getString(Event.KEY_EVENT_TITLE).orEmpty(),
-                    nowStart = map.getString(Event.KEY_EVENT_START_TIME_READABLE).orEmpty(),
-                    nowDuration = map.getString(Event.KEY_EVENT_DURATION_READABLE).orEmpty(),
+                    nowTitle = map.getString(EventKeys.KEY_EVENT_TITLE).orEmpty(),
+                    nowStart = map.getString(EventKeys.KEY_EVENT_START_TIME_READABLE).orEmpty(),
+                    nowDuration = map.getString(EventKeys.KEY_EVENT_DURATION_READABLE).orEmpty(),
                     nextTitle = nextTitle,
-                    nextStart = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_START_TIME_READABLE).orEmpty(),
-                    nextDuration = map.getString(Event.PREFIX_NEXT + Event.KEY_EVENT_DURATION_READABLE).orEmpty(),
+                    nextStart = map.getString(EventKeys.PREFIX_NEXT + EventKeys.KEY_EVENT_START_TIME_READABLE).orEmpty(),
+                    nextDuration = map.getString(EventKeys.PREFIX_NEXT + EventKeys.KEY_EVENT_DURATION_READABLE).orEmpty(),
                     progressMax = max,
                     progress = cur.coerceAtLeast(0),
                 )
             }
+        }
+    }
+}
+
+fun serviceListItemsFromNowNext(rows: List<ServiceNowNext>): List<ServiceListItem> {
+    return rows.mapIndexed { index, row ->
+        val ref = row.serviceReference
+        val name = row.serviceName
+        when {
+            Service.isMarker(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.MARKER)
+            Service.isDirectory(ref) -> ServiceListItem(index, ref, name, ServiceRowKind.DIRECTORY)
+            else -> {
+                val now = row.now
+                var max = 0
+                var cur = 0
+                if (now != null && now.duration.isNotEmpty() && now.start.isNotEmpty()
+                    && now.duration != Python.NONE && now.start != Python.NONE
+                ) {
+                    try {
+                        max = (now.duration.toDouble() / 60).toLong().toInt()
+                        cur = max - DateTime.getRemaining(now.duration, now.start, now.currentTime)
+                    } catch (e: Exception) {
+                        Log.e(DreamDroid.LOG_TAG, e.toString())
+                    }
+                }
+                ServiceListItem(
+                    index = index,
+                    reference = ref,
+                    name = name,
+                    kind = ServiceRowKind.CHANNEL,
+                    nowTitle = now?.title.orEmpty(),
+                    nowStart = now?.startTimeReadable.orEmpty(),
+                    nowDuration = now?.durationReadable.orEmpty(),
+                    nextTitle = row.next?.title.orEmpty(),
+                    nextStart = row.next?.startTimeReadable.orEmpty(),
+                    nextDuration = row.next?.durationReadable.orEmpty(),
+                    progressMax = max,
+                    progress = cur.coerceAtLeast(0),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Combined now+next hash for stream Intent / legacy edges that still expect PREFIX_NEXT keys.
+ */
+fun serviceNowNextToExtendedHashMap(row: ServiceNowNext): ExtendedHashMap {
+    val map = ExtendedHashMap()
+    map.put(EventKeys.KEY_SERVICE_REFERENCE, row.serviceReference)
+    map.put(EventKeys.KEY_SERVICE_NAME, row.serviceName)
+    putEventFields(map, "", row.now)
+    putEventFields(map, EventKeys.PREFIX_NEXT, row.next)
+    return map
+}
+
+private fun putEventFields(map: ExtendedHashMap, prefix: String, event: Event?) {
+    if (event == null) {
+        return
+    }
+    map.put(prefix + EventKeys.KEY_EVENT_ID, event.eventId)
+    map.put(prefix + EventKeys.KEY_EVENT_TITLE, event.title)
+    map.put(prefix + EventKeys.KEY_EVENT_START, event.start)
+    map.put(prefix + EventKeys.KEY_EVENT_DURATION, event.duration)
+    map.put(prefix + EventKeys.KEY_CURRENT_TIME, event.currentTime)
+    map.put(prefix + EventKeys.KEY_EVENT_DESCRIPTION, event.description)
+    map.put(prefix + EventKeys.KEY_EVENT_DESCRIPTION_EXTENDED, event.descriptionExtended)
+    map.put(prefix + EventKeys.KEY_EVENT_START_READABLE, event.startReadable)
+    map.put(prefix + EventKeys.KEY_EVENT_START_TIME_READABLE, event.startTimeReadable)
+    map.put(prefix + EventKeys.KEY_EVENT_DURATION_READABLE, event.durationReadable)
+    if (prefix.isEmpty()) {
+        if (event.serviceReference.isNotEmpty()) {
+            map.put(EventKeys.KEY_SERVICE_REFERENCE, event.serviceReference)
+        }
+        if (event.serviceName.isNotEmpty()) {
+            map.put(EventKeys.KEY_SERVICE_NAME, event.serviceName)
         }
     }
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/EpgNowNextParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/EpgNowNextParserTest.java
@@ -1,0 +1,71 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class EpgNowNextParserTest {
+    @Test
+    public void pairsConsecutiveEventsFromFixture() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/epgnownext.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<ServiceNowNext> rows = EpgNowNextParser.INSTANCE.parse(xml);
+
+        assertEquals(3, rows.size());
+
+        ServiceNowNext first = rows.get(0);
+        assertEquals("1:0:1:6DCA:44D:1:C00000:0:0:0:", first.getServiceReference());
+        assertEquals("Das Erste HD", first.getServiceName());
+        assertNotNull(first.getNow());
+        assertNotNull(first.getNext());
+        assertEquals("News Now", first.getNow().getTitle());
+        assertEquals("News Next", first.getNext().getTitle());
+        assertTrue(first.getNow().getDescriptionExtended().contains("\n"));
+
+        ServiceNowNext second = rows.get(1);
+        assertEquals("ZDF HD", second.getServiceName());
+        assertEquals("Sport Now", second.getNow().getTitle());
+        assertEquals("Sport Next", second.getNext().getTitle());
+
+        ServiceNowNext trailing = rows.get(2);
+        assertEquals("Arte HD", trailing.getServiceName());
+        assertEquals("Trailing Only", trailing.getNow().getTitle());
+        assertNull(trailing.getNext());
+    }
+
+    @Test
+    public void emptyXmlYieldsNoRows() {
+        assertEquals(0, EpgNowNextParser.INSTANCE.parse("").size());
+    }
+
+    @Test
+    public void singleEventIsNowOnlyRow() {
+        List<Event> events = EventParser.INSTANCE.parse(""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2eventlist>"
+                + "<e2event>"
+                + "<e2eventid>1</e2eventid>"
+                + "<e2eventstart>1893456000</e2eventstart>"
+                + "<e2eventduration>60</e2eventduration>"
+                + "<e2eventcurrenttime>1893456000</e2eventcurrenttime>"
+                + "<e2eventtitle>Solo</e2eventtitle>"
+                + "<e2eventdescription/>"
+                + "<e2eventdescriptionextended/>"
+                + "<e2eventservicereference>1:0:1:1:1:1:0:0:0:0:</e2eventservicereference>"
+                + "<e2eventservicename>TV</e2eventservicename>"
+                + "</e2event>"
+                + "</e2eventlist>");
+        List<ServiceNowNext> rows = EpgNowNextParser.INSTANCE.pairEvents(events);
+        assertEquals(1, rows.size());
+        assertEquals("Solo", rows.get(0).getNow().getTitle());
+        assertNull(rows.get(0).getNext());
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/EpgNowNextParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/EpgNowNextParserTest.java
@@ -68,4 +68,24 @@ public class EpgNowNextParserTest {
         assertEquals("Solo", rows.get(0).getNow().getTitle());
         assertNull(rows.get(0).getNext());
     }
+
+    @Test
+    public void flatEpgNowMustNotPairUnrelatedServices() throws Exception {
+        // epgservice.xml is a flat two-event list for one service; treat like epgnow: one row each.
+        InputStream in = getClass().getResourceAsStream("/web/epgservice.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Event> events = EventParser.INSTANCE.parse(xml);
+        assertEquals(2, events.size());
+        // Client maps flat lists without pairing (see EnigmaClient.getEpgNowNext for non-NOWNEXT).
+        List<ServiceNowNext> rows = new java.util.ArrayList<>();
+        for (Event event : events) {
+            rows.add(new ServiceNowNext(event.getServiceReference(), event.getServiceName(), event, null));
+        }
+        assertEquals(2, rows.size());
+        assertEquals("Tagesschau", rows.get(0).getNow().getTitle());
+        assertNull(rows.get(0).getNext());
+        assertEquals("N/A", rows.get(1).getNow().getTitle());
+        assertNull(rows.get(1).getNext());
+    }
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/ServiceListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/ServiceListMapperTest.java
@@ -1,0 +1,90 @@
+package net.reichholf.dreamdroid.ui.services;
+
+import net.reichholf.dreamdroid.enigma.EpgNowNextParser;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.enigma.ServiceNowNext;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ServiceListMapperTest {
+    @Test
+    public void mapsTypedNowNextRowsToComposeItems() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/epgnownext.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<ServiceNowNext> rows = EpgNowNextParser.INSTANCE.parse(xml);
+        List<ServiceListItem> items = ServiceListMapperKt.serviceListItemsFromNowNext(rows);
+
+        assertEquals(3, items.size());
+        ServiceListItem first = items.get(0);
+        assertEquals(ServiceRowKind.CHANNEL, first.getKind());
+        assertEquals("Das Erste HD", first.getName());
+        assertEquals("News Now", first.getNowTitle());
+        assertEquals("News Next", first.getNextTitle());
+        assertFalse(first.getNowStart().isEmpty());
+        assertTrue(first.getProgressMax() > 0);
+        assertTrue(first.getProgress() >= 0);
+
+        ServiceListItem trailing = items.get(2);
+        assertEquals("Trailing Only", trailing.getNowTitle());
+        assertEquals("", trailing.getNextTitle());
+    }
+
+    @Test
+    public void mapsMarkerAndDirectoryKinds() {
+        ServiceNowNext marker = new ServiceNowNext(
+                "1:64:1:0:0:0:0:0:0:0:",
+                "Favorites",
+                null,
+                null
+        );
+        ServiceNowNext directory = new ServiceNowNext(
+                "1:1:1:0:0:0:0:0:0:0:",
+                "Subfolder",
+                null,
+                null
+        );
+        List<ServiceListItem> items = ServiceListMapperKt.serviceListItemsFromNowNext(
+                java.util.Arrays.asList(marker, directory)
+        );
+        assertEquals(ServiceRowKind.MARKER, items.get(0).getKind());
+        assertEquals(ServiceRowKind.DIRECTORY, items.get(1).getKind());
+    }
+
+    @Test
+    public void combinedHashCarriesNowAndNextPrefixes() {
+        Event now = new Event(
+                "1", "Now", "100", "60", "100", "d", "x",
+                "1:0:1:1:1:1:0:0:0:0:", "TV", "r", "t", "1"
+        );
+        Event next = new Event(
+                "2", "Next", "160", "60", "100", "d2", "x2",
+                "1:0:1:1:1:1:0:0:0:0:", "TV", "r2", "t2", "1"
+        );
+        ServiceNowNext row = new ServiceNowNext("1:0:1:1:1:1:0:0:0:0:", "TV", now, next);
+        ExtendedHashMap map = ServiceListMapperKt.serviceNowNextToExtendedHashMap(row);
+        assertEquals("Now", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_TITLE));
+        assertEquals(
+                "Next",
+                map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.PREFIX_NEXT
+                        + net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_EVENT_TITLE)
+        );
+        assertEquals("TV", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME));
+    }
+
+    @Test
+    public void emptyTypedListYieldsNoItems() {
+        assertEquals(0, ServiceListMapperKt.serviceListItemsFromNowNext(Collections.emptyList()).size());
+    }
+}

--- a/app/src/test/resources/web/epgnownext.xml
+++ b/app/src/test/resources/web/epgnownext.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2eventlist>
+	<e2event>
+		<e2eventid>100</e2eventid>
+		<e2eventstart>1893456000</e2eventstart>
+		<e2eventduration>3600</e2eventduration>
+		<e2eventcurrenttime>1893457800</e2eventcurrenttime>
+		<e2eventtitle>News Now</e2eventtitle>
+		<e2eventdescription>Now desc</e2eventdescription>
+		<e2eventdescriptionextended>Now extended.Line two.</e2eventdescriptionextended>
+		<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>Das Erste HD</e2eventservicename>
+	</e2event>
+	<e2event>
+		<e2eventid>101</e2eventid>
+		<e2eventstart>1893459600</e2eventstart>
+		<e2eventduration>1800</e2eventduration>
+		<e2eventcurrenttime>1893457800</e2eventcurrenttime>
+		<e2eventtitle>News Next</e2eventtitle>
+		<e2eventdescription>Next desc</e2eventdescription>
+		<e2eventdescriptionextended>Next extended</e2eventdescriptionextended>
+		<e2eventservicereference>1:0:1:6DCA:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>Das Erste HD</e2eventservicename>
+	</e2event>
+	<e2event>
+		<e2eventid>200</e2eventid>
+		<e2eventstart>1893456000</e2eventstart>
+		<e2eventduration>7200</e2eventduration>
+		<e2eventcurrenttime>1893457800</e2eventcurrenttime>
+		<e2eventtitle>Sport Now</e2eventtitle>
+		<e2eventdescription>Sport</e2eventdescription>
+		<e2eventdescriptionextended/>
+		<e2eventservicereference>1:0:1:6DCB:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>ZDF HD</e2eventservicename>
+	</e2event>
+	<e2event>
+		<e2eventid>201</e2eventid>
+		<e2eventstart>1893463200</e2eventstart>
+		<e2eventduration>3600</e2eventduration>
+		<e2eventcurrenttime>1893457800</e2eventcurrenttime>
+		<e2eventtitle>Sport Next</e2eventtitle>
+		<e2eventdescription/>
+		<e2eventdescriptionextended/>
+		<e2eventservicereference>1:0:1:6DCB:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>ZDF HD</e2eventservicename>
+	</e2event>
+	<e2event>
+		<e2eventid>300</e2eventid>
+		<e2eventstart>1893456000</e2eventstart>
+		<e2eventduration>600</e2eventduration>
+		<e2eventcurrenttime>1893457800</e2eventcurrenttime>
+		<e2eventtitle>Trailing Only</e2eventtitle>
+		<e2eventdescription/>
+		<e2eventdescriptionextended/>
+		<e2eventservicereference>1:0:1:6DCC:44D:1:C00000:0:0:0:</e2eventservicereference>
+		<e2eventservicename>Arte HD</e2eventservicename>
+	</e2event>
+</e2eventlist>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -54,10 +54,11 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | timer-edit-compose | [#205](https://github.com/sreichholf/dreamDroid/pull/205) | merged | `TimerEditFragment` Compose form + `TimerEditScreenTest`; hash at save/pick edge; drop `timer_edit.xml`. |
 | movie-detail-compose | [#206](https://github.com/sreichholf/dreamDroid/pull/206) | merged | `MovieDetailBottomSheet` Compose + typed `enigma.Movie` edge; drop phone ButterKnife on detail + `movie_epg_dialog` phone layout. |
 | timer-service-pick-compose | [#207](https://github.com/sreichholf/dreamDroid/pull/207) | merged | `TimerServicePickFragment` Compose bouquet→service pick; drop unused `ServiceListFragment` + `dual_list_view`. |
+| hub-nownext-typed | open | — | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203) are on `main`. Remaining typed API: hub now/next, movies list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203) are on `main`. Remaining typed API: movies list path (hub now/next open as hub-nownext-typed). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Wave 3 phone screens complete on `main` through #206** (plus CI #204). Drawer shell and Leanback TV are later programs (Appendix H).
 
@@ -78,7 +79,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
-- Remaining typed API (not Wave 3 UI): hub now/next, movies list path (detail edge typed in #206).
+- Remaining typed API (not Wave 3 UI): hub now/next (this PR), movies list path (detail edge typed in #206).
 - Out of wave: drawer shell, Leanback `tv/`, VLC, widgets. See Appendix H for the one-by-one plan after Wave 3.
 
 ## How to read this
@@ -376,7 +377,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 | Surface | Code | Notes |
 | --- | --- | --- |
-| Channel / bouquet rows | Compose on `main` via #170 | Long-press, picons, popup menu. |
+| Channel / bouquet rows | Compose on `main` via #170; typed now/next in this PR | Long-press, picons, popup menu; `ServiceNowNext` load path. |
 | Movies list | Compose on `main` via #170 | Hub Movies destination. |
 | Timer list / edit | Compose list on `main` via #170/#203; edit #205; service pick #207 | List typed+Compose; edit Compose form (hash save/pick). |
 | Profile add/edit | Compose on `main` via #184 | Form Compose; list was #168. Autodiscovery stays Java. |
@@ -403,7 +404,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Other lists still use `ExtendedHashMap` through SAX handlers, `AsyncListLoader`, and `HttpFragmentHelper`.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (this PR). Movies list path still uses `ExtendedHashMap` through SAX handlers / loaders.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (4 files: phone `VideoOverlayFragment` + 3 Leanback TV). `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -417,7 +418,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183. **Still hash / in flight:** hub now/next, movies, timers, device info, signal remain.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183, timers #203, device info #199, signal #200. **Still hash / in flight:** hub now/next (this PR), movies list.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen). `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). #177: dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. ButterKnife still open while TV is frozen.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
@@ -474,7 +475,7 @@ Appendix G phone Compose screens are on `main` through #206 (+ CI #204). Phone B
 
 | Order | Slug | Notes |
 | --- | --- | --- |
-| 1 | typed hub now/next | `ServiceListPage` events — unlocks cleaner rows |
+| 1 | typed hub now/next | `ServiceListPage` events — open as `hub-nownext-typed` (this PR) |
 | 2 | typed movies list path | Detail edge already typed in #206 |
 
 Gate: unit + assemble; instrumented tests when the PR touches UI; Bugbot; land when authorized.

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -54,11 +54,11 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | timer-edit-compose | [#205](https://github.com/sreichholf/dreamDroid/pull/205) | merged | `TimerEditFragment` Compose form + `TimerEditScreenTest`; hash at save/pick edge; drop `timer_edit.xml`. |
 | movie-detail-compose | [#206](https://github.com/sreichholf/dreamDroid/pull/206) | merged | `MovieDetailBottomSheet` Compose + typed `enigma.Movie` edge; drop phone ButterKnife on detail + `movie_epg_dialog` phone layout. |
 | timer-service-pick-compose | [#207](https://github.com/sreichholf/dreamDroid/pull/207) | merged | `TimerServicePickFragment` Compose bouquet→service pick; drop unused `ServiceListFragment` + `dual_list_view`. |
-| hub-nownext-typed | open | — | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
+| hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203) are on `main`. Remaining typed API: movies list path (hub now/next open as hub-nownext-typed). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203/#209) are on `main`. Remaining typed API: movies list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Wave 3 phone screens complete on `main` through #206** (plus CI #204). Drawer shell and Leanback TV are later programs (Appendix H).
 
@@ -79,7 +79,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
-- Remaining typed API (not Wave 3 UI): hub now/next (this PR), movies list path (detail edge typed in #206).
+- Remaining typed API (not Wave 3 UI): movies list path (hub now/next typed in #209; detail edge typed in #206).
 - Out of wave: drawer shell, Leanback `tv/`, VLC, widgets. See Appendix H for the one-by-one plan after Wave 3.
 
 ## How to read this
@@ -377,7 +377,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 | Surface | Code | Notes |
 | --- | --- | --- |
-| Channel / bouquet rows | Compose on `main` via #170; typed now/next in this PR | Long-press, picons, popup menu; `ServiceNowNext` load path. |
+| Channel / bouquet rows | Compose on `main` via #170; typed now/next #209 | Long-press, picons, popup menu; `ServiceNowNext` load path. |
 | Movies list | Compose on `main` via #170 | Hub Movies destination. |
 | Timer list / edit | Compose list on `main` via #170/#203; edit #205; service pick #207 | List typed+Compose; edit Compose form (hash save/pick). |
 | Profile add/edit | Compose on `main` via #184 | Form Compose; list was #168. Autodiscovery stays Java. |
@@ -404,7 +404,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (this PR). Movies list path still uses `ExtendedHashMap` through SAX handlers / loaders.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (#209). Movies list path still uses `ExtendedHashMap` through SAX handlers / loaders.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (4 files: phone `VideoOverlayFragment` + 3 Leanback TV). `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -418,7 +418,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183, timers #203, device info #199, signal #200. **Still hash / in flight:** hub now/next (this PR), movies list.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183, timers #203, device info #199, signal #200, hub now/next #209. **Still hash / in flight:** movies list.
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen). `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). #177: dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. ButterKnife still open while TV is frozen.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
@@ -475,7 +475,7 @@ Appendix G phone Compose screens are on `main` through #206 (+ CI #204). Phone B
 
 | Order | Slug | Notes |
 | --- | --- | --- |
-| 1 | typed hub now/next | `ServiceListPage` events — open as `hub-nownext-typed` (this PR) |
+| 1 | typed hub now/next | `ServiceListPage` events — **merged** [#209](https://github.com/sreichholf/dreamDroid/pull/209) |
 | 2 | typed movies list path | Detail edge already typed in #206 |
 
 Gate: unit + assemble; instrumented tests when the PR touches UI; Bugbot; land when authorized.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add typed `ServiceNowNext` + `EpgNowNextParser` for `/web/epgnownext`.
- Wire hub TV/Radio `ServiceListPageFragment` through `GetEpgNowNextTask` / `EnigmaClient`; Compose rows from typed model.
- Keep `ExtendedHashMap` only at detail / timer / stream edges.
- Flat `/web/epgnow` fallback maps one row per event (no pairing).
- Unit tests for parser + mapper; docs Appendix H Phase 1 item 1.

## Test plan
- [x] JDK 17 unit + assemble + androidTest compile
- [x] Bugbot (fixed epgnow pairing; re-review clean expected)
- [ ] CI unit job

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

