### PR TITLE
feat(data): point Android Backup at Room (Phase 2.4)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/DreamDroid.java
+++ b/app/src/net/reichholf/dreamdroid/DreamDroid.java
@@ -195,7 +195,8 @@ public class DreamDroid extends Application {
 					dbh.deleteProfile(p);
 					p.setId( dao.addProfile(p) );
 				}
-
+				// Legacy SQLite is migrate-only; drop the file once Room has the profiles.
+				getAppContext().deleteDatabase(DatabaseHelper.DATABASE_NAME);
 			}
 		}
 

--- a/app/src/net/reichholf/dreamdroid/DreamDroidBackupAgent.java
+++ b/app/src/net/reichholf/dreamdroid/DreamDroidBackupAgent.java
@@ -13,8 +13,10 @@ import android.app.backup.SharedPreferencesBackupHelper;
 import net.reichholf.dreamdroid.room.AppDatabase;
 
 /**
- * Cloud backup for SharedPreferences + Room profile DB ({@link AppDatabase#DATABASE_NAME}).
- * Legacy SQLite {@code dreamdroid} is migrate-only and is not backed up.
+ * Cloud backup for SharedPreferences + profile DBs.
+ * Backs up Room {@link AppDatabase#DATABASE_NAME} and legacy {@link DatabaseHelper#DATABASE_NAME}
+ * so pre-cutover cloud snapshots (legacy file only) still restore; {@link DreamDroid} migrates
+ * legacy → Room on first launch after restore.
  */
 public class DreamDroidBackupAgent extends BackupAgentHelper {
 	public static final String PREFS = "net.reichholf.dreamdroid_preferences";
@@ -24,7 +26,9 @@ public class DreamDroidBackupAgent extends BackupAgentHelper {
 	public void onCreate(){
 		SharedPreferencesBackupHelper spbh = new SharedPreferencesBackupHelper(this, PREFS);
 		addHelper(PREFS_BACKUP_KEY, spbh);
-		FileBackupHelper dbfbh = new FileBackupHelper(this, "../databases/" + AppDatabase.DATABASE_NAME);
+		FileBackupHelper dbfbh = new FileBackupHelper(this,
+				"../databases/" + AppDatabase.DATABASE_NAME,
+				"../databases/" + DatabaseHelper.DATABASE_NAME);
 		addHelper(DATABASE_BACKUP_KEY, dbfbh);
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/DreamDroidBackupAgent.java
+++ b/app/src/net/reichholf/dreamdroid/DreamDroidBackupAgent.java
@@ -10,9 +10,11 @@ import android.app.backup.BackupAgentHelper;
 import android.app.backup.FileBackupHelper;
 import android.app.backup.SharedPreferencesBackupHelper;
 
+import net.reichholf.dreamdroid.room.AppDatabase;
+
 /**
- * @author sre
- *
+ * Cloud backup for SharedPreferences + Room profile DB ({@link AppDatabase#DATABASE_NAME}).
+ * Legacy SQLite {@code dreamdroid} is migrate-only and is not backed up.
  */
 public class DreamDroidBackupAgent extends BackupAgentHelper {
 	public static final String PREFS = "net.reichholf.dreamdroid_preferences";
@@ -22,7 +24,7 @@ public class DreamDroidBackupAgent extends BackupAgentHelper {
 	public void onCreate(){
 		SharedPreferencesBackupHelper spbh = new SharedPreferencesBackupHelper(this, PREFS);
 		addHelper(PREFS_BACKUP_KEY, spbh);
-		FileBackupHelper dbfbh = new FileBackupHelper(this, "../databases/" + DatabaseHelper.DATABASE_NAME);
+		FileBackupHelper dbfbh = new FileBackupHelper(this, "../databases/" + AppDatabase.DATABASE_NAME);
 		addHelper(DATABASE_BACKUP_KEY, dbfbh);
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetConfiguration.java
+++ b/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetConfiguration.java
@@ -15,7 +15,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import net.reichholf.dreamdroid.DatabaseHelper;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
@@ -31,6 +30,10 @@ import java.util.List;
  * Created by Stephan on 07.12.13.
  */
 public class VirtualRemoteWidgetConfiguration extends AppCompatActivity implements ItemClickSupport.OnItemClickListener {
+	/** Adapter map keys (display only; not DB columns). */
+	private static final String KEY_PROFILE_NAME = "profile";
+	private static final String KEY_PROFILE_HOST = "host";
+
     private List<Profile> mProfiles;
 	private RecyclerView mRecyclerView;
 	private ItemClickSupport mItemClickSupport;
@@ -67,13 +70,13 @@ public class VirtualRemoteWidgetConfiguration extends AppCompatActivity implemen
 		if (mProfiles.size() > 0) {
 			for (Profile m : mProfiles) {
 				ExtendedHashMap map = new ExtendedHashMap();
-				map.put(DatabaseHelper.KEY_PROFILE_PROFILE, m.getName());
-				map.put(DatabaseHelper.KEY_PROFILE_HOST, m.getHost());
+				map.put(KEY_PROFILE_NAME, m.getName());
+				map.put(KEY_PROFILE_HOST, m.getHost());
 				profiles.add(map);
 			}
 
 			SimpleTextAdapter adapter = new SimpleTextAdapter(profiles, R.layout.two_line_card_list_item_no_indicator, new String[]{
-                    DatabaseHelper.KEY_PROFILE_PROFILE, DatabaseHelper.KEY_PROFILE_HOST}, new int[]{android.R.id.text1,
+                    KEY_PROFILE_NAME, KEY_PROFILE_HOST}, new int[]{android.R.id.text1,
                     android.R.id.text2});
 			mRecyclerView.setAdapter(adapter);
 			mRecyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/net/reichholf/dreamdroid/room/AppDatabase.java
+++ b/app/src/net/reichholf/dreamdroid/room/AppDatabase.java
@@ -10,6 +10,9 @@ import net.reichholf.dreamdroid.Profile;
 
 @Database(entities = {Profile.class}, version = 1)
 public abstract class AppDatabase extends RoomDatabase {
+	/** Room profile DB file name under {@code databases/}. */
+	public static final String DATABASE_NAME = "dreambox";
+
 	public abstract Profile.ProfileDao profileDao();
 
 	private static AppDatabase db = null;
@@ -20,7 +23,7 @@ public abstract class AppDatabase extends RoomDatabase {
 			return db;
 		db = Room.databaseBuilder(
 						context.getApplicationContext(),
-						AppDatabase.class, "dreambox"
+						AppDatabase.class, DATABASE_NAME
 				)
 				.allowMainThreadQueries()
 				.build();

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -84,7 +84,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | tv-compose-textcard | [#239](https://github.com/sreichholf/dreamDroid/pull/239) | merged | Phase 3.1c-i: Leanback movie `TextCardView` → Compose body inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
 | tv-compose-imagecard | [#240](https://github.com/sreichholf/dreamDroid/pull/240) | merged | Phase 3.1c-ii: Leanback service/settings image cards → Compose text + ImageView picons inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
 | docs-tv-hub-shell-decision | [#241](https://github.com/sreichholf/dreamDroid/pull/241) | merged | Phase 3.1c-iii (docs only): keep Leanback shell + Compose cards (option B); defer full Compose hub (C / 3.1c-iv). No hub code. Keep OkHttp 3.14.9. |
-| room-backup-finish | this PR | open | Phase 2.4: Android BackupAgent → Room `dreambox`; drop legacy `dreamdroid` file after migrate; widget stops using `DatabaseHelper` keys. Keep migrate-only `DatabaseHelper`. Keep OkHttp 3.14.9. |
+| room-backup-finish | this PR | open | Phase 2.4: Android BackupAgent includes Room `dreambox` (and legacy `dreamdroid` for restore compat); drop legacy file after migrate; widget stops using `DatabaseHelper` keys. Keep migrate-only `DatabaseHelper`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -409,7 +409,7 @@ ButterKnife remains only on phone `VideoOverlayFragment` (VLC). Do not drop the 
 
 Two HTTP stacks. Box XML is `HttpURLConnection`. Picons are Picasso plus OkHttp 3.14.9.
 
-Two database files historically. Room `dreambox` holds `profile` and is what Android Backup backs up (**this PR**). Legacy SQLite `dreamdroid` remains only for first-run migrate, then is deleted once profiles are copied into Room. Do not drop `DatabaseHelper` until no install still needs that migrate path (or operator accepts migrate-from-backup-only).
+Two database files historically. Room `dreambox` holds `profile` and is included in Android Backup (**this PR**). Legacy SQLite `dreamdroid` stays on the BackupAgent file list so pre-cutover cloud snapshots still restore; after restore (or first-run migrate) copies profiles into Room, the legacy file is deleted. Do not drop `DatabaseHelper` until no install still needs that migrate path (or operator accepts migrate-from-backup-only).
 
 First-start skip-Profiles race is fixed on `main` in #168. Still wait for `Demo` after Changelog, not the word Profiles inside changelog text.
 
@@ -464,7 +464,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 - Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (#209). Movies list loads typed `enigma.Movie` (#210). Leanback movie browse still uses hash SAX.
 - Enigma2 HTTP still uses `HttpURLConnection` via `SimpleHttpClient` (coroutines + typed `EnigmaClient`). Picons still Picasso + OkHttp 3.14.9. `asynctask/*` retired.
-- Room holds `profile` only (`dreambox`). Android Backup points at Room (**this PR**). `DatabaseHelper` / `dreamdroid` SQLite remain migrate-only (deleted after successful copy).
+- Room holds `profile` only (`dreambox`). Android Backup includes Room and legacy `dreamdroid` for restore compat (**this PR**). After migrate/restore copy, legacy file is deleted; `DatabaseHelper` stays migrate-only.
 - ButterKnife (1 file: phone `VideoOverlayFragment` / VLC). TV binds cleared. `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
 
 ### Explicitly frozen

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -83,7 +83,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | tv-hub-focus-dive | [#238](https://github.com/sreichholf/dreamDroid/pull/238) | merged | Phase 3.1c dive (docs only): TV browse hub focus options + agreed hub Compose PR slices. No hub code. |
 | tv-compose-textcard | [#239](https://github.com/sreichholf/dreamDroid/pull/239) | merged | Phase 3.1c-i: Leanback movie `TextCardView` → Compose body inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
 | tv-compose-imagecard | [#240](https://github.com/sreichholf/dreamDroid/pull/240) | merged | Phase 3.1c-ii: Leanback service/settings image cards → Compose text + ImageView picons inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
-| docs-tv-hub-shell-decision | this PR | open | Phase 3.1c-iii (docs only): keep Leanback shell + Compose cards (option B); defer full Compose hub (C / 3.1c-iv). No hub code. Keep OkHttp 3.14.9. |
+| docs-tv-hub-shell-decision | [#241](https://github.com/sreichholf/dreamDroid/pull/241) | merged | Phase 3.1c-iii (docs only): keep Leanback shell + Compose cards (option B); defer full Compose hub (C / 3.1c-iv). No hub code. Keep OkHttp 3.14.9. |
+| room-backup-finish | this PR | open | Phase 2.4: Android BackupAgent → Room `dreambox`; drop legacy `dreamdroid` file after migrate; widget stops using `DatabaseHelper` keys. Keep migrate-only `DatabaseHelper`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -135,8 +136,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 3.1c TV hub focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238).
 - Phase 3.1c-i Compose `TextCardView` beachhead **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239).
 - Phase 3.1c-ii Compose service/settings image cards **merged** [#240](https://github.com/sreichholf/dreamDroid/pull/240).
-- Phase 3.1c-iii hub shell decision — **this PR** (keep Leanback + Compose cards; defer full Compose hub).
-- Out of wave still: VLC, widgets, NavHost, state/Room. See Appendix H.
+- Phase 3.1c-iii hub shell decision **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241) (keep Leanback + Compose cards; defer full Compose hub).
+- Phase 2.4 Room backup finish — **this PR** (BackupAgent → Room; delete legacy DB after migrate).
+- Out of wave still: VLC, widgets, NavHost, state. See Appendix H.
 
 ## How to read this
 
@@ -407,7 +409,7 @@ ButterKnife remains only on phone `VideoOverlayFragment` (VLC). Do not drop the 
 
 Two HTTP stacks. Box XML is `HttpURLConnection`. Picons are Picasso plus OkHttp 3.14.9.
 
-Two database files. Room `dreambox` holds `profile`. Legacy SQLite `dreamdroid` still feeds first-run migration and backup. Do not delete the old file until backup points at Room.
+Two database files historically. Room `dreambox` holds `profile` and is what Android Backup backs up (**this PR**). Legacy SQLite `dreamdroid` remains only for first-run migrate, then is deleted once profiles are copied into Room. Do not drop `DatabaseHelper` until no install still needs that migrate path (or operator accepts migrate-from-backup-only).
 
 First-start skip-Profiles race is fixed on `main` in #168. Still wait for `Demo` after Changelog, not the word Profiles inside changelog text.
 
@@ -462,7 +464,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 
 - Typed `EnigmaClient` exists. Zap list rows load typed `Service`. Service EPG list rows load typed `Event` (#176). EPG bouquet rows load typed `Event` (#179). EPG search rows load typed `Event` (#180). PickService list typing is on `main` via #181. Hub TV/Radio now/next loads typed `ServiceNowNext` (#209). Movies list loads typed `enigma.Movie` (#210). Leanback movie browse still uses hash SAX.
 - Enigma2 HTTP still uses `HttpURLConnection` via `SimpleHttpClient` (coroutines + typed `EnigmaClient`). Picons still Picasso + OkHttp 3.14.9. `asynctask/*` retired.
-- Room holds `profile` only. `DatabaseHelper` / `dreamdroid` SQLite still exist for migration and backup.
+- Room holds `profile` only (`dreambox`). Android Backup points at Room (**this PR**). `DatabaseHelper` / `dreamdroid` SQLite remain migrate-only (deleted after successful copy).
 - ButterKnife (1 file: phone `VideoOverlayFragment` / VLC). TV binds cleared. `legacy-support-v4` and `legacy-preference-v14` removed. `multiDexEnabled` stays; the `androidx.multidex` install helper is gone (minSdk 26).
 
 ### Explicitly frozen
@@ -603,7 +605,7 @@ No in-tree `FocusRequester` / `androidx.tv` / TV LazyRow helpers today. No instr
 
 **Implementation path taken:** **A → B** (#239 movie text cards, #240 service/settings image cards). Focus rule used: Leanback card keeps focus (`descendantFocusability = FOCUS_BLOCK_DESCENDANTS`; ComposeView not focusable).
 
-#### Hub shell decision (Phase 3.1c-iii — this PR)
+#### Hub shell decision (Phase 3.1c-iii — merged [#241](https://github.com/sreichholf/dreamDroid/pull/241))
 
 **Decision: keep option B** (Leanback `BrowseSupportFragment` headers/rows + Compose card bodies). **Do not start option C / 3.1c-iv now.**
 
@@ -621,7 +623,7 @@ Why:
 | --- | --- | --- |
 | 3.1c-i | Compose movie `TextCardView` inside Leanback rows | **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239) |
 | 3.1c-ii | Service image cards → Compose (picon + now/next text) | **merged** [#240](https://github.com/sreichholf/dreamDroid/pull/240) |
-| 3.1c-iii | Decide keep Leanback shell vs full Compose hub | **this PR** — keep B; defer C |
+| 3.1c-iii | Decide keep Leanback shell vs full Compose hub | **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241) — keep B; defer C |
 | 3.1c-iv | If C: replace `RootBrowseFragment` / `BaseHttpBrowseFragment` with Compose hub host | **Deferred** (not scheduled). No OkHttp 4; no ButterKnife library drop |
 
 #### Explicit non-goals of this dive PR
@@ -670,7 +672,7 @@ One program each, still one PR (or small PR series) at a time:
 | 2r | HTTP / async — Leanback RootBrowse | `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV LoaderCallbacks; delete `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + ExtendedHashMap. Keep OkHttp 3.14.9. **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). |
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |
-| 4 | Data | Finish Room migration; shrink `DatabaseHelper` to backup-only then remove |
+| 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate (**this PR**). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
 | 5 | VLC / streaming | `VideoActivity` + `VideoOverlayFragment` (ButterKnife) — product decision before rewrite |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
 
@@ -682,11 +684,11 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | --- | --- | --- |
 | 3.1a | Typed `BrowseItem` | Sealed Kotlin `Service`/`Movie`/`Settings`; hash only at stream Intent edge; keep Leanback UI. Keep OkHttp 3.14.9. **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234). |
 | 3.1b | TV detail dialogs → Compose | Shared phone detail + `DreamDroidTheme`; hide EPG actions on TV; drop ButterKnife on Epg/Movie detail. Keep OkHttp 3.14.9. **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235). |
-| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). Cards **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239)/[#240](https://github.com/sreichholf/dreamDroid/pull/240). **3.1c-iii this PR:** keep Leanback shell (B); defer full Compose hub (C/3.1c-iv). |
+| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). Cards **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239)/[#240](https://github.com/sreichholf/dreamDroid/pull/240). Shell decision **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241): keep Leanback shell (B); defer full Compose hub (C/3.1c-iv). |
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Full library drop waits on phone `VideoOverlayFragment` (VLC). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared). Next Appendix H programs: Phase 2.1b NavHost, Phase 2.3 state/rotation, Phase 2.4 Room, Phase 2.5 VLC product decision, Phase 2.6 widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). **This PR:** Phase 2.4 Room backup finish. Next Appendix H: Phase 2.1b NavHost dive, Phase 2.3 state/rotation, Phase 2.5 VLC product decision, Phase 2.6 widgets — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.4** of Appendix H: finish the Room profile data path for Android Backup.

- `DreamDroidBackupAgent` backs up Room `dreambox` **and** legacy `dreamdroid` (restore compat for pre-cutover cloud snapshots)
- After first-run migrate copies profiles into Room, delete the legacy SQLite file
- Widget config uses local adapter keys (no `DatabaseHelper` import)
- `AppDatabase.DATABASE_NAME` constant for the Room file name
- Keep migrate-only `DatabaseHelper` for installs that still have the old DB
- Docs: mark #241 merged; this PR is Phase 2.4

No OkHttp 4; no ButterKnife drop; no NavHost / state / VLC.

## Test plan

- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [x] Bugbot: fixed restore-compat finding (both DB files on BackupAgent)
- [ ] CI green
- [ ] Manual: legacy cloud restore → migrate → Room; new backup includes `dreambox`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

