### PR TITLE
feat(ui): Compose drawer chrome (Phase 2.1a)

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenHostTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenHostTest.kt
@@ -1,0 +1,90 @@
+package net.reichholf.dreamdroid.ui.drawer
+
+import android.view.ContextThemeWrapper
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.preference.PreferenceManager
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Hosts [DrawerScreen] in a [ComposeView] under the app View theme the way
+ * [R.layout.dualpane] does — catches LocalContentColor leaks from the host.
+ */
+class DrawerScreenHostTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun contentColorIsOnSurfaceInsideNightViewHost() {
+        var localContent = Color.Unspecified
+        var onSurface = Color.Unspecified
+        val activity = composeRule.activity
+        composeRule.runOnUiThread {
+            val themed = ContextThemeWrapper(activity, R.style.Theme_DreamDroid_Night)
+            val host = FrameLayout(themed).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+            val state = DrawerListState()
+            val composeView = ComposeView(themed).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                setViewTreeLifecycleOwner(activity)
+                setViewTreeViewModelStoreOwner(activity)
+                setViewTreeSavedStateRegistryOwner(activity)
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                setContent {
+                    DreamDroidTheme {
+                        localContent = LocalContentColor.current
+                        onSurface = MaterialTheme.colorScheme.onSurface
+                        DrawerScreen(state = state, onItemClick = {})
+                    }
+                }
+            }
+            host.addView(composeView)
+            activity.setContentView(host)
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Control").assertIsDisplayed()
+        composeRule.onNodeWithText("TV & Movies").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertEquals(onSurface, localContent)
+            assertTrue(
+                "night onSurface should be light, luminance=${onSurface.luminance()}",
+                onSurface.luminance() > 0.5f,
+            )
+        }
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
@@ -1,0 +1,88 @@
+package net.reichholf.dreamdroid.ui.drawer
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DrawerScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun showsSectionsAndItems() {
+        val state = DrawerListState()
+        composeRule.setContent {
+            DreamDroidTheme {
+                DrawerScreen(state = state, onItemClick = {})
+            }
+        }
+
+        composeRule.onNodeWithText("Control").assertIsDisplayed()
+        composeRule.onNodeWithText("Tools").assertIsDisplayed()
+        composeRule.onNodeWithText("Settings & About").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("TV & Movies").assertIsDisplayed()
+        composeRule.onNodeWithText("Signal Meter").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Backup").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun clickInvokesCallbackAndSelectionHighlightsDestination() {
+        val state = DrawerListState()
+        var clicked = 0
+        composeRule.setContent {
+            DreamDroidTheme {
+                DrawerScreen(
+                    state = state,
+                    onItemClick = { id ->
+                        clicked = id
+                        state.select(id)
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Zap").performClick()
+        composeRule.waitForIdle()
+        assertEquals(R.id.menu_navigation_zap, clicked)
+        composeRule.onNodeWithText("Zap").assertIsSelected()
+    }
+
+    @Test
+    fun clearSelectionRemovesHighlight() {
+        val state = DrawerListState()
+        state.select(R.id.menu_navigation_services)
+        composeRule.setContent {
+            DreamDroidTheme {
+                DrawerScreen(state = state, onItemClick = {})
+            }
+        }
+        composeRule.onNodeWithText("TV & Movies").assertIsSelected()
+
+        composeRule.runOnIdle { state.clearSelection() }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("TV & Movies").assertIsDisplayed()
+        // After clear, no drawer destination should stay selected.
+        composeRule.runOnIdle {
+            assertEquals(R.id.menu_none, state.selectedItemId)
+        }
+    }
+}

--- a/app/res/layout-sw720dp/dualpane.xml
+++ b/app/res/layout-sw720dp/dualpane.xml
@@ -109,12 +109,24 @@
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    <com.google.android.material.navigation.NavigationView
+    <LinearLayout
         android:id="@+id/navigation_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:headerLayout="@layout/navigation_header"
-        app:menu="@menu/navigation" />
+        android:background="?attr/colorSurface"
+        android:clickable="true"
+        android:focusable="true"
+        android:minWidth="280dp"
+        android:orientation="vertical">
+
+        <include layout="@layout/navigation_header"/>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/drawer_compose"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+    </LinearLayout>
 
 </net.reichholf.dreamdroid.widget.DrawerLayout>

--- a/app/res/layout/dualpane.xml
+++ b/app/res/layout/dualpane.xml
@@ -87,13 +87,24 @@
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        style="@style/NavigationView"
+    <LinearLayout
         android:id="@+id/navigation_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:headerLayout="@layout/navigation_header"
-        app:menu="@menu/navigation"/>
+        android:background="?attr/colorSurface"
+        android:clickable="true"
+        android:focusable="true"
+        android:minWidth="280dp"
+        android:orientation="vertical">
+
+        <include layout="@layout/navigation_header"/>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/drawer_compose"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+    </LinearLayout>
 
 </net.reichholf.dreamdroid.widget.DrawerLayout>

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -60,6 +60,7 @@ import net.reichholf.dreamdroid.fragment.interfaces.IHttpBase;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.helpers.enigma2.CheckProfile;
+import net.reichholf.dreamdroid.ui.drawer.DrawerListState;
 
 import java.util.Arrays;
 import java.util.List;
@@ -88,6 +89,8 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 	@Nullable
 	private NavigationHelper mNavigationHelper;
+	@Nullable
+	private DrawerListState mDrawerListState;
 	@Nullable
 	private Fragment mDetailFragment;
 
@@ -226,7 +229,13 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 	private boolean checkNavigationHelper(boolean isResume) {
 		if (mNavigationHelper == null) {
 			//TODO preserve/restore mNavigationHelper properly
-			mNavigationHelper = new NavigationHelper(this);
+			// Keep DrawerListState across pause/resume so the Compose drawer
+			// highlight survives helper recreation (NavigationView used to keep
+			// checked state on the view itself).
+			if (mDrawerListState == null) {
+				mDrawerListState = new DrawerListState();
+			}
+			mNavigationHelper = new NavigationHelper(this, mDrawerListState);
 			onProfileChanged(DreamDroid.getCurrentProfile(), isResume);
 			return true;
 		}

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -34,7 +34,6 @@ import androidx.preference.PreferenceManager;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.Snackbar;
 
 import net.reichholf.dreamdroid.BuildConfig;
@@ -333,15 +332,13 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 			};
 			mDrawerLayout.addDrawerListener(mDrawerToggle);
 
-			NavigationView navigationView = findViewById(R.id.navigation_view);
-			View navHeader = navigationView.getHeaderView(0);
-			View profileChooser = navHeader.findViewById(R.id.drawer_profile);
+			View profileChooser = findViewById(R.id.drawer_profile);
 			profileChooser.setOnClickListener(view -> {
 				checkNavigationHelper();
 				mNavigationHelper.navigateTo(R.id.menu_navigation_profiles);
 			});
-			mActiveProfile = navHeader.findViewById(R.id.drawer_profile_name);
-			mConnectionState = navHeader.findViewById(R.id.drawer_profile_status);
+			mActiveProfile = findViewById(R.id.drawer_profile_name);
+			mConnectionState = findViewById(R.id.drawer_profile_status);
 		} else {
 			getSupportActionBar().setDisplayHomeAsUpEnabled(false);
 		}

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -68,10 +68,10 @@ public class NavigationHelper implements SetPowerStateTask.PowerStateTaskHandler
 
     protected int mSelectedItemId;
 
-    public NavigationHelper(MainActivity activity) {
+    public NavigationHelper(MainActivity activity, @NonNull DrawerListState drawerState) {
         mActivity = activity;
-        mSelectedItemId = -1;
-        mDrawerState = new DrawerListState();
+        mDrawerState = drawerState;
+        mSelectedItemId = drawerState.getSelectedItemId();
         ComposeView drawerCompose = activity.findViewById(R.id.drawer_compose);
         if (drawerCompose != null) {
             DrawerScreenKt.bindDrawerScreen(drawerCompose, mDrawerState, itemId -> {

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -3,15 +3,11 @@ package net.reichholf.dreamdroid.fragment.helper;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.MenuItem;
-import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.fragment.app.FragmentManager;
-
-import com.google.android.material.navigation.NavigationView;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
@@ -48,13 +44,17 @@ import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult;
 import net.reichholf.dreamdroid.helpers.enigma2.SleepTimer;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.MessageRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SimpleResultRequestHandler;
+import net.reichholf.dreamdroid.ui.drawer.DrawerListState;
+import net.reichholf.dreamdroid.ui.drawer.DrawerScreenKt;
 
 import java.util.ArrayList;
+
+import kotlin.Unit;
 
 /**
  * Created by Stephan on 25.12.2015.
  */
-public class NavigationHelper implements NavigationView.OnNavigationItemSelectedListener, SetPowerStateTask.PowerStateTaskHandler, SleepTimerTask.SleepTimerTaskHandler, SimpleResultTask.SimpleResultTaskHandler {
+public class NavigationHelper implements SetPowerStateTask.PowerStateTaskHandler, SleepTimerTask.SleepTimerTaskHandler, SimpleResultTask.SimpleResultTaskHandler {
 
     @NonNull
 	protected static int[] sDialogItemIds = {R.id.menu_navigation_sleeptimer, R.id.menu_navigation_remote, R.id.menu_navigation_settings, R.id.menu_navigation_message, R.id.menu_navigation_power, R.id.menu_navigation_about, R.id.menu_navigation_changelog};
@@ -64,13 +64,21 @@ public class NavigationHelper implements NavigationView.OnNavigationItemSelected
     protected SleepTimerTask mSleepTimerTask;
     protected SimpleResultTask mSimpleResultTask;
     protected SimpleHttpClient mShc;
+    protected final DrawerListState mDrawerState;
 
     protected int mSelectedItemId;
 
     public NavigationHelper(MainActivity activity) {
         mActivity = activity;
         mSelectedItemId = -1;
-        getNavigationView().setNavigationItemSelectedListener(this);
+        mDrawerState = new DrawerListState();
+        ComposeView drawerCompose = activity.findViewById(R.id.drawer_compose);
+        if (drawerCompose != null) {
+            DrawerScreenKt.bindDrawerScreen(drawerCompose, mDrawerState, itemId -> {
+                onNavigationItemClick(itemId);
+                return Unit.INSTANCE;
+            });
+        }
     }
 
     protected SimpleHttpClient getHttpClient() {
@@ -81,17 +89,6 @@ public class NavigationHelper implements NavigationView.OnNavigationItemSelected
 
     protected MainActivity getMainActivity() {
         return mActivity;
-    }
-
-    @Nullable
-	protected NavigationView getNavigationView() {
-        if (mActivity == null)
-            return null;
-        return (NavigationView) getMainActivity().findViewById(R.id.navigation_view);
-    }
-
-    protected View getHeaderView() {
-        return getNavigationView().getHeaderView(0);
     }
 
     protected void clearBackStack() {
@@ -134,21 +131,16 @@ public class NavigationHelper implements NavigationView.OnNavigationItemSelected
     protected void setSelectedItem(int itemId) {
         if (isDialogItem(itemId))
             return;
-        if(itemId == R.id.menu_navigation_profiles) {
-            getNavigationView().setCheckedItem(R.id.menu_none);
+        if (itemId == R.id.menu_navigation_profiles) {
+            mDrawerState.clearSelection();
             return;
         }
-        getNavigationView().setCheckedItem(itemId);
+        mDrawerState.select(itemId);
         mSelectedItemId = itemId;
     }
 
     public void navigateTo(int itemId) {
         onNavigationItemClick(itemId);
-    }
-
-    @Override
-    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-        return onNavigationItemClick(item.getItemId());
     }
 
     protected boolean isDialogItem(int itemId) {

--- a/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
@@ -1,0 +1,158 @@
+package net.reichholf.dreamdroid.ui.drawer
+
+import android.util.TypedValue
+import androidx.annotation.AttrRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+data class DrawerMenuItem(
+    val id: Int,
+    @StringRes val titleRes: Int,
+    @AttrRes val iconAttr: Int,
+)
+
+data class DrawerSection(
+    @StringRes val titleRes: Int,
+    val items: List<DrawerMenuItem>,
+)
+
+object DrawerDestinations {
+    val sections: List<DrawerSection> = listOf(
+        DrawerSection(
+            titleRes = R.string.control,
+            items = listOf(
+                DrawerMenuItem(R.id.menu_navigation_services, R.string.live_movie, R.attr.ic_menu_services),
+                DrawerMenuItem(R.id.menu_navigation_epg, R.string.epg, R.attr.ic_menu_epg),
+                DrawerMenuItem(R.id.menu_navigation_remote, R.string.virtual_remote, R.attr.ic_menu_remote),
+                DrawerMenuItem(R.id.menu_navigation_current, R.string.current_event, R.attr.ic_menu_current),
+                DrawerMenuItem(R.id.menu_navigation_power, R.string.powercontrol, R.attr.ic_menu_power_off),
+                DrawerMenuItem(R.id.menu_navigation_zap, R.string.zap, R.attr.ic_menu_zap),
+                DrawerMenuItem(R.id.menu_navigation_sleeptimer, R.string.sleeptimer, R.attr.ic_menu_sleeptimer),
+            ),
+        ),
+        DrawerSection(
+            titleRes = R.string.tools,
+            items = listOf(
+                DrawerMenuItem(R.id.menu_navigation_screenshot, R.string.screenshot, R.attr.ic_menu_picture),
+                DrawerMenuItem(R.id.menu_navigation_device_info, R.string.device_info, R.attr.ic_menu_device),
+                DrawerMenuItem(R.id.menu_navigation_message, R.string.send_message, R.attr.ic_menu_mail),
+                DrawerMenuItem(R.id.menu_navigation_signal, R.string.signal_meter, R.attr.ic_menu_signal),
+            ),
+        ),
+        DrawerSection(
+            titleRes = R.string.settings_and_about,
+            items = listOf(
+                DrawerMenuItem(R.id.menu_navigation_settings, R.string.settings, R.attr.ic_menu_settings),
+                DrawerMenuItem(R.id.menu_navigation_about, R.string.about, R.attr.ic_menu_about),
+                DrawerMenuItem(R.id.menu_navigation_backup, R.string.backup, R.attr.ic_import_export),
+                DrawerMenuItem(R.id.menu_navigation_changelog, R.string.changelog, R.attr.ic_menu_changelog),
+            ),
+        ),
+    )
+}
+
+class DrawerListState {
+    var selectedItemId by mutableIntStateOf(R.id.menu_none)
+        private set
+
+    fun select(itemId: Int) {
+        selectedItemId = itemId
+    }
+
+    fun clearSelection() {
+        selectedItemId = R.id.menu_none
+    }
+}
+
+@Composable
+private fun resolveThemeDrawable(@AttrRes attr: Int): Int {
+    val context = LocalContext.current
+    val typed = TypedValue()
+    context.theme.resolveAttribute(attr, typed, true)
+    return typed.resourceId
+}
+
+@Composable
+fun DrawerScreen(
+    state: DrawerListState,
+    onItemClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        DrawerDestinations.sections.forEach { section ->
+            Text(
+                text = stringResource(section.titleRes),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
+            )
+            section.items.forEach { item ->
+                val selected = state.selectedItemId == item.id
+                val iconRes = resolveThemeDrawable(item.iconAttr)
+                NavigationDrawerItem(
+                    label = { Text(stringResource(item.titleRes)) },
+                    selected = selected,
+                    onClick = { onItemClick(item.id) },
+                    icon = {
+                        if (iconRes != 0) {
+                            Icon(
+                                painter = painterResource(iconRes),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        unselectedTextColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+fun ComposeView.bindDrawerScreen(
+    state: DrawerListState,
+    onItemClick: (Int) -> Unit,
+) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            DrawerScreen(state = state, onItemClick = onItemClick)
+        }
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -57,7 +57,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
 | movies-typed | [#210](https://github.com/sreichholf/dreamDroid/pull/210) | merged | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
 | leanback-dive | [#211](https://github.com/sreichholf/dreamDroid/pull/211) | merged | Phase 0 Leanback inventory + risks + agreed Phase 3 PR order (docs only; no TV code). |
-| drawer-compose | [#212](https://github.com/sreichholf/dreamDroid/pull/212) | open | Phase 2.1a: Compose drawer chrome (`DrawerScreen` in `ComposeView`); keep `DrawerLayout` + fragment host + `NavigationHelper.navigateTo`; no `NavHost` yet. |
+| drawer-compose | [#212](https://github.com/sreichholf/dreamDroid/pull/212) | merged | Phase 2.1a: Compose drawer chrome (`DrawerScreen` in `ComposeView`); keep `DrawerLayout` + fragment host + `NavigationHelper.navigateTo`; no `NavHost` yet. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -83,7 +83,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a (this PR): Compose drawer menu chrome; full Compose Navigation / `NavHost` still later.
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Full Compose Navigation / `NavHost` still later (2.1b).
 - Out of wave still: Leanback `tv/` (Phase 3), VLC, widgets. See Appendix H.
 
 ## How to read this
@@ -533,7 +533,7 @@ Appendix G phone Compose screens are on `main` through #206 (+ CI #204). Phone B
 | 1 | typed hub now/next | **merged** [#209](https://github.com/sreichholf/dreamDroid/pull/209) |
 | 2 | typed movies list path | **merged** [#210](https://github.com/sreichholf/dreamDroid/pull/210) |
 
-Next after Phase 2.1a lands: Phase 2.2 HTTP/async, then state/rotation, Room, VLC (product decision), widgets. Phase 3 Leanback only after Phase 0 dive (done #211) and preferably after HTTP direction is clear for the hub.
+Next after Phase 2.1a (#212): Phase 2.2 HTTP/async, then state/rotation, Room, VLC (product decision), widgets. Phase 3 Leanback only after Phase 0 dive (done #211) and preferably after HTTP direction is clear for the hub.
 
 ### Phase 2 — Phone chassis (still not Leanback)
 
@@ -541,7 +541,7 @@ One program each, still one PR (or small PR series) at a time:
 
 | Order | Program | What |
 | --- | --- | --- |
-| 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **[#212](https://github.com/sreichholf/dreamDroid/pull/212).** |
+| 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
 | 1b | Drawer Navigation (later) | `MainActivity` + destinations → Compose Navigation / `NavHost`; retire dual-pane XML host gradually. Do **not** start until chrome is stable. |
 | 2 | HTTP / async stack | Replace `HttpURLConnection` + `AsyncTask`/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -57,6 +57,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
 | movies-typed | [#210](https://github.com/sreichholf/dreamDroid/pull/210) | merged | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
 | leanback-dive | [#211](https://github.com/sreichholf/dreamDroid/pull/211) | merged | Phase 0 Leanback inventory + risks + agreed Phase 3 PR order (docs only; no TV code). |
+| drawer-compose | (this PR) | open | Phase 2.1a: Compose drawer chrome (`DrawerScreen` in `ComposeView`); keep `DrawerLayout` + fragment host + `NavigationHelper.navigateTo`; no `NavHost` yet. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -81,8 +82,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Leftover `app/res/service_list_pager.xml` stub and `android-retrostreams` were removed in #172. Inflater still uses `R.layout.service_list_pager`.
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
-- Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive in this PR.
-- Out of wave: drawer shell, Leanback `tv/`, VLC, widgets. See Appendix H for the one-by-one plan after Wave 3.
+- Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
+- Phase 2.1a (this PR): Compose drawer menu chrome; full Compose Navigation / `NavHost` still later.
+- Out of wave still: Leanback `tv/` (Phase 3), VLC, widgets. See Appendix H.
 
 ## How to read this
 
@@ -531,7 +533,7 @@ Appendix G phone Compose screens are on `main` through #206 (+ CI #204). Phone B
 | 1 | typed hub now/next | **merged** [#209](https://github.com/sreichholf/dreamDroid/pull/209) |
 | 2 | typed movies list path | **merged** [#210](https://github.com/sreichholf/dreamDroid/pull/210) |
 
-Next: Phase 2 phone chassis (drawer shell first), then Phase 3 Leanback per the dive above.
+Next after Phase 2.1a lands: Phase 2.2 HTTP/async, then state/rotation, Room, VLC (product decision), widgets. Phase 3 Leanback only after Phase 0 dive (done #211) and preferably after HTTP direction is clear for the hub.
 
 ### Phase 2 — Phone chassis (still not Leanback)
 
@@ -539,7 +541,8 @@ One program each, still one PR (or small PR series) at a time:
 
 | Order | Program | What |
 | --- | --- | --- |
-| 1 | Drawer shell | `MainActivity` + `NavigationHelper` → Compose Navigation; retire dual-pane XML host gradually |
+| 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **This PR.** |
+| 1b | Drawer Navigation (later) | `MainActivity` + destinations → Compose Navigation / `NavHost`; retire dual-pane XML host gradually. Do **not** start until chrome is stable. |
 | 2 | HTTP / async stack | Replace `HttpURLConnection` + `AsyncTask`/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |
 | 4 | Data | Finish Room migration; shrink `DatabaseHelper` to backup-only then remove |

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -57,7 +57,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | hub-nownext-typed | [#209](https://github.com/sreichholf/dreamDroid/pull/209) | merged | typed `ServiceNowNext` for `/web/epgnownext` into hub TV/Radio `ServiceListPageFragment`; hash only at detail/timer/stream edge. |
 | movies-typed | [#210](https://github.com/sreichholf/dreamDroid/pull/210) | merged | typed `enigma.Movie` for `/web/movielist` into hub `MovieListFragment`; hash only at delete/stream edge; detail uses typed sheet. |
 | leanback-dive | [#211](https://github.com/sreichholf/dreamDroid/pull/211) | merged | Phase 0 Leanback inventory + risks + agreed Phase 3 PR order (docs only; no TV code). |
-| drawer-compose | (this PR) | open | Phase 2.1a: Compose drawer chrome (`DrawerScreen` in `ComposeView`); keep `DrawerLayout` + fragment host + `NavigationHelper.navigateTo`; no `NavHost` yet. |
+| drawer-compose | [#212](https://github.com/sreichholf/dreamDroid/pull/212) | open | Phase 2.1a: Compose drawer chrome (`DrawerScreen` in `ComposeView`); keep `DrawerLayout` + fragment host + `NavigationHelper.navigateTo`; no `NavHost` yet. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -541,7 +541,7 @@ One program each, still one PR (or small PR series) at a time:
 
 | Order | Program | What |
 | --- | --- | --- |
-| 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **This PR.** |
+| 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **[#212](https://github.com/sreichholf/dreamDroid/pull/212).** |
 | 1b | Drawer Navigation (later) | `MainActivity` + destinations → Compose Navigation / `NavHost`; retire dual-pane XML host gradually. Do **not** start until chrome is stable. |
 | 2 | HTTP / async stack | Replace `HttpURLConnection` + `AsyncTask`/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2.1a from Appendix H: replace the Material `NavigationView` drawer **menu** with Compose `DrawerScreen` hosted in a `ComposeView`. Keep `DrawerLayout`, the XML profile header, the fragment `detail_view` host, and `NavigationHelper.navigateTo` routing. Full Compose Navigation / `NavHost` stays for Phase 2.1b.

## Changes

- `DrawerScreen` + `DrawerListState` + `DrawerDestinations` (same section/item ids as `res/menu/navigation.xml`)
- Phone + tablet `dualpane.xml`: `LinearLayout` drawer with header include + `ComposeView`
- `NavigationHelper` binds Compose drawer; selection state owned by `MainActivity` so pause/resume does not clear the highlight
- `MainActivity` wires profile header via `findViewById` (no `getHeaderView`)
- Instrumented: `DrawerScreenTest`, `DrawerScreenHostTest` (View-theme `ComposeView` host for `LocalContentColor`)
- Docs: Phase 2 split into 2.1a chrome / 2.1b NavHost

## Test plan

- [x] JDK 17 `:app:assembleGoogleDebug` + `:app:testGoogleDebugUnitTest`
- [x] `:app:compileGoogleDebugAndroidTestKotlin`
- [x] Drawer instrumented tests on emulator: `DrawerScreenTest` + `DrawerScreenHostTest` — OK (4 tests)
- [x] Manual look: Compose drawer opens with Control/Tools sections and destination labels
- [x] CI Unit tests + assemble green
- [x] Bugbot: fixed selection-lost-on-resume; re-review clean

## Non-goals

- No `navigation-compose` / `NavHost`
- No OkHttp 4, no ButterKnife drop, no Leanback

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

