### PR TITLE
ci: upload googleDebug APK artifact (2-day retention)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -75,6 +75,15 @@ jobs:
           :app:compileGoogleDebugAndroidTestKotlin
           :app:compileGoogleDebugAndroidTestJavaWithJavac
 
+      - name: Upload googleDebug APK
+        uses: actions/upload-artifact@v6
+        with:
+          name: dreamdroid-google-debug-apk
+          # -Pci builds one APK (no ABI splits). Path still matches the debug output.
+          path: app/build/outputs/apk/google/debug/*.apk
+          if-no-files-found: error
+          retention-days: 2
+
       - name: Upload unit test reports
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -67,20 +67,25 @@ jobs:
       # .temp path; dependency/build caches already make the real work ~30s.
       # -Pci disables ABI splits (one APK). androidTest compile catches broken
       # Compose tests without an emulator.
-      - name: Unit tests + assemble + compile androidTest
+      - name: Unit tests + compile androidTest
         run: >
           ./gradlew -Pci --no-configuration-cache
           :app:testGoogleDebugUnitTest
-          :app:assembleGoogleDebug
           :app:compileGoogleDebugAndroidTestKotlin
           :app:compileGoogleDebugAndroidTestJavaWithJavac
 
-      - name: Upload googleDebug APK
+      # Separate assemble so the artifact zip is arm64-only (~57MB), not the
+      # -Pci fat APK (~197MB). -Parm64Apk enables a single ABI split.
+      - name: Assemble googleDebug arm64 APK
+        run: >
+          ./gradlew --no-configuration-cache -Parm64Apk
+          :app:assembleGoogleDebug
+
+      - name: Upload googleDebug arm64 APK
         uses: actions/upload-artifact@v6
         with:
           name: dreamdroid-google-debug-apk
-          # -Pci builds one APK (no ABI splits). Path still matches the debug output.
-          path: app/build/outputs/apk/google/debug/*.apk
+          path: app/build/outputs/apk/google/debug/app-google-arm64-v8a-debug.apk
           if-no-files-found: error
           retention-days: 2
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use `JAVA_HOME` pointing at JDK 17. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile (all with `-Pci` to skip ABI splits). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile (all with `-Pci` to skip ABI splits); uploads `dreamdroid-google-debug-apk` (2-day retention). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` is for a single look when you need a screenshot or a shell-only path that has no test yet. It is not the verification loop.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use `JAVA_HOME` pointing at JDK 17. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile (all with `-Pci` to skip ABI splits); uploads `dreamdroid-google-debug-apk` (2-day retention). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`); uploads arm64 `dreamdroid-google-debug-apk` (2-day retention). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` is for a single look when you need a screenshot or a shell-only path that has no test yet. It is not the verification loop.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,11 +130,17 @@ android {
     }
     splits {
         abi {
-            // CI passes -Pci (unit + androidTest jobs) so we build one APK.
-            enable !project.hasProperty("ci")
+            // -Pci: one fat APK (unit/androidTest jobs).
+            // -Parm64Apk: ABI-split arm64-only (CI artifact upload).
+            enable project.hasProperty("arm64Apk") || !project.hasProperty("ci")
             reset()
-            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-            universalApk true
+            if (project.hasProperty("arm64Apk")) {
+                include 'arm64-v8a'
+                universalApk false
+            } else {
+                include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+                universalApk true
+            }
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Upload **arm64-only** googleDebug APK as artifact `dreamdroid-google-debug-apk` (2-day retention)
- `-Parm64Apk` builds a single ABI-split APK (`app-google-arm64-v8a-debug.apk`) so the zip is ~34MB compressed, not the fat `-Pci` APK
- Unit/androidTest compile still use `-Pci`
- `actions/upload-artifact@v6`

## Why
Cursor agent artifact paths 404; GitHub Actions is the reliable download path. Phone installs need arm64.

## Download
https://github.com/sreichholf/dreamDroid/actions/runs/34504581601#artifacts  
Artifact zip contains only `app-google-arm64-v8a-debug.apk` (expires **2026-09-12**).

## Test plan
- [x] Local `-Parm64Apk :app:assembleGoogleDebug` produces only `app-google-arm64-v8a-debug.apk`
- [x] PR CI succeeds and artifact zip contains only that arm64 APK
- [x] Retention shows 2 days
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a24b2376-10b5-4568-9f50-c115e54070b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a24b2376-10b5-4568-9f50-c115e54070b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

