### PR TITLE
feat(tv): Compose ImageCardView for service/settings cards (Phase 3.1c-ii)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/tv/presenter/CardPresenter.java
+++ b/app/src/net/reichholf/dreamdroid/tv/presenter/CardPresenter.java
@@ -19,20 +19,14 @@ package net.reichholf.dreamdroid.tv.presenter;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.style.StyleSpan;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.leanback.widget.BaseCardView;
-import androidx.leanback.widget.ImageCardView;
 import androidx.leanback.widget.Presenter;
 
 import net.reichholf.dreamdroid.R;
@@ -40,11 +34,13 @@ import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.enigma.ServiceNowNext;
 import net.reichholf.dreamdroid.helpers.enigma2.Picon;
 import net.reichholf.dreamdroid.tv.BrowseItem;
+import net.reichholf.dreamdroid.tv.view.ImageCardView;
 import net.reichholf.dreamdroid.tv.view.TextCardView;
 
 /*
  * A CardPresenter is used to generate Views and bind Objects to them on demand.
- * It contains an Image CardView
+ * Image cards (services/settings) and text cards (movies) use Compose bodies
+ * inside Leanback BaseCardView (Phase 3.1c-i / 3.1c-ii).
  */
 public class CardPresenter extends Presenter {
 	private int mSelectedBackgroundColor = -1;
@@ -90,12 +86,6 @@ public class CardPresenter extends Presenter {
 				@Override
 				public void setSelected(boolean selected) {
 					updateCardBackgroundColor(this, selected);
-					TextView content = findViewById(androidx.leanback.R.id.content_text);
-					if (selected) {
-						content.setMaxLines(4);
-					} else {
-						content.setMaxLines(1);
-					}
 					super.setSelected(selected);
 				}
 			};
@@ -132,6 +122,7 @@ public class CardPresenter extends Presenter {
 	protected void bindSettingsViewHolder(@NonNull Presenter.ViewHolder viewHolder, @NonNull BrowseItem.Settings item) {
 		ImageCardView cardView = (ImageCardView) viewHolder.view;
 		cardView.setTitleText(item.getTitle());
+		cardView.clearContent();
 		cardView.setMainImage(ResourcesCompat.getDrawable(cardView.getResources(), item.getIconRes(),
 				cardView.getContext().getTheme()));
 		cardView.getMainImageView().setScaleType(ImageView.ScaleType.FIT_CENTER);
@@ -153,19 +144,13 @@ public class CardPresenter extends Presenter {
 		String serviceName = row.getServiceName();
 		cardView.setTitleText(serviceName);
 		if (next == null || next.getTitle().isEmpty()) {
+			cardView.clearContent();
 			if (!nowTitle.isEmpty()) {
 				cardView.setTitleText(nowTitle);
 			}
 		} else {
 			String displayTitle = !nowTitle.isEmpty() ? nowTitle : serviceName;
-			String nextStart = next.getStartTimeReadable();
-			String t = String.format("%s\n%s %s", displayTitle, nextStart, next.getTitle());
-			Spannable spannable = new SpannableString(t);
-			int offset = displayTitle.length();
-			int end = offset + nextStart.length() + 1;
-			spannable.setSpan(new StyleSpan(Typeface.BOLD_ITALIC), offset, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-			TextView content = cardView.findViewById(androidx.leanback.R.id.content_text);
-			content.setText(spannable, TextView.BufferType.SPANNABLE);
+			cardView.setNowNextContent(displayTitle, next.getStartTimeReadable(), next.getTitle());
 		}
 		cardView.getMainImageView().setScaleType(ImageView.ScaleType.FIT_CENTER);
 		Resources res = cardView.getResources();

--- a/app/src/net/reichholf/dreamdroid/tv/view/ImageCardView.kt
+++ b/app/src/net/reichholf/dreamdroid/tv/view/ImageCardView.kt
@@ -1,0 +1,232 @@
+package net.reichholf.dreamdroid.tv.view
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.widget.ImageView
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.leanback.widget.BaseCardView
+import net.reichholf.dreamdroid.R
+
+/**
+ * Leanback service/settings card with ImageView picon + Compose text (Phase 3.1c-ii).
+ * Keeps [BaseCardView] focus/selection; CardPresenter binds picons via [getMainImageView].
+ */
+open class ImageCardView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.leanback.R.attr.imageCardViewStyle,
+) : BaseCardView(context, attrs, defStyleAttr) {
+
+    private var titleText by mutableStateOf("")
+    private var contentPrimary by mutableStateOf("")
+    private var nextStart by mutableStateOf("")
+    private var nextTitle by mutableStateOf("")
+    private var contentExpanded by mutableStateOf(false)
+    private var imageWidthPx by mutableIntStateOf(
+        resources.getDimensionPixelSize(R.dimen.card_width),
+    )
+    private var imageHeightPx by mutableIntStateOf(
+        resources.getDimensionPixelSize(R.dimen.card_height),
+    )
+
+    private val mainImageView = ImageView(context).apply {
+        scaleType = ImageView.ScaleType.FIT_CENTER
+        adjustViewBounds = true
+        isFocusable = false
+        isFocusableInTouchMode = false
+    }
+    private val composeView = ComposeView(context)
+
+    init {
+        cardType = CARD_TYPE_INFO_UNDER
+        isFocusable = true
+        isFocusableInTouchMode = true
+        // Leanback must keep focus on the card, not Compose / ImageView children.
+        descendantFocusability = FOCUS_BLOCK_DESCENDANTS
+        composeView.isFocusable = false
+        composeView.isFocusableInTouchMode = false
+        composeView.id = androidx.leanback.R.id.info_field
+
+        val imageLp = LayoutParams(imageWidthPx, imageHeightPx)
+        imageLp.viewType = LayoutParams.VIEW_TYPE_MAIN
+        addView(mainImageView, imageLp)
+
+        val infoLp = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        infoLp.viewType = LayoutParams.VIEW_TYPE_INFO
+        addView(composeView, infoLp)
+
+        composeView.setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
+        )
+        composeView.setContent {
+            ImageCardContent(
+                title = titleText,
+                contentPrimary = contentPrimary,
+                nextStart = nextStart,
+                nextTitle = nextTitle,
+                contentExpanded = contentExpanded,
+                imageWidthPx = imageWidthPx,
+            )
+        }
+    }
+
+    fun getMainImageView(): ImageView = mainImageView
+
+    fun setMainImage(drawable: Drawable?) {
+        mainImageView.setImageDrawable(drawable)
+    }
+
+    fun setMainImageDimensions(width: Int, height: Int) {
+        imageWidthPx = width
+        imageHeightPx = height
+        val lp = mainImageView.layoutParams
+        if (lp != null) {
+            lp.width = width
+            lp.height = height
+            mainImageView.layoutParams = lp
+        }
+    }
+
+    fun setTitleText(text: CharSequence?) {
+        titleText = text?.toString().orEmpty()
+    }
+
+    fun getTitleText(): CharSequence? = titleText.ifEmpty { null }
+
+    /** Plain content line (no next-event styling). Clears structured next fields. */
+    fun setContentText(text: CharSequence?) {
+        contentPrimary = text?.toString().orEmpty()
+        nextStart = ""
+        nextTitle = ""
+    }
+
+    /**
+     * Now/next content: primary line + bold-italic next start + next title
+     * (matches former Spannable on Leanback ImageCardView).
+     */
+    fun setNowNextContent(primary: String, startReadable: String, eventTitle: String) {
+        contentPrimary = primary
+        nextStart = startReadable
+        nextTitle = eventTitle
+    }
+
+    fun clearContent() {
+        contentPrimary = ""
+        nextStart = ""
+        nextTitle = ""
+    }
+
+    /** API compat with Leanback ImageCardView; badge not used on this card. */
+    @Suppress("UNUSED_PARAMETER")
+    fun setBadgeImage(drawable: Drawable?) {
+        // no-op
+    }
+
+    override fun setSelected(selected: Boolean) {
+        contentExpanded = selected
+        super.setSelected(selected)
+    }
+
+    override fun hasOverlappingRendering(): Boolean = false
+}
+
+@Composable
+fun ImageCardContent(
+    title: String,
+    contentPrimary: String,
+    nextStart: String,
+    nextTitle: String,
+    contentExpanded: Boolean,
+    imageWidthPx: Int,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val cardWidth = if (imageWidthPx > 0) {
+        with(density) { imageWidthPx.toDp() }
+    } else {
+        dimensionResource(R.dimen.card_width)
+    }
+    val titleColor = Color.White
+    val bodyColor = Color.White.copy(alpha = 0.85f)
+    val hasNext = nextStart.isNotEmpty() || nextTitle.isNotEmpty()
+    val hasContent = contentPrimary.isNotEmpty() || hasNext
+    Column(
+        modifier = modifier
+            .width(cardWidth)
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+    ) {
+        Text(
+            text = title,
+            color = titleColor,
+            fontSize = 14.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (hasContent) {
+            val body = buildAnnotatedString {
+                if (contentPrimary.isNotEmpty()) {
+                    append(contentPrimary)
+                }
+                if (hasNext) {
+                    if (contentPrimary.isNotEmpty()) {
+                        append('\n')
+                    }
+                    if (nextStart.isNotEmpty()) {
+                        withStyle(
+                            SpanStyle(
+                                fontWeight = FontWeight.Bold,
+                                fontStyle = FontStyle.Italic,
+                            ),
+                        ) {
+                            append(nextStart)
+                        }
+                        if (nextTitle.isNotEmpty()) {
+                            append(' ')
+                        }
+                    }
+                    if (nextTitle.isNotEmpty()) {
+                        append(nextTitle)
+                    }
+                }
+            }
+            Text(
+                text = body,
+                color = bodyColor,
+                fontSize = 12.sp,
+                maxLines = if (contentExpanded) 4 else 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 2.dp),
+            )
+        }
+    }
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -81,7 +81,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | tv-prefs-compose | [#236](https://github.com/sreichholf/dreamDroid/pull/236) | merged | Phase 3.1d: Leanback prefs → Compose (`TvSettingsScreen` + `ProfileEditScreen` in `PreferenceActivity`); same PreferenceManager keys. Keep OkHttp 3.14.9. |
 | tv-textcard-drop-butterknife | [#237](https://github.com/sreichholf/dreamDroid/pull/237) | merged | Drop ButterKnife on TV `TextCardView` (last TV binds); keep dep for `VideoOverlayFragment` (VLC). Keep OkHttp 3.14.9. |
 | tv-hub-focus-dive | [#238](https://github.com/sreichholf/dreamDroid/pull/238) | merged | Phase 3.1c dive (docs only): TV browse hub focus options + agreed hub Compose PR slices. No hub code. |
-| tv-compose-textcard | this PR | open | Phase 3.1c-i: Leanback movie `TextCardView` → Compose body inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
+| tv-compose-textcard | [#239](https://github.com/sreichholf/dreamDroid/pull/239) | merged | Phase 3.1c-i: Leanback movie `TextCardView` → Compose body inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
+| tv-compose-imagecard | this PR | open | Phase 3.1c-ii: Leanback service/settings image cards → Compose text + ImageView picons inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -131,7 +132,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 3.1d Leanback prefs → Compose **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236).
 - TV `TextCardView` ButterKnife dropped **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237).
 - Phase 3.1c TV hub focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238).
-- Phase 3.1c-i Compose `TextCardView` beachhead — **this PR**.
+- Phase 3.1c-i Compose `TextCardView` beachhead **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239).
+- Phase 3.1c-ii Compose service/settings image cards — **this PR**.
 - Out of wave still: Leanback `tv/` (Phase 3), VLC, widgets. See Appendix H.
 
 ## How to read this
@@ -580,8 +582,9 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 | TV `MainActivity` | `tv/activities/MainActivity.java` | ~102 | Hosts `tv_main`; TLS + Picasso OkHttp singleton (app-wide) |
 | `RootBrowseFragment` | `tv/fragment/RootBrowseFragment.java` | ~440 | Bouquet queue, service now/next rows, movie locations, settings row; coroutine loads; typed `BrowseItem` |
 | `BaseHttpBrowseFragment` | `tv/fragment/abs/BaseHttpBrowseFragment.java` | ~29 | `BrowseSupportFragment` + `ArrayObjectAdapter` / `ListRowPresenter` |
-| `CardPresenter` | `tv/presenter/CardPresenter.java` | ~199 | Image cards (services/settings) + `TextCardView` (movies) |
-| `TextCardView` | `tv/view/TextCardView.java` | ~81 | Movie cards; ButterKnife cleared (#237) |
+| `CardPresenter` | `tv/presenter/CardPresenter.java` | ~199 | Compose `ImageCardView` (services/settings) + `TextCardView` (movies) |
+| `TextCardView` | `tv/view/TextCardView.kt` | ~125 | Movie cards; Compose body (#239) |
+| `ImageCardView` | `tv/view/ImageCardView.kt` | ~220 | Service/settings cards; ImageView picon + Compose text (this PR) |
 | `BrowseItem` | `tv/BrowseItem.kt` | ~25 | Sealed `Service` / `Movie` / `Settings` (#234) |
 
 Behaviors to preserve: headers on; brand color + badge; settings Reload/Preferences/Profile; lazy movie load on row select; stream Intent edge via hash mappers; profile-changed reload.
@@ -602,8 +605,8 @@ No in-tree `FocusRequester` / `androidx.tv` / TV LazyRow helpers today. No instr
 
 | Slice | Scope | Non-goals |
 | --- | --- | --- |
-| 3.1c-i | Compose movie `TextCardView` inside Leanback rows | **this PR**. No full hub rewrite; no VLC |
-| 3.1c-ii | Service image cards → Compose (picon + now/next text) | Keep Leanback headers/rows |
+| 3.1c-i | Compose movie `TextCardView` inside Leanback rows | **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239). No full hub rewrite; no VLC |
+| 3.1c-ii | Service image cards → Compose (picon + now/next text) | **this PR**. Keep Leanback headers/rows |
 | 3.1c-iii | Decide keep Leanback shell vs full Compose hub; if full, add `androidx.tv` (or equivalent) + focus tests | No OkHttp 4; no ButterKnife library drop |
 | 3.1c-iv | If C: replace `RootBrowseFragment` / `BaseHttpBrowseFragment` with Compose hub host | Keep typed loads + Intent edge |
 
@@ -665,7 +668,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | --- | --- | --- |
 | 3.1a | Typed `BrowseItem` | Sealed Kotlin `Service`/`Movie`/`Settings`; hash only at stream Intent edge; keep Leanback UI. Keep OkHttp 3.14.9. **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234). |
 | 3.1b | TV detail dialogs → Compose | Shared phone detail + `DreamDroidTheme`; hide EPG actions on TV; drop ButterKnife on Epg/Movie detail. Keep OkHttp 3.14.9. **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235). |
-| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). **3.1c-i this PR:** Compose `TextCardView` inside Leanback. |
+| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). 3.1c-i **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239). **3.1c-ii this PR:** Compose `ImageCardView` (picon + now/next) inside Leanback. |
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Full library drop waits on phone `VideoOverlayFragment` (VLC). |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **3.1c-ii** of Appendix H: replace Leanback `ImageCardView` for TV browse service/settings rows with a custom `BaseCardView` that keeps an `ImageView` for Picasso picons and renders title / now-next text in Compose.

- New `tv/view/ImageCardView.kt` — `CARD_TYPE_INFO_UNDER`, `FOCUS_BLOCK_DESCENDANTS`, structured `setNowNextContent` (bold-italic next start)
- `CardPresenter` MODE_IMAGE uses the new card; movie `TextCardView` path unchanged
- Docs: mark #239 merged; this PR is 3.1c-ii
- Keep OkHttp 3.14.9; no ButterKnife / VLC / hub shell rewrite

## Test plan

- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] Bugbot clean
- [ ] CI green
- [ ] Manual TV smoke when available: service row focus, picon load, now/next expand on select, settings icons
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

