### PR TITLE
feat(http): VideoOverlay now/next via coroutines (Phase 2.2q)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/fragment/VideoOverlayFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/VideoOverlayFragment.java
@@ -30,9 +30,9 @@ import androidx.core.view.GestureDetectorCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.leanback.widget.HorizontalGridView;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
 import androidx.preference.PreferenceManager;
+
+import kotlinx.coroutines.Job;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -51,13 +51,10 @@ import net.reichholf.dreamdroid.helpers.Python;
 import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Movie;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
-import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.AbstractListRequestHandler;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EpgNowNextListRequestHandler;
-import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.EventListRequestHandler;
+import net.reichholf.dreamdroid.enigma.EpgNowNextLoadKt;
+import net.reichholf.dreamdroid.enigma.ServiceNowNext;
 import net.reichholf.dreamdroid.intents.IntentFactory;
-import net.reichholf.dreamdroid.loader.AsyncListLoader;
-import net.reichholf.dreamdroid.loader.LoaderResult;
+import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
 import net.reichholf.dreamdroid.tv.fragment.EpgDetailDialog;
 import net.reichholf.dreamdroid.tv.fragment.MovieDetailDialog;
 import net.reichholf.dreamdroid.video.VLCPlayer;
@@ -73,7 +70,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventListener,
-		LoaderManager.LoaderCallbacks<LoaderResult<ArrayList<ExtendedHashMap>>>, ItemClickSupport.OnItemClickListener, ActionDialog.DialogActionListener {
+		ItemClickSupport.OnItemClickListener, ActionDialog.DialogActionListener {
 
 	public static final String DIALOG_TAG_AUDIO_TRACK = "dialog_audio_track";
 	public static final String DIALOG_TAG_SUBTITLE_TRACK = "dialog_subtitle_track";
@@ -152,6 +149,9 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	private float mVolume;
 	private boolean mServicesViewVisible;
 
+	@Nullable
+	private Job mLoadJob;
+
 	public VideoOverlayFragment() {
 	}
 
@@ -176,7 +176,6 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		mVolume = -1f;
 
 		autohide();
-		reload();
 	}
 
 	@Nullable
@@ -396,25 +395,11 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		onServiceInfoChanged(true);
 	}
 
-	@NonNull
-	@Override
-	public Loader<LoaderResult<ArrayList<ExtendedHashMap>>> onCreateLoader(int id, Bundle args) {
-		AbstractListRequestHandler handler;
-		if (DreamDroid.featureNowNext())
-			handler = new EpgNowNextListRequestHandler();
-		else
-			handler = new EventListRequestHandler(URIStore.EPG_NOW);
-		return new AsyncListLoader(getActivity(), handler, true, args);
-	}
-
-	@Override
-	public void onLoadFinished(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader, @NonNull LoaderResult<ArrayList<ExtendedHashMap>> data) {
-		if (data.isError())
-			return;
+	private void applyServiceList(@NonNull ArrayList<ExtendedHashMap> services) {
 		mServiceList.clear();
 		if (mServicesView != null)
 			mServicesView.getAdapter().notifyDataSetChanged();
-		mServiceList.addAll(data.getResult());
+		mServiceList.addAll(services);
 		for (ExtendedHashMap service : mServiceList) {
 			if (service.getString(Event.KEY_SERVICE_REFERENCE).equals(mServiceRef)) {
 				ExtendedHashMap oldServiceInfo = mServiceInfo;
@@ -434,11 +419,6 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 			if (isOverlaysVisible() && mServicesViewVisible)
 				showZapOverlays();
 		}
-	}
-
-	@Override
-	public void onLoaderReset(@NonNull Loader<LoaderResult<ArrayList<ExtendedHashMap>>> loader) {
-
 	}
 
 	private void zap() {
@@ -540,11 +520,37 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	public void reload() {
 		if ((mBouquetRef == null || mBouquetRef.isEmpty()) || getActivity() == null)
 			return;
+		if (!isAdded() || getView() == null)
+			return;
+		cancelLoad();
 		ArrayList<NameValuePair> params = new ArrayList<>();
 		params.add(new NameValuePair("bRef", mBouquetRef));
-		Bundle args = new Bundle();
-		args.putSerializable("params", params);
-		getLoaderManager().restartLoader(1, args, this);
+		mLoadJob = EpgNowNextLoadKt.launchEpgNowNextLoad(this, params, (success, rows, errorText) -> {
+			onEpgNowNextReady(success, rows, errorText);
+			return kotlin.Unit.INSTANCE;
+		});
+	}
+
+	private void cancelLoad() {
+		if (mLoadJob != null) {
+			mLoadJob.cancel(null);
+			mLoadJob = null;
+		}
+	}
+
+	private void onEpgNowNextReady(boolean success, @NonNull java.util.List<ServiceNowNext> rows,
+			@Nullable String errorText) {
+		if (!isAdded()) {
+			return;
+		}
+		if (!success) {
+			return;
+		}
+		ArrayList<ExtendedHashMap> services = new ArrayList<>();
+		for (ServiceNowNext row : rows) {
+			services.add(ServiceListMapperKt.serviceNowNextToExtendedHashMap(row));
+		}
+		applyServiceList(services);
 	}
 
 	private void seek(int pos) {
@@ -732,6 +738,7 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	public void onPause() {
 		mHandler.removeCallbacks(mAutoHideRunnable);
 		mHandler.removeCallbacks(mIssueReloadRunnable);
+		cancelLoad();
 		super.onPause();
 	}
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -73,7 +73,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | http-async-profile-detect | [#226](https://github.com/sreichholf/dreamDroid/pull/226) | merged | Phase 2.2m: Profile check + device detect via `lifecycleScope`; drop `CheckProfileTask`/`DetectDevicesTask`. |
 | http-async-drop-asynctask-base | [#227](https://github.com/sreichholf/dreamDroid/pull/227) | merged | Phase 2.2n: Delete unused `AsyncHttpTaskBase` / `AsyncTaskExecutorService` and empty `asynctask/` package. |
 | http-loader-chassis-stubs | [#229](https://github.com/sreichholf/dreamDroid/pull/229) | merged | Phase 2.2o: Drop dead `LoaderCallbacks` from phone HTTP bases + stub fragments; delete unused `AsyncSimpleLoader`. |
-| http-async-screenshot | | open | Phase 2.2p: ScreenShot grab via `lifecycleScope` + `ScreenshotLoad`; drop `AsyncByteLoader`. Keep `AsyncListLoader` for VideoOverlay + Leanback TV. |
+| http-async-screenshot | [#230](https://github.com/sreichholf/dreamDroid/pull/230) | merged | Phase 2.2p: ScreenShot grab via `lifecycleScope` + `ScreenshotLoad`; drop `AsyncByteLoader`. |
+| http-async-videooverlay-epg | | open | Phase 2.2q: VideoOverlay bouquet now/next via `lifecycleScope` + reuse `EpgNowNextLoad`; map with `serviceNowNextToExtendedHashMap`; drop LoaderCallbacks on overlay only. Keep ButterKnife/VLC UI and `AsyncListLoader` for Leanback TV. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -115,7 +116,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.2m Profile check + device-detect coroutines **merged** [#226](https://github.com/sreichholf/dreamDroid/pull/226).
 - Phase 2.2n AsyncTask base retirement **merged** [#227](https://github.com/sreichholf/dreamDroid/pull/227).
 - Phase 2.2o Loader chassis stubs **merged** [#229](https://github.com/sreichholf/dreamDroid/pull/229).
-- Phase 2.2p (this PR): ScreenShot bytes via coroutines; delete `AsyncByteLoader`.
+- Phase 2.2p ScreenShot bytes **merged** [#230](https://github.com/sreichholf/dreamDroid/pull/230).
+- Phase 2.2q (this PR): VideoOverlay now/next via coroutines; keep `AsyncListLoader` for Leanback.
 - Out of wave still: Leanback `tv/` (Phase 3), VLC, widgets. See Appendix H.
 
 ## How to read this
@@ -590,8 +592,9 @@ One program each, still one PR (or small PR series) at a time:
 | 2m | HTTP / async — Profile/detect | `MainActivity` + `ProfileListFragment` → `lifecycleScope` profile check / device detect; delete `CheckProfileTask`/`DetectDevicesTask`. **merged** [#226](https://github.com/sreichholf/dreamDroid/pull/226). |
 | 2n | HTTP / async — Retire AsyncTask base | Delete unused `AsyncHttpTaskBase` / `AsyncTaskExecutorService` and empty `asynctask/` package. **merged** [#227](https://github.com/sreichholf/dreamDroid/pull/227). |
 | 2o | HTTP / async — Loader chassis stubs | Drop `LoaderCallbacks` from `BaseHttpFragment`/`BaseHttpRecyclerFragment` + stub phone screens; gut `HttpFragmentHelper.reload()`; delete unused `AsyncSimpleLoader`. **merged** [#229](https://github.com/sreichholf/dreamDroid/pull/229). |
-| 2p | HTTP / async — ScreenShot bytes | `ScreenShotFragment` → `lifecycleScope` + `ScreenshotLoad` / `Request.getBytes`; delete `AsyncByteLoader`. Keep `AsyncListLoader` for VideoOverlay + Leanback. **(this PR).** |
-| 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. Follow-ons after 2p: VideoOverlay/TV loaders. |
+| 2p | HTTP / async — ScreenShot bytes | `ScreenShotFragment` → `lifecycleScope` + `ScreenshotLoad` / `Request.getBytes`; delete `AsyncByteLoader`. **merged** [#230](https://github.com/sreichholf/dreamDroid/pull/230). |
+| 2q | HTTP / async — VideoOverlay now/next | `VideoOverlayFragment` → `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`; drop overlay LoaderCallbacks only. Keep ButterKnife/VLC UI; keep `AsyncListLoader` for Leanback. Keep OkHttp 3.14.9. **(this PR).** |
+| 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. Follow-ons after 2q: Leanback TV loaders / VLC product decision. |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |
 | 4 | Data | Finish Room migration; shrink `DatabaseHelper` to backup-only then remove |
 | 5 | VLC / streaming | `VideoActivity` + `VideoOverlayFragment` (ButterKnife) — product decision before rewrite |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.2q**: `VideoOverlayFragment` bouquet now/next via `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`.
- Drop LoaderCallbacks on the overlay only.
- Docs: mark Phase **2.2p** / #230 **merged**; record 2.2q.

## Evidence
- Local JDK 17: unit tests + assemble **BUILD SUCCESSFUL**

## Out of scope
- ButterKnife / VLC UI rewrite (product decision)
- Leanback `AsyncListLoader` / `RootBrowseFragment`
- OkHttp 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

