### PR TITLE
chore(tv): drop TextCardView ButterKnife

### DIFF
--- a/app/src/net/reichholf/dreamdroid/tv/view/TextCardView.java
+++ b/app/src/net/reichholf/dreamdroid/tv/view/TextCardView.java
@@ -1,17 +1,14 @@
 package net.reichholf.dreamdroid.tv.view;
 
 import android.content.Context;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.leanback.widget.BaseCardView;
-import butterknife.BindView;
-import butterknife.ButterKnife;
-
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.leanback.widget.BaseCardView;
 
 import net.reichholf.dreamdroid.R;
 
@@ -20,68 +17,65 @@ import net.reichholf.dreamdroid.R;
  */
 public class TextCardView extends BaseCardView {
 
-    @Nullable
-	@BindView(R.id.title_text)
-    protected TextView mTitle;
+	@Nullable
+	protected TextView mTitle;
 
-    @Nullable
-	@BindView(R.id.content_text)
-    protected TextView mContent;
+	@Nullable
+	protected TextView mContent;
 
-    public TextCardView(@NonNull Context context) {
-        this(context, null);
-    }
+	public TextCardView(@NonNull Context context) {
+		this(context, null);
+	}
 
-    public TextCardView(@NonNull Context context, AttributeSet attrs) {
-        this(context, attrs, androidx.leanback.R.attr.imageCardViewStyle);
-    }
+	public TextCardView(@NonNull Context context, AttributeSet attrs) {
+		this(context, attrs, androidx.leanback.R.attr.imageCardViewStyle);
+	}
 
+	public TextCardView(@NonNull Context context, AttributeSet attrs, int defStyle) {
+		super(context, attrs, defStyle);
+		setCardType(BaseCardView.CARD_TYPE_INFO_UNDER);
+		LayoutInflater inflater = LayoutInflater.from(context);
+		View v = inflater.inflate(R.layout.tv_text_card_item, this);
+		mTitle = v.findViewById(R.id.title_text);
+		mContent = v.findViewById(R.id.content_text);
+	}
 
-    public TextCardView(@NonNull Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs, defStyle);
-        setCardType(BaseCardView.CARD_TYPE_INFO_UNDER);
-        LayoutInflater inflater = LayoutInflater.from(context);
-        View v = inflater.inflate(R.layout.tv_text_card_item, this);
-        ButterKnife.bind(this, v);
-    }
+	public void setTitleText(CharSequence text) {
+		if (mTitle == null) {
+			return;
+		}
 
-    public void setTitleText(CharSequence text) {
-        if (mTitle == null) {
-            return;
-        }
+		mTitle.setText(text);
+	}
 
-        mTitle.setText(text);
-    }
-
-    @Nullable
+	@Nullable
 	public CharSequence getTitleText() {
-        if (mTitle == null) {
-            return null;
-        }
+		if (mTitle == null) {
+			return null;
+		}
 
-        return mTitle.getText();
-    }
+		return mTitle.getText();
+	}
 
-    public void setContentText(CharSequence text) {
-        if (mContent == null) {
-            return;
-        }
+	public void setContentText(CharSequence text) {
+		if (mContent == null) {
+			return;
+		}
 
-        mContent.setText(text);
-    }
+		mContent.setText(text);
+	}
 
-    @Nullable
+	@Nullable
 	public CharSequence getContentText() {
-        if (mContent == null) {
-            return null;
-        }
+		if (mContent == null) {
+			return null;
+		}
 
-        return mContent.getText();
-    }
+		return mContent.getText();
+	}
 
-    @Override
-    public boolean hasOverlappingRendering() {
-        return false;
-    }
-
+	@Override
+	public boolean hasOverlappingRendering() {
+		return false;
+	}
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -78,7 +78,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | http-async-tv-browse | [#232](https://github.com/sreichholf/dreamDroid/pull/232) | merged | Phase 2.2r: Leanback `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV `LoaderCallbacks` / `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + `ExtendedHashMap` BrowseItem. Keep OkHttp 3.14.9. |
 | tv-browse-typed-item | [#234](https://github.com/sreichholf/dreamDroid/pull/234) | merged | Phase 3.1a: sealed Kotlin `BrowseItem` (`Service`/`Movie`/`Settings`); hash only at stream Intent edge; keep Leanback UI. Keep OkHttp 3.14.9. |
 | tv-detail-compose | [#235](https://github.com/sreichholf/dreamDroid/pull/235) | merged | Phase 3.1b: TV `EpgDetailDialog` / `MovieDetailDialog` → Compose via shared phone screens + `DreamDroidTheme`; actions hidden on TV EPG; drop ButterKnife on those two dialogs. Keep OkHttp 3.14.9. |
-| tv-prefs-compose | this PR | open | Phase 3.1d: Leanback prefs → Compose (`TvSettingsScreen` + `ProfileEditScreen` in `PreferenceActivity`); same PreferenceManager keys. Keep OkHttp 3.14.9. |
+| tv-prefs-compose | [#236](https://github.com/sreichholf/dreamDroid/pull/236) | merged | Phase 3.1d: Leanback prefs → Compose (`TvSettingsScreen` + `ProfileEditScreen` in `PreferenceActivity`); same PreferenceManager keys. Keep OkHttp 3.14.9. |
+| tv-textcard-drop-butterknife | this PR | open | Drop ButterKnife on TV `TextCardView` (last TV binds); keep dep for `VideoOverlayFragment` (VLC). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -125,7 +126,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.2r Leanback RootBrowse coroutines **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). HTTP Loader chassis retired (`loader/` package gone).
 - Phase 3.1a typed Leanback `BrowseItem` **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234).
 - Phase 3.1b TV detail dialogs → Compose **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235).
-- Phase 3.1d Leanback prefs → Compose — **this PR** (`TvSettingsScreen` + profile edit host).
+- Phase 3.1d Leanback prefs → Compose **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236).
+- TV `TextCardView` ButterKnife dropped — **this PR** (phone VLC overlay still binds).
 - Out of wave still: Leanback `tv/` (Phase 3), VLC, widgets. See Appendix H.
 
 ## How to read this
@@ -527,10 +529,10 @@ Entry: `TabbedNavigationActivity` → TV `MainActivity` when `DreamDroid.isTV()`
 
 | File | `@BindView` count |
 | --- | --- |
-| `TextCardView` | 2 |
-| **Total** | **2** (1 file) |
+| *(none on TV)* | 0 |
+| **Total** | **0** |
 
-TV EPG/Movie detail ButterKnife dropped in Phase 3.1b.
+TV ButterKnife cleared (details in 3.1b; `TextCardView` in this PR). Phone leftover: `VideoOverlayFragment` (VLC).
 
 Phone leftover: `VideoOverlayFragment` (Phase 2 VLC). ButterKnife cannot be dropped until TV + that site are gone.
 
@@ -559,11 +561,11 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 
 1. Typed TV browse data — stop `ExtendedHashMap` in `BrowseItem`; reuse phone typed client — **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234) (Phase 3.1a)
 2. Detail dialogs → Compose (shared phone detail + DreamDroidTheme) — **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235) (Phase 3.1b); TV ButterKnife left on `TextCardView` only
-3. Browse hub → TV Compose / foundational focus — needs typed data; kills `TextCardView` ButterKnife (deferred; needs TV focus model)
-4. Leanback prefs → Compose preferences — **this PR** (Phase 3.1d); same PreferenceManager keys
-5. Drop ButterKnife when zero call sites remain (TV + phone VLC)
+3. Browse hub → TV Compose / foundational focus — needs typed data; `TextCardView` ButterKnife already cleared (this PR)
+4. Leanback prefs → Compose preferences — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
+5. Drop ButterKnife when zero call sites remain — TV cleared (**this PR** for `TextCardView`); phone VLC still binds
 
-**Safe next:** browse hub TV Compose / focus model (3.1c). **Defer full ButterKnife drop** until VLC overlay is rewritten.
+**Safe next:** browse hub TV Compose / focus model (3.1c), or state/rotation / Room. **Defer full ButterKnife drop** until VLC overlay is rewritten.
 
 ### Phase 1 — Remaining phone typed API (done)
 
@@ -617,8 +619,8 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1a | Typed `BrowseItem` | Sealed Kotlin `Service`/`Movie`/`Settings`; hash only at stream Intent edge; keep Leanback UI. Keep OkHttp 3.14.9. **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234). |
 | 3.1b | TV detail dialogs → Compose | Shared phone detail + `DreamDroidTheme`; hide EPG actions on TV; drop ButterKnife on Epg/Movie detail. Keep OkHttp 3.14.9. **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235). |
 | 3.1c | Browse hub → TV Compose | Foundational focus model; kill `TextCardView` ButterKnife. |
-| 3.1d | Leanback prefs → Compose | `TvSettingsScreen` + `ProfileEditScreen` in `PreferenceActivity`; same PreferenceManager keys. Keep OkHttp 3.14.9. **this PR**. |
-| 3.1e | Drop ButterKnife | When zero call sites remain (TV + phone VLC). |
+| 3.1d | Leanback prefs → Compose | `TvSettingsScreen` + `ProfileEditScreen` in `PreferenceActivity`; same PreferenceManager keys. Keep OkHttp 3.14.9. **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
+| 3.1e | Drop ButterKnife | TV binds cleared (**this PR** for `TextCardView`). Full library drop waits on phone `VideoOverlayFragment` (VLC). |
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clear the last TV ButterKnife site and mark Phase 3.1d merged.

- `TextCardView`: `@BindView` → `findViewById`
- ButterKnife dependency kept for phone `VideoOverlayFragment` (VLC / Phase 3.1e remainder)
- Docs: mark [#236](https://github.com/sreichholf/dreamDroid/pull/236) merged; note TV ButterKnife cleared
- Keep OkHttp **3.14.9**

## Test plan

- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [x] Bugbot clean
- [ ] CI green

## Docs

`docs/modernize-dreamdroid.md` — PR table + ButterKnife inventory.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

