### PR TITLE
feat(client): typed Movie for hub movies list

### DIFF
--- a/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
@@ -26,6 +26,17 @@ public class GetMovieListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>
 		if (isCancelled()) {
 			return false;
 		}
+		// Match AsyncListLoader requireLocsAndTags=true used by the old movies loader.
+		if (net.reichholf.dreamdroid.DreamDroid.getLocations().size() <= 1) {
+			if (!net.reichholf.dreamdroid.DreamDroid.loadLocations(getHttpClient())) {
+				android.util.Log.e(net.reichholf.dreamdroid.DreamDroid.LOG_TAG, "ERROR loading locations");
+			}
+		}
+		if (net.reichholf.dreamdroid.DreamDroid.getTags().size() <= 1) {
+			if (!net.reichholf.dreamdroid.DreamDroid.loadTags(getHttpClient())) {
+				android.util.Log.e(net.reichholf.dreamdroid.DreamDroid.LOG_TAG, "ERROR loading tags");
+			}
+		}
 		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
 		List<Movie> fetched = HttpFragmentHelper.fetchMovies(getHttpClient(), requestParams);
 		if (getHttpClient().hasError()) {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
@@ -8,9 +8,11 @@ import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GetMovieListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	@Nullable
 	private ArrayList<Movie> mMovies;
 
 	public GetMovieListTask(GetMovieListTaskHandler taskHandler) {
@@ -20,13 +22,23 @@ public class GetMovieListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>
 	@NonNull
 	@Override
 	protected Boolean doInBackground(ArrayList<NameValuePair> params) {
-		mMovies = new ArrayList<>();
+		mMovies = null;
 		if (isCancelled()) {
 			return false;
 		}
 		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
-		mMovies.addAll(HttpFragmentHelper.fetchMovies(getHttpClient(), requestParams));
-		return !getHttpClient().hasError();
+		List<Movie> fetched = HttpFragmentHelper.fetchMovies(getHttpClient(), requestParams);
+		if (getHttpClient().hasError()) {
+			mMovies = new ArrayList<>();
+			return false;
+		}
+		// Successful HTTP can still fail SAX; null means parse failure (not an empty movie list).
+		if (fetched == null) {
+			mMovies = new ArrayList<>();
+			return false;
+		}
+		mMovies = new ArrayList<>(fetched);
+		return true;
 	}
 
 	@Override
@@ -35,8 +47,17 @@ public class GetMovieListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>
 		if (isInvalid(handler)) {
 			return;
 		}
-		boolean success = Boolean.TRUE.equals(result);
-		handler.onMovieListReady(success, mMovies, success ? null : getErrorText());
+		boolean success = Boolean.TRUE.equals(result) && mMovies != null;
+		List<Movie> movies = mMovies != null ? mMovies : Collections.emptyList();
+		String errorText = null;
+		if (!success) {
+			if (getHttpClient().hasError()) {
+				errorText = getErrorText();
+			} else {
+				errorText = handler.getString(net.reichholf.dreamdroid.R.string.error_parsing);
+			}
+		}
+		handler.onMovieListReady(success, movies, errorText);
 	}
 
 	public interface GetMovieListTaskHandler extends AsyncHttpTaskBaseHandler {

--- a/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
+++ b/app/src/net/reichholf/dreamdroid/asynctask/GetMovieListTask.java
@@ -1,0 +1,45 @@
+package net.reichholf.dreamdroid.asynctask;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import net.reichholf.dreamdroid.enigma.Movie;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
+import net.reichholf.dreamdroid.helpers.NameValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetMovieListTask extends AsyncHttpTaskBase<ArrayList<NameValuePair>, String, Boolean> {
+	private ArrayList<Movie> mMovies;
+
+	public GetMovieListTask(GetMovieListTaskHandler taskHandler) {
+		super(taskHandler);
+	}
+
+	@NonNull
+	@Override
+	protected Boolean doInBackground(ArrayList<NameValuePair> params) {
+		mMovies = new ArrayList<>();
+		if (isCancelled()) {
+			return false;
+		}
+		List<NameValuePair> requestParams = params != null ? params : new ArrayList<>();
+		mMovies.addAll(HttpFragmentHelper.fetchMovies(getHttpClient(), requestParams));
+		return !getHttpClient().hasError();
+	}
+
+	@Override
+	protected void onPostExecute(Boolean result) {
+		GetMovieListTaskHandler handler = (GetMovieListTaskHandler) mTaskHandler.get();
+		if (isInvalid(handler)) {
+			return;
+		}
+		boolean success = Boolean.TRUE.equals(result);
+		handler.onMovieListReady(success, mMovies, success ? null : getErrorText());
+	}
+
+	public interface GetMovieListTaskHandler extends AsyncHttpTaskBaseHandler {
+		void onMovieListReady(boolean success, @NonNull List<Movie> movies, @Nullable String errorText);
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -101,11 +101,11 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
-    suspend fun getMovies(params: List<NameValuePair> = emptyList()): List<Movie> {
+    suspend fun getMovies(params: List<NameValuePair> = emptyList()): List<Movie>? {
         return withContext(Dispatchers.IO) {
             val requestParams = ArrayList(params)
             if (!http.fetchPageContent(URIStore.MOVIES, requestParams)) {
-                emptyList()
+                null
             } else {
                 MovieParser.parse(http.pageContentString)
             }
@@ -173,7 +173,7 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
 
         @JvmStatic
-        fun getMoviesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Movie> {
+        fun getMoviesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Movie>? {
             return runBlocking {
                 EnigmaClient(http).getMovies(params)
             }

--- a/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/EnigmaClient.kt
@@ -101,6 +101,17 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         }
     }
 
+    suspend fun getMovies(params: List<NameValuePair> = emptyList()): List<Movie> {
+        return withContext(Dispatchers.IO) {
+            val requestParams = ArrayList(params)
+            if (!http.fetchPageContent(URIStore.MOVIES, requestParams)) {
+                emptyList()
+            } else {
+                MovieParser.parse(http.pageContentString)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun getServicesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Service> {
@@ -158,6 +169,13 @@ class EnigmaClient(private val http: SimpleHttpClient) {
         fun getTimersBlocking(http: SimpleHttpClient): List<Timer>? {
             return runBlocking {
                 EnigmaClient(http).getTimers()
+            }
+        }
+
+        @JvmStatic
+        fun getMoviesBlocking(http: SimpleHttpClient, params: List<NameValuePair>): List<Movie> {
+            return runBlocking {
+                EnigmaClient(http).getMovies(params)
             }
         }
     }

--- a/app/src/net/reichholf/dreamdroid/enigma/MovieParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/MovieParser.kt
@@ -9,13 +9,15 @@ import java.io.StringReader
 import javax.xml.parsers.SAXParserFactory
 
 object MovieParser {
-    fun parse(xml: String): List<Movie> {
+    /**
+     * @return parsed movies, or null when XML cannot be parsed (distinct from a valid empty list).
+     */
+    fun parse(xml: String): List<Movie>? {
         if (xml.isEmpty()) {
-            return emptyList()
+            return null
         }
         return parseSanitized(xml, aggressive = false)
             ?: parseSanitized(xml, aggressive = true)
-            ?: emptyList()
     }
 
     private fun parseSanitized(xml: String, aggressive: Boolean): List<Movie>? {

--- a/app/src/net/reichholf/dreamdroid/enigma/MovieParser.kt
+++ b/app/src/net/reichholf/dreamdroid/enigma/MovieParser.kt
@@ -1,0 +1,165 @@
+package net.reichholf.dreamdroid.enigma
+
+import net.reichholf.dreamdroid.helpers.DateTime
+import net.reichholf.dreamdroid.helpers.Python
+import org.xml.sax.Attributes
+import org.xml.sax.InputSource
+import org.xml.sax.helpers.DefaultHandler
+import java.io.StringReader
+import javax.xml.parsers.SAXParserFactory
+
+object MovieParser {
+    fun parse(xml: String): List<Movie> {
+        if (xml.isEmpty()) {
+            return emptyList()
+        }
+        return parseSanitized(xml, aggressive = false)
+            ?: parseSanitized(xml, aggressive = true)
+            ?: emptyList()
+    }
+
+    private fun parseSanitized(xml: String, aggressive: Boolean): List<Movie>? {
+        return try {
+            val handler = MovieListHandler()
+            val factory = SAXParserFactory.newInstance()
+            factory.isValidating = false
+            val reader = factory.newSAXParser().xmlReader
+            reader.contentHandler = handler
+            reader.parse(InputSource(StringReader(XmlInput.sanitize(xml, aggressive))))
+            handler.movies
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+private class MovieListHandler : DefaultHandler() {
+    val movies = ArrayList<Movie>()
+
+    private var inMovie = false
+    private var inReference = false
+    private var inTitle = false
+    private var inDescription = false
+    private var inDescriptionEx = false
+    private var inName = false
+    private var inTime = false
+    private var inLength = false
+    private var inTags = false
+    private var inFilename = false
+    private var inFilesize = false
+
+    private val reference = StringBuilder()
+    private val title = StringBuilder()
+    private val description = StringBuilder()
+    private val descriptionExtended = StringBuilder()
+    private val serviceName = StringBuilder()
+    private val time = StringBuilder()
+    private val length = StringBuilder()
+    private val tags = StringBuilder()
+    private val fileName = StringBuilder()
+    private val fileSize = StringBuilder()
+
+    override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?) {
+        when (tag(localName, qName)) {
+            "e2movie" -> {
+                inMovie = true
+                reference.setLength(0)
+                title.setLength(0)
+                description.setLength(0)
+                descriptionExtended.setLength(0)
+                serviceName.setLength(0)
+                time.setLength(0)
+                length.setLength(0)
+                tags.setLength(0)
+                fileName.setLength(0)
+                fileSize.setLength(0)
+            }
+            "e2servicereference" -> inReference = true
+            "e2title" -> inTitle = true
+            "e2description" -> inDescription = true
+            "e2descriptionextended" -> inDescriptionEx = true
+            "e2servicename" -> inName = true
+            "e2time" -> inTime = true
+            "e2length" -> inLength = true
+            "e2tags" -> inTags = true
+            "e2filename" -> inFilename = true
+            "e2filesize" -> inFilesize = true
+        }
+    }
+
+    override fun endElement(uri: String?, localName: String?, qName: String?) {
+        when (tag(localName, qName)) {
+            "e2movie" -> {
+                inMovie = false
+                movies.add(buildMovie())
+            }
+            "e2servicereference" -> inReference = false
+            "e2title" -> inTitle = false
+            "e2description" -> inDescription = false
+            "e2descriptionextended" -> inDescriptionEx = false
+            "e2servicename" -> inName = false
+            "e2time" -> inTime = false
+            "e2length" -> inLength = false
+            "e2tags" -> inTags = false
+            "e2filename" -> inFilename = false
+            "e2filesize" -> inFilesize = false
+        }
+    }
+
+    override fun characters(ch: CharArray, start: Int, length: Int) {
+        if (!inMovie) {
+            return
+        }
+        when {
+            inReference -> reference.append(ch, start, length)
+            inTitle -> title.append(ch, start, length)
+            inDescription -> description.append(ch, start, length)
+            inDescriptionEx -> descriptionExtended.append(ch, start, length)
+            inName -> serviceName.append(ch, start, length)
+            inTime -> time.append(ch, start, length)
+            inLength -> this.length.append(ch, start, length)
+            inTags -> tags.append(ch, start, length)
+            inFilename -> fileName.append(ch, start, length)
+            inFilesize -> fileSize.append(ch, start, length)
+        }
+    }
+
+    private fun buildMovie(): Movie {
+        val timeRaw = time.toString()
+        var sizeRaw = fileSize.toString()
+        var sizeReadable = ""
+        if (sizeRaw.isNotEmpty()) {
+            var forCalc = sizeRaw
+            if (Python.NONE == forCalc) {
+                forCalc = "0"
+            }
+            try {
+                var size = forCalc.toLong()
+                size /= (1024 * 1024)
+                sizeReadable = "$size MB"
+            } catch (e: NumberFormatException) {
+                sizeReadable = ""
+            }
+        }
+        return Movie(
+            reference = reference.toString(),
+            title = title.toString(),
+            description = description.toString(),
+            descriptionExtended = descriptionExtended.toString(),
+            serviceName = serviceName.toString().replace("\\p{Cntrl}".toRegex(), ""),
+            time = timeRaw,
+            timeReadable = if (timeRaw.isNotEmpty()) DateTime.getDateTimeString(timeRaw) else "",
+            length = length.toString(),
+            tags = tags.toString(),
+            fileName = fileName.toString(),
+            fileSize = sizeRaw,
+            fileSizeReadable = sizeReadable,
+        )
+    }
+
+    private fun tag(localName: String?, qName: String?): String {
+        val raw = if (!localName.isNullOrEmpty()) localName else (qName ?: "")
+        val colon = raw.lastIndexOf(':')
+        return if (colon >= 0) raw.substring(colon + 1) else raw
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -31,15 +31,17 @@ import com.evernote.android.state.State;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.SimpleTextAdapter;
+import net.reichholf.dreamdroid.asynctask.GetMovieListTask;
+import net.reichholf.dreamdroid.enigma.Movie;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.MovieDetailBottomSheet;
 import net.reichholf.dreamdroid.fragment.dialogs.MultiChoiceDialog;
 import net.reichholf.dreamdroid.fragment.dialogs.PositiveNegativeDialog;
+import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Python;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Movie;
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult;
 import net.reichholf.dreamdroid.helpers.enigma2.Tag;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
@@ -54,13 +56,16 @@ import net.reichholf.dreamdroid.ui.services.MovieListState;
 import net.reichholf.dreamdroid.ui.services.MovieListStateKt;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Allows browsing recorded movies. Supports filtering by tags and locations
+ * Allows browsing recorded movies. Supports filtering by tags and locations.
+ * Compose Material 3 list of typed {@link Movie}; delete/stream still take ExtendedHashMap at the edge.
  *
  * @author sreichholf
  */
-public class MovieListFragment extends BaseHttpRecyclerFragment implements MultiChoiceDialog.MultiChoiceDialogListener {
+public class MovieListFragment extends BaseHttpRecyclerFragment
+		implements MultiChoiceDialog.MultiChoiceDialogListener, GetMovieListTask.GetMovieListTaskHandler {
 	public static String ARGUMENT_LOCATION = "location";
 	private boolean mTagsChanged;
 	private boolean mReloadOnSimpleResult;
@@ -69,7 +74,10 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 	@State public ArrayList<String> mSelectedTags;
 	@State public ArrayList<String> mOldTags;
 	@State public ExtendedHashMap mMovie;
+	private final ArrayList<Movie> mMovies = new ArrayList<>();
 	private MovieListState mListState;
+	@Nullable
+	private GetMovieListTask mMovieListTask;
 
 	@Nullable
 	private ProgressDialog mProgress;
@@ -137,11 +145,22 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
 		mAdapter = new SimpleTextAdapter(mMapList, R.layout.movie_list_item, new String[]{
-				Movie.KEY_TITLE, Movie.KEY_SERVICE_NAME, Movie.KEY_FILE_SIZE_READABLE, Movie.KEY_TIME_READABLE,
-				Movie.KEY_LENGTH}, new int[]{R.id.movie_title, R.id.service_name, R.id.file_size, R.id.event_start,
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_TITLE,
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_SERVICE_NAME,
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_SIZE_READABLE,
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_TIME_READABLE,
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_LENGTH}, new int[]{R.id.movie_title, R.id.service_name, R.id.file_size, R.id.event_start,
 				R.id.event_duration});
 		getRecyclerView().setAdapter(mAdapter);
 		super.onActivityCreated(savedInstanceState);
+	}
+
+	@Override
+	public void onDestroy() {
+		if (mMovieListTask != null) {
+			mMovieListTask.cancel(true);
+		}
+		super.onDestroy();
 	}
 
 	@Override
@@ -184,21 +203,24 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 
 	@Override
 	public void onItemClick(RecyclerView parent, @NonNull View view, int position, long id) {
-		onMovieItemClick(view, position, false);
+		// Compose owns clicks.
 	}
 
 	@Override
 	public boolean onItemLongClick(RecyclerView parent, @NonNull View view, int position, long id) {
-		onMovieItemClick(view, position, true);
 		return true;
 	}
 
 	private void onMovieItemClick(@NonNull View view, int position, boolean isLong) {
-	mMovie = mMapList.get(position);
+		if (position < 0 || position >= mMovies.size()) {
+			return;
+		}
+		Movie typed = mMovies.get(position);
+		mMovie = MovieListMapperKt.movieToExtendedHashMap(typed);
 		boolean isInsta = PreferenceManager.getDefaultSharedPreferences(getAppCompatActivity()).getBoolean(
 				DreamDroid.PREFS_KEY_INSTANT_ZAP, false);
 		if ((isInsta && !isLong) || (!isInsta && isLong)) {
-			zapTo(mMovie.getString(Movie.KEY_REFERENCE));
+			zapTo(typed.getReference());
 		} else {
 			showPopupMenu(view);
 		}
@@ -223,7 +245,8 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 
 		mProgress = ProgressDialog.show(getAppCompatActivity(), "", getText(R.string.deleting), true);
 		mReloadOnSimpleResult = true;
-		execSimpleResultTask(new MovieDeleteRequestHandler(), Movie.getDeleteParams(mMovie));
+		execSimpleResultTask(new MovieDeleteRequestHandler(),
+				net.reichholf.dreamdroid.helpers.enigma2.Movie.getDeleteParams(mMovie));
 	}
 
 	@Override
@@ -261,20 +284,60 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 	@NonNull
 	@Override
 	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
-		return new AsyncListLoader(getAppCompatActivity(), new MovieListRequestHandler(), true, args);
+		// Movies list no longer starts this loader. BaseHttpRecyclerFragment still requires LoaderCallbacks.
+		return new AsyncListLoader(getAppCompatActivity(), new MovieListRequestHandler(), false, args);
 	}
 
 	@Override
 	public void onLoadFinished(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader,
 							   @NonNull LoaderResult<ArrayList<ExtendedHashMap>> result) {
-		//when popping fromt he backstack (e.g. after epg search) onStart will restore the loader which will in return call onLoadfinished
-		//because this in done twice (in onStart and in onResumed and we are not ready to handle this before onResume, we ignore any onLoadFinished
-		//that happens while we are not in a Resumed state
-		if (!isResumed())
+		// Unused: rows come from GetMovieListTask / EnigmaClient.
+	}
+
+	@Override
+	protected void reload() {
+		mReload = false;
+		if (mMovies.isEmpty())
+			setEmptyText(getText(R.string.loading), R.drawable.ic_loading_48dp);
+		else
+			setEmptyText(null);
+		loadMovies();
+	}
+
+	private void loadMovies() {
+		mHttpHelper.onLoadStarted();
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(getString(R.string.loading));
+		}
+		if (mMovieListTask != null) {
+			mMovieListTask.cancel(true);
+		}
+		mMovieListTask = new GetMovieListTask(this);
+		mMovieListTask.execute(getHttpParams(HttpFragmentHelper.LOADER_DEFAULT_ID));
+	}
+
+	@Override
+	public void onMovieListReady(boolean success, @NonNull List<Movie> movies, @Nullable String errorText) {
+		mHttpHelper.onLoadFinished();
+		if (!isResumed()) {
 			return;
-		super.onLoadFinished(loader, result);
-		getAppCompatActivity().setTitle(mCurrentLocation);
-		mListState.replaceAll(MovieListMapperKt.movieListItemsFrom(mMapList));
+		}
+		mMovies.clear();
+		mListState.replaceAll(java.util.Collections.emptyList());
+		if (!success) {
+			setEmptyText(errorText);
+			return;
+		}
+		setEmptyText(null);
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(mCurrentLocation);
+		}
+		if (movies.isEmpty()) {
+			setEmptyText(getText(R.string.no_list_item));
+		} else {
+			mMovies.addAll(movies);
+			mListState.replaceAll(MovieListMapperKt.movieListItemsFromMovies(mMovies));
+		}
 	}
 
 	private void onComposeClick(@NonNull MovieListItem item, boolean isLong) {
@@ -301,21 +364,28 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 	public boolean onMovieAction(int action) {
 		switch (action) {
 			case R.id.menu_info: {
-				if(mMovie.getString(Movie.KEY_DESCRIPTION_EXTENDED) == null){
+				if(mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_DESCRIPTION_EXTENDED) == null){
 					showToast(getString(R.string.no_epg_available));
 					break;
 				}
-				getMultiPaneHandler().showDialogFragment(MovieDetailBottomSheet.newInstance(new Movie(mMovie)), "movie_detail_dialog");
+				Movie typed = findSelectedTypedMovie();
+				if (typed != null) {
+					getMultiPaneHandler().showDialogFragment(MovieDetailBottomSheet.newInstance(typed), "movie_detail_dialog");
+				} else {
+					getMultiPaneHandler().showDialogFragment(
+							MovieDetailBottomSheet.newInstance(new net.reichholf.dreamdroid.helpers.enigma2.Movie(mMovie)),
+							"movie_detail_dialog");
+				}
 				break;
 			}
 
 			case R.id.menu_zap:
-				zapTo(mMovie.getString(Movie.KEY_REFERENCE));
+				zapTo(mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_REFERENCE));
 				break;
 
 			case R.id.menu_delete:
 				getMultiPaneHandler().showDialogFragment(
-						PositiveNegativeDialog.newInstance(mMovie.getString(Movie.KEY_TITLE), R.string.delete_confirm,
+						PositiveNegativeDialog.newInstance(mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_TITLE), R.string.delete_confirm,
 								android.R.string.yes, Statics.ACTION_DELETE_CONFIRMED, android.R.string.no,
 								Statics.ACTION_NONE), "dialog_delete_movie_confirm");
 				break;
@@ -326,7 +396,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 
 			case R.id.menu_download:
 				ArrayList<NameValuePair> params = new ArrayList<>();
-				params.add(new NameValuePair("file", mMovie.getString(Movie.KEY_FILE_NAME)));
+				params.add(new NameValuePair("file", mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_NAME)));
 				String url = getHttpClient().buildUrl(URIStore.FILE, params);
 
 				Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
@@ -335,8 +405,11 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 
 			case R.id.menu_stream:
 				try {
-					startActivity(IntentFactory.getStreamFileIntent(getAppCompatActivity(), mMovie.getString(Movie.KEY_REFERENCE), mMovie.getString(Movie.KEY_FILE_NAME),
-							mMovie.getString(Movie.KEY_TITLE), mMovie));
+					startActivity(IntentFactory.getStreamFileIntent(getAppCompatActivity(),
+							mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_REFERENCE),
+							mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_NAME),
+							mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_TITLE),
+							mMovie));
 				} catch (ActivityNotFoundException e) {
 					showToast(getText(R.string.missing_stream_player));
 				}
@@ -345,6 +418,21 @@ public class MovieListFragment extends BaseHttpRecyclerFragment implements Multi
 				return false;
 		}
 		return true;
+	}
+
+	@Nullable
+	private Movie findSelectedTypedMovie() {
+		if (mMovie == null) {
+			return null;
+		}
+		String ref = mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_REFERENCE);
+		String file = mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_NAME);
+		for (Movie movie : mMovies) {
+			if (movie.getReference().equals(ref) && movie.getFileName().equals(file)) {
+				return movie;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -78,9 +78,23 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 	private MovieListState mListState;
 	@Nullable
 	private GetMovieListTask mMovieListTask;
+	@Nullable
+	private PendingMovieList mPendingMovieList;
 
 	@Nullable
 	private ProgressDialog mProgress;
+
+	private static final class PendingMovieList {
+		final boolean success;
+		@NonNull final List<Movie> movies;
+		@Nullable final String errorText;
+
+		PendingMovieList(boolean success, @NonNull List<Movie> movies, @Nullable String errorText) {
+			this.success = success;
+			this.movies = movies;
+			this.errorText = errorText;
+		}
+	}
 
 	@Override
 	public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -161,6 +175,16 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 			mMovieListTask.cancel(true);
 		}
 		super.onDestroy();
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		if (mPendingMovieList != null) {
+			PendingMovieList pending = mPendingMovieList;
+			mPendingMovieList = null;
+			applyMovieList(pending.success, pending.movies, pending.errorText);
+		}
 	}
 
 	@Override
@@ -320,18 +344,23 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 	public void onMovieListReady(boolean success, @NonNull List<Movie> movies, @Nullable String errorText) {
 		mHttpHelper.onLoadFinished();
 		if (!isResumed()) {
+			mPendingMovieList = new PendingMovieList(success, new ArrayList<>(movies), errorText);
 			return;
 		}
+		applyMovieList(success, movies, errorText);
+	}
+
+	private void applyMovieList(boolean success, @NonNull List<Movie> movies, @Nullable String errorText) {
 		mMovies.clear();
 		mListState.replaceAll(java.util.Collections.emptyList());
+		if (getAppCompatActivity() != null) {
+			getAppCompatActivity().setTitle(mCurrentLocation != null ? mCurrentLocation : getBaseTitle());
+		}
 		if (!success) {
 			setEmptyText(errorText);
 			return;
 		}
 		setEmptyText(null);
-		if (getAppCompatActivity() != null) {
-			getAppCompatActivity().setTitle(mCurrentLocation);
-		}
 		if (movies.isEmpty()) {
 			setEmptyText(getText(R.string.no_list_item));
 		} else {

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -364,7 +364,9 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 	public boolean onMovieAction(int action) {
 		switch (action) {
 			case R.id.menu_info: {
-				if(mMovie.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_DESCRIPTION_EXTENDED) == null){
+				String descriptionEx = mMovie.getString(
+						net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_DESCRIPTION_EXTENDED);
+				if (descriptionEx == null || descriptionEx.isEmpty()) {
 					showToast(getString(R.string.no_epg_available));
 					break;
 				}

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -340,7 +340,7 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getTimersBlocking(shc);
     }
 
-    @NonNull
+    @Nullable
     public static List<net.reichholf.dreamdroid.enigma.Movie> fetchMovies(
             @NonNull SimpleHttpClient shc,
             @NonNull List<NameValuePair> params) {

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -340,6 +340,13 @@ public class HttpFragmentHelper implements SimpleResultTask.SimpleResultTaskHand
         return EnigmaClient.getTimersBlocking(shc);
     }
 
+    @NonNull
+    public static List<net.reichholf.dreamdroid.enigma.Movie> fetchMovies(
+            @NonNull SimpleHttpClient shc,
+            @NonNull List<NameValuePair> params) {
+        return EnigmaClient.getMoviesBlocking(shc, params);
+    }
+
     public void onLoadStarted() {
         if (mIsReloading)
             return;

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
@@ -1,17 +1,48 @@
 package net.reichholf.dreamdroid.ui.services
 
+import net.reichholf.dreamdroid.enigma.Movie
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
-import net.reichholf.dreamdroid.helpers.enigma2.Movie
+import net.reichholf.dreamdroid.helpers.enigma2.Movie as MovieKeys
 
 fun movieListItemsFrom(maps: List<ExtendedHashMap>): List<MovieListItem> {
     return maps.mapIndexed { index, map ->
         MovieListItem(
             index = index,
-            title = map.getString(Movie.KEY_TITLE).orEmpty(),
-            serviceName = map.getString(Movie.KEY_SERVICE_NAME).orEmpty(),
-            fileSize = map.getString(Movie.KEY_FILE_SIZE_READABLE).orEmpty(),
-            time = map.getString(Movie.KEY_TIME_READABLE).orEmpty(),
-            length = map.getString(Movie.KEY_LENGTH).orEmpty(),
+            title = map.getString(MovieKeys.KEY_TITLE).orEmpty(),
+            serviceName = map.getString(MovieKeys.KEY_SERVICE_NAME).orEmpty(),
+            fileSize = map.getString(MovieKeys.KEY_FILE_SIZE_READABLE).orEmpty(),
+            time = map.getString(MovieKeys.KEY_TIME_READABLE).orEmpty(),
+            length = map.getString(MovieKeys.KEY_LENGTH).orEmpty(),
         )
     }
+}
+
+fun movieListItemsFromMovies(movies: List<Movie>): List<MovieListItem> {
+    return movies.mapIndexed { index, movie ->
+        MovieListItem(
+            index = index,
+            title = movie.title,
+            serviceName = movie.serviceName,
+            fileSize = movie.fileSizeReadable,
+            time = movie.timeReadable,
+            length = movie.length,
+        )
+    }
+}
+
+fun movieToExtendedHashMap(movie: Movie): ExtendedHashMap {
+    val map = ExtendedHashMap()
+    map.put(MovieKeys.KEY_REFERENCE, movie.reference)
+    map.put(MovieKeys.KEY_TITLE, movie.title)
+    map.put(MovieKeys.KEY_DESCRIPTION, movie.description)
+    map.put(MovieKeys.KEY_DESCRIPTION_EXTENDED, movie.descriptionExtended)
+    map.put(MovieKeys.KEY_SERVICE_NAME, movie.serviceName)
+    map.put(MovieKeys.KEY_TIME, movie.time)
+    map.put(MovieKeys.KEY_TIME_READABLE, movie.timeReadable)
+    map.put(MovieKeys.KEY_LENGTH, movie.length)
+    map.put(MovieKeys.KEY_TAGS, movie.tags)
+    map.put(MovieKeys.KEY_FILE_NAME, movie.fileName)
+    map.put(MovieKeys.KEY_FILE_SIZE, movie.fileSize)
+    map.put(MovieKeys.KEY_FILE_SIZE_READABLE, movie.fileSizeReadable)
+    return map
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
@@ -1,0 +1,71 @@
+package net.reichholf.dreamdroid.enigma;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MovieParserTest {
+    @Test
+    public void parsesMovielistFixture() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/movielist.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        assertEquals(2, movies.size());
+
+        Movie first = movies.get(0);
+        assertEquals("Evening News", first.getTitle());
+        assertEquals("Das Erste HD", first.getServiceName());
+        assertEquals("45", first.getLength());
+        assertEquals("news sports", first.getTags());
+        assertEquals("/media/hdd/movie/news.ts", first.getFileName());
+        assertEquals("104857600", first.getFileSize());
+        assertEquals("100 MB", first.getFileSizeReadable());
+        assertFalse(first.getTimeReadable().isEmpty());
+        assertTrue(first.getDescriptionExtended().contains("Full bulletin."));
+
+        Movie second = movies.get(1);
+        assertEquals("Empty Size", second.getTitle());
+        assertEquals("ZDF HD", second.getServiceName());
+        assertEquals("None", second.getFileSize());
+        assertEquals("0 MB", second.getFileSizeReadable());
+    }
+
+    @Test
+    public void stripsControlCharactersFromServiceName() {
+        String xml = ""
+                + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<e2movielist><e2movie>"
+                + "<e2servicereference>1:0:0:0:0:0:0:0:0:0:/f.ts</e2servicereference>"
+                + "<e2title>T</e2title>"
+                + "<e2description/>"
+                + "<e2descriptionextended/>"
+                + "<e2servicename>ZDF\u0001HD</e2servicename>"
+                + "<e2time>1893456000</e2time>"
+                + "<e2length>1</e2length>"
+                + "<e2tags/>"
+                + "<e2filename>/f.ts</e2filename>"
+                + "<e2filesize>0</e2filesize>"
+                + "</e2movie></e2movielist>";
+        List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        assertEquals(1, movies.size());
+        assertEquals("ZDFHD", movies.get(0).getServiceName());
+    }
+
+    @Test
+    public void emptyXmlYieldsNoMovies() {
+        assertEquals(0, MovieParser.INSTANCE.parse("").size());
+    }
+
+    @Test
+    public void malformedXmlYieldsNoMovies() {
+        assertEquals(0, MovieParser.INSTANCE.parse("<e2movielist><e2movie>").size());
+    }
+}

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
@@ -56,17 +56,18 @@ public class MovieParserTest {
                 + "<e2filesize>0</e2filesize>"
                 + "</e2movie></e2movielist>";
         List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        assertNotNull(movies);
         assertEquals(1, movies.size());
         assertEquals("ZDFHD", movies.get(0).getServiceName());
     }
 
     @Test
-    public void emptyXmlYieldsNoMovies() {
-        assertEquals(0, MovieParser.INSTANCE.parse("").size());
+    public void emptyXmlYieldsNull() {
+        assertEquals(null, MovieParser.INSTANCE.parse(""));
     }
 
     @Test
-    public void malformedXmlYieldsNoMovies() {
-        assertEquals(0, MovieParser.INSTANCE.parse("<e2movielist><e2movie>").size());
+    public void malformedXmlYieldsNull() {
+        assertEquals(null, MovieParser.INSTANCE.parse("<e2movielist><e2movie>"));
     }
 }

--- a/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/enigma/MovieParserTest.java
@@ -18,6 +18,7 @@ public class MovieParserTest {
         assertNotNull(in);
         String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        assertNotNull(movies);
         assertEquals(2, movies.size());
 
         Movie first = movies.get(0);

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
@@ -21,6 +21,7 @@ public class MovieListMapperTest {
         assertNotNull(in);
         String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        assertNotNull(movies);
         List<MovieListItem> items = MovieListMapperKt.movieListItemsFromMovies(movies);
         assertEquals(2, items.size());
         assertEquals("Evening News", items.get(0).getTitle());

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
@@ -1,0 +1,59 @@
+package net.reichholf.dreamdroid.ui.services;
+
+import net.reichholf.dreamdroid.enigma.Movie;
+import net.reichholf.dreamdroid.enigma.MovieParser;
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MovieListMapperTest {
+    @Test
+    public void mapsTypedMoviesToComposeItems() throws Exception {
+        InputStream in = getClass().getResourceAsStream("/web/movielist.xml");
+        assertNotNull(in);
+        String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        List<Movie> movies = MovieParser.INSTANCE.parse(xml);
+        List<MovieListItem> items = MovieListMapperKt.movieListItemsFromMovies(movies);
+        assertEquals(2, items.size());
+        assertEquals("Evening News", items.get(0).getTitle());
+        assertEquals("100 MB", items.get(0).getFileSize());
+        assertEquals("Empty Size", items.get(1).getTitle());
+        assertEquals("0 MB", items.get(1).getFileSize());
+    }
+
+    @Test
+    public void toExtendedHashMapKeepsLegacyKeys() {
+        Movie movie = new Movie(
+                "ref",
+                "Title",
+                "desc",
+                "ext",
+                "Service",
+                "100",
+                "readable",
+                "30",
+                "tag",
+                "/file.ts",
+                "1024",
+                "0 MB"
+        );
+        ExtendedHashMap map = MovieListMapperKt.movieToExtendedHashMap(movie);
+        assertEquals("Title", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_TITLE));
+        assertEquals("ref", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_REFERENCE));
+        assertEquals("/file.ts", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_NAME));
+        assertEquals("0 MB", map.getString(net.reichholf.dreamdroid.helpers.enigma2.Movie.KEY_FILE_SIZE_READABLE));
+    }
+
+    @Test
+    public void emptyTypedListYieldsNoItems() {
+        assertEquals(0, MovieListMapperKt.movieListItemsFromMovies(Collections.emptyList()).size());
+    }
+}

--- a/app/src/test/resources/web/movielist.xml
+++ b/app/src/test/resources/web/movielist.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e2movielist>
+	<e2movie>
+		<e2servicereference>1:0:0:0:0:0:0:0:0:0:/media/hdd/movie/news.ts</e2servicereference>
+		<e2title>Evening News</e2title>
+		<e2description>Daily news</e2description>
+		<e2descriptionextended>Full bulletin.Weather at the end.</e2descriptionextended>
+		<e2servicename>Das Erste HD</e2servicename>
+		<e2time>1893456000</e2time>
+		<e2length>45</e2length>
+		<e2tags>news sports</e2tags>
+		<e2filename>/media/hdd/movie/news.ts</e2filename>
+		<e2filesize>104857600</e2filesize>
+	</e2movie>
+	<e2movie>
+		<e2servicereference>1:0:0:0:0:0:0:0:0:0:/media/hdd/movie/empty.ts</e2servicereference>
+		<e2title>Empty Size</e2title>
+		<e2description/>
+		<e2descriptionextended/>
+		<e2servicename>ZDF HD</e2servicename>
+		<e2time>1893460000</e2time>
+		<e2length>10</e2length>
+		<e2tags/>
+		<e2filename>/media/hdd/movie/empty.ts</e2filename>
+		<e2filesize>None</e2filesize>
+	</e2movie>
+</e2movielist>

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -55,10 +55,11 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | movie-detail-compose | [#206](https://github.com/sreichholf/dreamDroid/pull/206) | merged | `MovieDetailBottomSheet` Compose + typed `enigma.Movie` edge; drop phone ButterKnife on detail + `movie_epg_dialog` phone layout. |
 | timer-service-pick-compose | [#207](https://github.com/sreichholf/dreamDroid/pull/207) | merged | `TimerServicePickFragment` Compose bouquet→service pick; drop unused `ServiceListFragment` + `dual_list_view`. |
 | hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
+| movies-typed | open | — | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
-Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203/#209) are on `main`. Remaining typed API: movies list path. Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
+Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203/#209) are on `main`. Remaining typed API: movies list path (this PR). Dead-weight deletes must not drop ButterKnife (still used by frozen Leanback TV).
 
 Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Wave 3 phone screens complete on `main` through #206** (plus CI #204). Drawer shell and Leanback TV are later programs (Appendix H).
 
@@ -79,7 +80,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
-- Remaining typed API (not Wave 3 UI): movies list path (hub now/next typed in #209; detail edge typed in #206).
+- Remaining typed API (not Wave 3 UI): movies list path (this PR; hub now/next typed in #209; detail edge typed in #206).
 - Out of wave: drawer shell, Leanback `tv/`, VLC, widgets. See Appendix H for the one-by-one plan after Wave 3.
 
 ## How to read this
@@ -378,7 +379,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 | Surface | Code | Notes |
 | --- | --- | --- |
 | Channel / bouquet rows | Compose on `main` via #170; typed now/next #209 | Long-press, picons, popup menu; `ServiceNowNext` load path. |
-| Movies list | Compose on `main` via #170 | Hub Movies destination. |
+| Movies list | Compose on `main` via #170; typed list in this PR | Hub Movies destination; `enigma.Movie` load path. |
 | Timer list / edit | Compose list on `main` via #170/#203; edit #205; service pick #207 | List typed+Compose; edit Compose form (hash save/pick). |
 | Profile add/edit | Compose on `main` via #184 | Form Compose; list was #168. Autodiscovery stays Java. |
 | Share / pick profile | Compose on `main` via #196 | Compose list; Room profiles; dropped `ProfileAdapter`. |
@@ -404,7 +405,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 ### Still the old data stack
 
-- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (#209). Movies list path still uses `ExtendedHashMap` through SAX handlers / loaders.
+- Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (#209). Movies list loads typed `enigma.Movie` (this PR). Leanback movie browse still uses hash SAX.
 - Enigma2 HTTP is still `HttpURLConnection` + `asynctask/*`. Picons still Picasso + OkHttp 3.14.9.
 - Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
 - ButterKnife (4 files: phone `VideoOverlayFragment` + 3 Leanback TV). `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
@@ -418,7 +419,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Sensible wave-2 shapes (pick one, do not do all at once)
 
 1. **Finish TV & Movies** — Compose channel/movie/timer rows, drop `ServiceAdapter` on the pager path, feed typed `Service`/`Movie`/`Timer`. Highest continuity with #169. **Done on `main` as #170.**
-2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183, timers #203, device info #199, signal #200, hub now/next #209. **Still hash / in flight:** movies list.
+2. **Retire `ExtendedHashMap` on one more list path at a time** — EPG, zap, current event. UI can stay XML until the parser boundary is typed. Stops the dual model from rotting. **Done on `main`:** Zap #173, Service EPG #176, bouquet EPG #179, search EPG #180, PickService #181, CurrentService #183, timers #203, device info #199, signal #200, hub now/next #209. **In flight:** movies list (this PR).
 3. **Replace the drawer shell** — `NavigationHelper` + `MainActivity` in Compose Navigation. Touches every screen. Do this only after a few more destinations are Compose, or it wraps XML forever.
 4. **Kill dead weight without UI rewrite** — ButterKnife (not while TV is frozen). `android-retrostreams` and leftover `res/service_list_pager.xml` dropped in **#172**. MediaPlayer UI + MultiDex lib + orphan layouts in **#175** (merged). #177: dead `EpgTimelineFragment`, `legacy-preference-v14`, `legacy-support-v4`, unused menus, GONE bottom nav. ButterKnife still open while TV is frozen.
 5. **TV program** — Leanback → Compose for TV. Separate program. Do not mix into phone PRs.
@@ -476,7 +477,7 @@ Appendix G phone Compose screens are on `main` through #206 (+ CI #204). Phone B
 | Order | Slug | Notes |
 | --- | --- | --- |
 | 1 | typed hub now/next | `ServiceListPage` events — **merged** [#209](https://github.com/sreichholf/dreamDroid/pull/209) |
-| 2 | typed movies list path | Detail edge already typed in #206 |
+| 2 | typed movies list path | Detail edge already typed in #206 — open as `movies-typed` (this PR) |
 
 Gate: unit + assemble; instrumented tests when the PR touches UI; Bugbot; land when authorized.
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -55,7 +55,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | movie-detail-compose | [#206](https://github.com/sreichholf/dreamDroid/pull/206) | merged | `MovieDetailBottomSheet` Compose + typed `enigma.Movie` edge; drop phone ButterKnife on detail + `movie_epg_dialog` phone layout. |
 | timer-service-pick-compose | [#207](https://github.com/sreichholf/dreamDroid/pull/207) | merged | `TimerServicePickFragment` Compose bouquet→service pick; drop unused `ServiceListFragment` + `dual_list_view`. |
 | hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
-| movies-typed | open | — | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
+| movies-typed | [#210](https://github.com/sreichholf/dreamDroid/pull/210) | merged | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `MovieParser` + `EnigmaClient.getMovies` for `/web/movielist`.
- Wire hub `MovieListFragment` through `GetMovieListTask`; Compose rows from typed `enigma.Movie`.
- Prefer typed `MovieDetailBottomSheet`; keep hash only for delete/stream Intent edges.
- Prefetch locations/tags like the old loader; surface parse failures; empty extended desc = no EPG.
- Unit tests + docs Appendix H Phase 1 item 2.

## Test plan
- [x] JDK 17 unit + assemble
- [x] Bugbot (fixes applied; re-review)
- [ ] CI unit job

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

