### PR TITLE
feat(overlay): typed VideoOverlay state (Phase 2.5b)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ServiceAdapter.java
+++ b/app/src/net/reichholf/dreamdroid/adapter/recyclerview/ServiceAdapter.java
@@ -14,11 +14,11 @@ import android.widget.TextView;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.enigma.Event;
+import net.reichholf.dreamdroid.enigma.ServiceNowNext;
 import net.reichholf.dreamdroid.helpers.DateTime;
-import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.Python;
 import net.reichholf.dreamdroid.helpers.Statics;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Picon;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
 
@@ -27,14 +27,19 @@ import java.util.ArrayList;
 /**
  * Created by Stephan on 14.05.2015.
  */
-public class ServiceAdapter extends BaseAdapter<ServiceAdapter.ServiceViewHolder> {
+public class ServiceAdapter extends RecyclerView.Adapter<ServiceAdapter.ServiceViewHolder> {
 	protected Context mContext;
+	protected ArrayList<ServiceNowNext> mData;
 
-	public ServiceAdapter(Context context, ArrayList<ExtendedHashMap> data) {
-		super(data);
+	public ServiceAdapter(Context context, ArrayList<ServiceNowNext> data) {
 		mContext = context;
+		mData = data;
 	}
 
+	@Override
+	public int getItemCount() {
+		return mData.size();
+	}
 
 	@NonNull
 	@Override
@@ -48,53 +53,56 @@ public class ServiceAdapter extends BaseAdapter<ServiceAdapter.ServiceViewHolder
 
 	@Override
 	public void onBindViewHolder(@NonNull ServiceViewHolder holder, int position) {
-		ExtendedHashMap service = mData.get(position);
-		String next = service.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_TITLE));
+		ServiceNowNext service = mData.get(position);
+		Event nextEvent = service.getNext();
+		String next = nextEvent != null ? nextEvent.getTitle() : null;
 		boolean hasNext = next != null && !"".equals(next);
 
-		if (service != null) {
-			String ref = service.getString(Service.KEY_REFERENCE);
-			if (Service.isMarker(ref)) {
-				holder.root.setCardElevation(0);
-				holder.root.setClickable(false);
-				holder.parentService.setVisibility(View.GONE);
-				holder.parentMarker.setVisibility(View.VISIBLE);
-				holder.markerName.setText(service.getString(Event.KEY_SERVICE_NAME));
-				return;
-			}
-			if (Service.isDirectory(ref)) {
-				holder.parentService.setVisibility(View.VISIBLE);
-				holder.parentMarker.setVisibility(View.GONE);
-				holder.parentNow.setVisibility(View.GONE);
-				holder.parentNext.setVisibility(View.GONE);
-				holder.picon.setVisibility(View.GONE);
-				holder.progress.setVisibility(View.GONE);
-				holder.root.setCardElevation(mContext.getResources().getDimension(R.dimen.cardview_elevation));
-				holder.root.setClickable(false);
-				holder.serviceName.setText(service.getString(Event.KEY_SERVICE_NAME));
-				return;
-			}
-			holder.parentNow.setVisibility(View.VISIBLE);
-
-			Event.supplementReadables(service);
-			Picon.setPiconForView(mContext, holder.picon, service, Statics.TAG_PICON);
-			holder.root.setCardElevation(mContext.getResources().getDimension(R.dimen.cardview_elevation));
+		String ref = service.getServiceReference();
+		if (Service.isMarker(ref)) {
+			holder.root.setCardElevation(0);
 			holder.root.setClickable(false);
+			holder.parentService.setVisibility(View.GONE);
+			holder.parentMarker.setVisibility(View.VISIBLE);
+			holder.markerName.setText(service.getServiceName());
+			return;
+		}
+		if (Service.isDirectory(ref)) {
 			holder.parentService.setVisibility(View.VISIBLE);
 			holder.parentMarker.setVisibility(View.GONE);
-			holder.serviceName.setText(service.getString(Event.KEY_SERVICE_NAME));
-			holder.eventNowTitle.setText(service.getString(Event.KEY_EVENT_TITLE));
-			holder.eventNowStart.setText(service.getString(Event.KEY_EVENT_START_TIME_READABLE));
-			holder.eventNowDuration.setText(service.getString(Event.KEY_EVENT_DURATION_READABLE));
+			holder.parentNow.setVisibility(View.GONE);
+			holder.parentNext.setVisibility(View.GONE);
+			holder.picon.setVisibility(View.GONE);
+			holder.progress.setVisibility(View.GONE);
+			holder.root.setCardElevation(mContext.getResources().getDimension(R.dimen.cardview_elevation));
+			holder.root.setClickable(false);
+			holder.serviceName.setText(service.getServiceName());
+			return;
+		}
+		holder.parentNow.setVisibility(View.VISIBLE);
 
-			long max = -1;
-			long cur = -1;
+		Picon.setPiconForView(mContext, holder.picon, ref, service.getServiceName(), Statics.TAG_PICON, null);
+		holder.root.setCardElevation(mContext.getResources().getDimension(R.dimen.cardview_elevation));
+		holder.root.setClickable(false);
+		holder.parentService.setVisibility(View.VISIBLE);
+		holder.parentMarker.setVisibility(View.GONE);
+		holder.serviceName.setText(service.getServiceName());
 
-			String nowTime = service.getString(Event.KEY_CURRENT_TIME);
-			String duration = service.getString(Event.KEY_EVENT_DURATION);
-			String start = service.getString(Event.KEY_EVENT_START);
+		Event now = service.getNow();
+		holder.eventNowTitle.setText(now != null ? now.getTitle() : null);
+		holder.eventNowStart.setText(now != null ? now.getStartTimeReadable() : null);
+		holder.eventNowDuration.setText(now != null ? now.getDurationReadable() : null);
 
-			if (duration != null && start != null && !Python.NONE.equals(duration) && !Python.NONE.equals(start)) {
+		long max = -1;
+		long cur = -1;
+
+		if (now != null) {
+			String nowTime = now.getCurrentTime();
+			String duration = now.getDuration();
+			String start = now.getStart();
+
+			if (duration != null && start != null && !Python.NONE.equals(duration) && !Python.NONE.equals(start)
+					&& !duration.isEmpty() && !start.isEmpty()) {
 				try {
 					max = Double.valueOf(duration).longValue() / 60;
 					cur = max - DateTime.getRemaining(duration, start, nowTime);
@@ -102,21 +110,21 @@ public class ServiceAdapter extends BaseAdapter<ServiceAdapter.ServiceViewHolder
 					Log.e(DreamDroid.LOG_TAG, e.toString());
 				}
 			}
+		}
 
-			holder.progress.setVisibility(View.VISIBLE);
-			if (max > 0 && cur >= 0) {
-				holder.progress.setMax((int) max);
-				holder.progress.setProgress((int) cur);
-			}
+		holder.progress.setVisibility(View.VISIBLE);
+		if (max > 0 && cur >= 0) {
+			holder.progress.setMax((int) max);
+			holder.progress.setProgress((int) cur);
+		}
 
-			if (hasNext) {
-				holder.parentNext.setVisibility(View.VISIBLE);
-				holder.eventNextTitle.setText(service.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_TITLE)));
-				holder.eventNextStart.setText(service.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_START_TIME_READABLE)));
-				holder.eventNextDuration.setText(service.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_DURATION_READABLE)));
-			} else {
-				holder.parentNext.setVisibility(View.GONE);
-			}
+		if (hasNext) {
+			holder.parentNext.setVisibility(View.VISIBLE);
+			holder.eventNextTitle.setText(nextEvent.getTitle());
+			holder.eventNextStart.setText(nextEvent.getStartTimeReadable());
+			holder.eventNextDuration.setText(nextEvent.getDurationReadable());
+		} else {
+			holder.parentNext.setVisibility(View.GONE);
 		}
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -103,7 +103,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
-		mAdapter = new ServiceAdapter(getAppCompatActivity(), mMapList);
+		mAdapter = new ServiceAdapter(getAppCompatActivity(), mRows);
 		getRecyclerView().setAdapter(mAdapter);
 
 		super.onActivityCreated(savedInstanceState);

--- a/app/src/net/reichholf/dreamdroid/fragment/VideoOverlayFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/VideoOverlayFragment.java
@@ -48,12 +48,13 @@ import net.reichholf.dreamdroid.helpers.DateTime;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Python;
-import net.reichholf.dreamdroid.helpers.enigma2.Event;
 import net.reichholf.dreamdroid.helpers.enigma2.Movie;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.enigma.EpgNowNextLoadKt;
+import net.reichholf.dreamdroid.enigma.Event;
 import net.reichholf.dreamdroid.enigma.ServiceNowNext;
 import net.reichholf.dreamdroid.intents.IntentFactory;
+import net.reichholf.dreamdroid.ui.services.MovieListMapperKt;
 import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
 import net.reichholf.dreamdroid.tv.fragment.EpgDetailDialog;
 import net.reichholf.dreamdroid.tv.fragment.MovieDetailDialog;
@@ -96,9 +97,11 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	protected String mServiceRef;
 	protected String mBouquetRef;
 
-	protected ArrayList<ExtendedHashMap> mServiceList;
+	protected ArrayList<ServiceNowNext> mServiceList;
 	@Nullable
-	protected ExtendedHashMap mServiceInfo;
+	protected ServiceNowNext mCurrentService;
+	@Nullable
+	protected net.reichholf.dreamdroid.enigma.Movie mMovie;
 
 	protected Handler mHandler;
 	protected Runnable mAutoHideRunnable;
@@ -164,7 +167,14 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		mServiceRef = getArguments().getString(SERVICE_REFERENCE);
 		mBouquetRef = getArguments().getString(BOUQUET_REFERENCE);
 		mServiceList = new ArrayList<>();
-		mServiceInfo = ((ExtendedHashMap) getArguments().get(SERVICE_INFO));
+		ExtendedHashMap serviceInfoHash = (ExtendedHashMap) getArguments().get(SERVICE_INFO);
+		if (serviceInfoHash != null) {
+			if (serviceInfoHash.containsKey(Movie.KEY_FILE_NAME)) {
+				mMovie = MovieListMapperKt.movieFromExtendedHashMap(serviceInfoHash);
+			} else {
+				mCurrentService = ServiceListMapperKt.serviceNowNextFromExtendedHashMap(serviceInfoHash);
+			}
+		}
 		mHandler = new Handler();
 		mServicesViewVisible = false;
 		mAutoHideRunnable = () -> hideOverlays();
@@ -311,23 +321,29 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	}
 
 	private void onInfo(){
-		if (mServiceInfo == null)
+		if (mMovie == null && mCurrentService == null)
 			return;
 
 		DialogFragment detailDialog;
-		if (mServiceInfo.containsKey(Movie.KEY_FILE_NAME)) {
-
-			Movie movie = new Movie(mServiceInfo);
+		if (mMovie != null) {
 			if (DreamDroid.isTV(getContext()))
-				detailDialog = MovieDetailDialog.newInstance(movie);
+				detailDialog = MovieDetailDialog.newInstance(mMovie);
 			else
-				detailDialog = MovieDetailBottomSheet.newInstance(movie);
-
+				detailDialog = MovieDetailBottomSheet.newInstance(mMovie);
 		} else {
-			if(DreamDroid.isTV(getContext()))
-				detailDialog = EpgDetailDialog.newInstance(new Event(mServiceInfo));
+			Event event = mCurrentService.getNow();
+			if (event == null) {
+				event = new Event(
+						"", "", "", "", "", "", "",
+						mCurrentService.getServiceReference(),
+						mCurrentService.getServiceName(),
+						"", "", ""
+				);
+			}
+			if (DreamDroid.isTV(getContext()))
+				detailDialog = EpgDetailDialog.newInstance(event);
 			else
-				detailDialog = EpgDetailBottomSheet.newInstance(mServiceInfo);
+				detailDialog = EpgDetailBottomSheet.newInstance(event);
 		}
 		if (detailDialog != null)
 			detailDialog.show(getFragmentManager(), "details_dialog_tv");
@@ -395,17 +411,21 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		onServiceInfoChanged(true);
 	}
 
-	private void applyServiceList(@NonNull ArrayList<ExtendedHashMap> services) {
+	private void applyServiceList(@NonNull ArrayList<ServiceNowNext> services) {
 		mServiceList.clear();
 		if (mServicesView != null)
 			mServicesView.getAdapter().notifyDataSetChanged();
 		mServiceList.addAll(services);
-		for (ExtendedHashMap service : mServiceList) {
-			if (service.getString(Event.KEY_SERVICE_REFERENCE).equals(mServiceRef)) {
-				ExtendedHashMap oldServiceInfo = mServiceInfo;
-				mServiceInfo = service;
-				String eventid = mServiceInfo.getString(Event.KEY_EVENT_ID, "-1");
-				if (oldServiceInfo == null || !eventid.equals(oldServiceInfo.getString(Event.KEY_EVENT_ID, "-2")))
+		for (ServiceNowNext service : mServiceList) {
+			if (service.getServiceReference().equals(mServiceRef)) {
+				ServiceNowNext oldService = mCurrentService;
+				mCurrentService = service;
+				mMovie = null;
+				String eventid = mCurrentService.getNow() != null
+						? mCurrentService.getNow().getEventId() : "-1";
+				String oldEventId = oldService != null && oldService.getNow() != null
+						? oldService.getNow().getEventId() : "-2";
+				if (oldService == null || !eventid.equals(oldEventId))
 					onServiceInfoChanged(false);
 			}
 			if (mServicesView != null)
@@ -424,18 +444,30 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	private void zap() {
 		if (Service.isMarker(mServiceRef))
 			return;
-		Intent streamingIntent = IntentFactory.getStreamServiceIntent(getActivity(), mServiceRef, mTitle, mBouquetRef, mServiceInfo);
+		ExtendedHashMap serviceInfoHash = serviceInfoForIntent();
+		Intent streamingIntent = IntentFactory.getStreamServiceIntent(getActivity(), mServiceRef, mTitle, mBouquetRef, serviceInfoHash);
 		getArguments().putString(TITLE, mTitle);
 		getArguments().getString(SERVICE_REFERENCE, mServiceRef);
 		getArguments().getString(BOUQUET_REFERENCE, mBouquetRef);
-		getArguments().putSerializable(SERVICE_INFO, mServiceInfo);
+		getArguments().putSerializable(SERVICE_INFO, serviceInfoHash);
 		((VideoActivity) getActivity()).handleIntent(streamingIntent);
 
 		onServiceInfoChanged(true);
 	}
 
 	@Nullable
-	private ExtendedHashMap getPreviousServiceInfo() {
+	private ExtendedHashMap serviceInfoForIntent() {
+		if (mMovie != null) {
+			return MovieListMapperKt.movieToExtendedHashMap(mMovie);
+		}
+		if (mCurrentService != null) {
+			return ServiceListMapperKt.serviceNowNextToExtendedHashMap(mCurrentService);
+		}
+		return null;
+	}
+
+	@Nullable
+	private ServiceNowNext getPreviousServiceInfo() {
 		int index = getCurrentServiceIndex();
 		if (index < 0)
 			return null;
@@ -447,17 +479,18 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	}
 
 	private void previous() {
-		ExtendedHashMap serviceInfo = getPreviousServiceInfo();
+		ServiceNowNext serviceInfo = getPreviousServiceInfo();
 		if (serviceInfo == null)
 			return;
-		mServiceInfo = serviceInfo;
-		mServiceRef = mServiceInfo.getString(Event.KEY_SERVICE_REFERENCE);
-		mTitle = mServiceInfo.getString(Event.KEY_SERVICE_NAME);
+		mCurrentService = serviceInfo;
+		mMovie = null;
+		mServiceRef = mCurrentService.getServiceReference();
+		mTitle = mCurrentService.getServiceName();
 		zap();
 	}
 
 	@Nullable
-	private ExtendedHashMap getNextServiceInfo() {
+	private ServiceNowNext getNextServiceInfo() {
 		int index = getCurrentServiceIndex();
 		if (index < 0)
 			return null;
@@ -469,12 +502,13 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	}
 
 	private void next() {
-		ExtendedHashMap serviceInfo = getNextServiceInfo();
+		ServiceNowNext serviceInfo = getNextServiceInfo();
 		if (serviceInfo == null)
 			return;
-		mServiceInfo = serviceInfo;
-		mServiceRef = mServiceInfo.getString(Event.KEY_SERVICE_REFERENCE);
-		mTitle = mServiceInfo.getString(Event.KEY_SERVICE_NAME);
+		mCurrentService = serviceInfo;
+		mMovie = null;
+		mServiceRef = mCurrentService.getServiceReference();
+		mTitle = mCurrentService.getServiceName();
 		zap();
 	}
 
@@ -482,8 +516,8 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		if (mServiceList == null || mServiceList.isEmpty())
 			return -1;
 		int idx = 0;
-		for (ExtendedHashMap service : mServiceList) {
-			if (service.getString(Event.KEY_SERVICE_REFERENCE).equals(mServiceRef))
+		for (ServiceNowNext service : mServiceList) {
+			if (service.getServiceReference().equals(mServiceRef))
 				return idx;
 			idx++;
 		}
@@ -496,19 +530,21 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 			showOverlays();
 		else
 			updateViews();
-		if (mServiceInfo == null)
+		if (mCurrentService == null && mMovie == null)
 			return;
 		mHandler.removeCallbacks(mIssueReloadRunnable);
 		//let's see if we have any info about when the current event ends
-		String start = mServiceInfo.getString(Event.KEY_EVENT_START);
-		String duration = mServiceInfo.getString(Event.KEY_EVENT_DURATION);
-		if (duration != null && start != null && !Python.NONE.equals(duration) && !Python.NONE.equals(start)) {
+		Event now = mCurrentService != null ? mCurrentService.getNow() : null;
+		String start = now != null ? now.getStart() : null;
+		String duration = now != null ? now.getDuration() : null;
+		if (duration != null && start != null && !duration.isEmpty() && !start.isEmpty()
+				&& !Python.NONE.equals(duration) && !Python.NONE.equals(start)) {
 			long eventStart = Double.valueOf(start).longValue() * 1000;
 			long eventEnd = eventStart + (Double.valueOf(duration).longValue() * 1000);
-			long now = System.currentTimeMillis();
-			long delay = eventEnd - now;
-			if (eventEnd <= now)
-				delay = now; //outdated, reload in few seconds
+			long nowMs = System.currentTimeMillis();
+			long delay = eventEnd - nowMs;
+			if (eventEnd <= nowMs)
+				delay = nowMs; //outdated, reload in few seconds
 			delay += 2000;
 			mHandler.postDelayed(mIssueReloadRunnable, delay);
 		} else {
@@ -546,10 +582,7 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		if (!success) {
 			return;
 		}
-		ArrayList<ExtendedHashMap> services = new ArrayList<>();
-		for (ServiceNowNext row : rows) {
-			services.add(ServiceListMapperKt.serviceNowNextToExtendedHashMap(row));
-		}
+		ArrayList<ServiceNowNext> services = new ArrayList<>(rows);
 		applyServiceList(services);
 	}
 
@@ -569,7 +602,7 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 	}
 
 	private boolean isRecording() {
-		boolean isDreamboxRecording = mServiceInfo != null && mServiceInfo.containsKey(Movie.KEY_FILE_NAME);
+		boolean isDreamboxRecording = mMovie != null;
 		return VLCPlayer.get().isSeekable() || isDreamboxRecording;
 	}
 
@@ -587,35 +620,37 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		View parentNow = view.findViewById(R.id.event_now);
 		View parentNext = view.findViewById(R.id.event_next);
 
-		if (mServiceInfo != null) {
+		if (mMovie != null || mCurrentService != null) {
 			mButtonInfo.setVisibility(View.VISIBLE);
 			if (isRecording()) {
-				title.setText(mServiceInfo.getString(Movie.KEY_TITLE, mTitle));
-			} else {
-				title.setText(mServiceInfo.getString(Event.KEY_SERVICE_NAME, mTitle));
+				String movieTitle = mMovie != null ? mMovie.getTitle() : null;
+				title.setText(movieTitle != null && !movieTitle.isEmpty() ? movieTitle : mTitle);
+			} else if (mCurrentService != null) {
+				String serviceName = mCurrentService.getServiceName();
+				title.setText(serviceName != null && !serviceName.isEmpty() ? serviceName : mTitle);
 				TextView nowStart = view.findViewById(R.id.event_now_start);
 				TextView nowDuration = view.findViewById(R.id.event_now_duration);
 				TextView nowTitle = view.findViewById(R.id.event_now_title);
 
-				Event.supplementReadables(mServiceInfo); //update readable values
-
-				nowStart.setText(mServiceInfo.getString(Event.KEY_EVENT_START_TIME_READABLE));
-				nowTitle.setText(mServiceInfo.getString(Event.KEY_EVENT_TITLE));
-				nowDuration.setText(mServiceInfo.getString(Event.KEY_EVENT_DURATION_READABLE));
+				Event now = mCurrentService.getNow();
+				nowStart.setText(now != null ? now.getStartTimeReadable() : null);
+				nowTitle.setText(now != null ? now.getTitle() : null);
+				nowDuration.setText(now != null ? now.getDurationReadable() : null);
 
 				parentNow.setVisibility(View.VISIBLE);
 			}
 
-			String next = mServiceInfo.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_TITLE));
+			Event nextEvent = mCurrentService != null ? mCurrentService.getNext() : null;
+			String next = nextEvent != null ? nextEvent.getTitle() : null;
 			boolean hasNext = next != null && !"".equals(next);
 			if (hasNext) {
 				TextView nextStart = view.findViewById(R.id.event_next_start);
 				TextView nextDuration = view.findViewById(R.id.event_next_duration);
 				TextView nextTitle = view.findViewById(R.id.event_next_title);
 
-				nextStart.setText(mServiceInfo.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_START_TIME_READABLE)));
-				nextTitle.setText(mServiceInfo.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_TITLE)));
-				nextDuration.setText(mServiceInfo.getString(Event.PREFIX_NEXT.concat(Event.KEY_EVENT_DURATION_READABLE)));
+				nextStart.setText(nextEvent.getStartTimeReadable());
+				nextTitle.setText(nextEvent.getTitle());
+				nextDuration.setText(nextEvent.getDurationReadable());
 				parentNext.setVisibility(View.VISIBLE);
 			} else {
 				parentNext.setVisibility(View.GONE);
@@ -662,13 +697,14 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 		serviceProgress.setClickable(isSeekable);
 		long len = -1;
 		long cur = -1;
-		if (mServiceInfo != null) {
+		if (mMovie != null || mCurrentService != null) {
 			View parentNow = getView().findViewById(R.id.event_now);
 			View parentNext = getView().findViewById(R.id.event_next);
 			if (isRecording()) {
 				long duration = player.getLength() / 1000;
 				if (duration <= 0) {
-					String textLen = mServiceInfo.getString(Movie.KEY_LENGTH, "00:00");
+					String textLen = mMovie != null && mMovie.getLength() != null && !mMovie.getLength().isEmpty()
+							? mMovie.getLength() : "00:00";
 					String[] l = textLen.split(":");
 					try {
 						duration = (Long.valueOf(l[0]) * 60) + Long.valueOf(l[1]);
@@ -685,18 +721,20 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 
 					long pos = (long) (duration * player.getPosition()); //getTime() may deliver quite bogous values when streaming from a dreambox so we don't use them.
 					nowStart.setText(DateTime.minutesAndSeconds((int) pos));
-					nowTitle.setText(mServiceInfo.getString(Movie.KEY_SERVICE_NAME, ""));
+					nowTitle.setText(mMovie != null ? mMovie.getServiceName() : "");
 					nowDuration.setText(DateTime.minutesAndSeconds((int) duration));
 					parentNow.setVisibility(View.VISIBLE);
 				} else {
 					parentNow.setVisibility(View.GONE);
 				}
 				parentNext.setVisibility(View.GONE);
-			} else {
-				String duration = mServiceInfo.getString(Event.KEY_EVENT_DURATION);
-				String start = mServiceInfo.getString(Event.KEY_EVENT_START);
+			} else if (mCurrentService != null && mCurrentService.getNow() != null) {
+				Event now = mCurrentService.getNow();
+				String duration = now.getDuration();
+				String start = now.getStart();
 
-				if (duration != null && start != null && !Python.NONE.equals(duration) && !Python.NONE.equals(start)) {
+				if (duration != null && start != null && !duration.isEmpty() && !start.isEmpty()
+						&& !Python.NONE.equals(duration) && !Python.NONE.equals(start)) {
 					try {
 						len = Double.valueOf(duration).longValue();
 						cur = len - DateTime.getRemaining(duration, start) * 60;
@@ -865,12 +903,14 @@ public class VideoOverlayFragment extends Fragment implements MediaPlayer.EventL
 
 	@Override
 	public void onItemClick(RecyclerView parent, View view, int position, long id) {
-		String serviceRef = mServiceList.get(position).getString(Event.KEY_SERVICE_REFERENCE);
+		ServiceNowNext row = mServiceList.get(position);
+		String serviceRef = row.getServiceReference();
 		if (Service.isMarker(serviceRef))
 			return;
-		mServiceInfo = mServiceList.get(position);
+		mCurrentService = row;
+		mMovie = null;
 		mServiceRef = serviceRef;
-		mTitle = mServiceInfo.getString(Event.KEY_SERVICE_NAME);
+		mTitle = row.getServiceName();
 		zap();
 	}
 

--- a/app/src/net/reichholf/dreamdroid/tv/fragment/EpgDetailDialog.kt
+++ b/app/src/net/reichholf/dreamdroid/tv/fragment/EpgDetailDialog.kt
@@ -14,15 +14,18 @@ import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.enigma.Event
 import net.reichholf.dreamdroid.fragment.dialogs.AbstractDialog
-import net.reichholf.dreamdroid.helpers.enigma2.Event
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.enigma2.Event as HashEvent
+import net.reichholf.dreamdroid.ui.epg.EpgDetailContent
 import net.reichholf.dreamdroid.ui.epg.EpgDetailScreen
 import net.reichholf.dreamdroid.ui.epg.toEpgDetailContent
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
  * TV fullscreen EPG detail. Reuses phone [EpgDetailScreen] under [DreamDroidTheme]
- * with actions hidden (Phase 3.1b).
+ * with actions hidden (Phase 3.1b). Prefers typed [Event]; hash kept for legacy callers.
  */
 class EpgDetailDialog : AbstractDialog() {
 
@@ -38,10 +41,18 @@ class EpgDetailDialog : AbstractDialog() {
         )
     }
 
+    private fun detailContent(minutesShort: String): EpgDetailContent? {
+        val args = requireArguments()
+        val typed = args.getSerializable(ARG_TYPED_EVENT) as? Event
+        if (typed != null) {
+            return typed.toEpgDetailContent(minutesShort)
+        }
+        val hash = args.getSerializable(ARG_HASH_EVENT) as? ExtendedHashMap ?: return null
+        return hash.toEpgDetailContent(false, minutesShort)
+    }
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val event = requireArguments().getSerializable(Event::class.java.simpleName) as Event
-        val minutesShort = getString(R.string.minutes_short)
-        val content = event.toEpgDetailContent(false, minutesShort)
+        val content = detailContent(getString(R.string.minutes_short))
         if (content != null) {
             return super.onCreateDialog(savedInstanceState)
         }
@@ -57,9 +68,7 @@ class EpgDetailDialog : AbstractDialog() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        val event = requireArguments().getSerializable(Event::class.java.simpleName) as Event
-        val minutesShort = getString(R.string.minutes_short)
-        val content = event.toEpgDetailContent(false, minutesShort) ?: return super.onCreateView(
+        val content = detailContent(getString(R.string.minutes_short)) ?: return super.onCreateView(
             inflater,
             container,
             savedInstanceState,
@@ -92,10 +101,22 @@ class EpgDetailDialog : AbstractDialog() {
     }
 
     companion object {
+        private const val ARG_TYPED_EVENT = "typedEvent"
+        private const val ARG_HASH_EVENT = "Event"
+
         @JvmStatic
         fun newInstance(epg: Event): EpgDetailDialog {
             val args = Bundle()
-            args.putSerializable(Event::class.java.simpleName, epg)
+            args.putSerializable(ARG_TYPED_EVENT, epg)
+            val fragment = EpgDetailDialog()
+            fragment.arguments = args
+            return fragment
+        }
+
+        @JvmStatic
+        fun newInstance(epg: HashEvent): EpgDetailDialog {
+            val args = Bundle()
+            args.putSerializable(ARG_HASH_EVENT, epg)
             val fragment = EpgDetailDialog()
             fragment.arguments = args
             return fragment

--- a/app/src/net/reichholf/dreamdroid/tv/fragment/MovieDetailDialog.kt
+++ b/app/src/net/reichholf/dreamdroid/tv/fragment/MovieDetailDialog.kt
@@ -12,15 +12,17 @@ import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.enigma.Movie
 import net.reichholf.dreamdroid.fragment.dialogs.AbstractDialog
-import net.reichholf.dreamdroid.helpers.enigma2.Movie
+import net.reichholf.dreamdroid.helpers.enigma2.Movie as HashMovie
+import net.reichholf.dreamdroid.ui.movies.MovieDetailContent
 import net.reichholf.dreamdroid.ui.movies.MovieDetailScreen
 import net.reichholf.dreamdroid.ui.movies.toMovieDetailContent
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
  * TV fullscreen movie detail. Reuses phone [MovieDetailScreen] under [DreamDroidTheme]
- * (Phase 3.1b).
+ * (Phase 3.1b). Prefers typed [Movie]; hash kept for legacy callers.
  */
 class MovieDetailDialog : AbstractDialog() {
 
@@ -37,13 +39,22 @@ class MovieDetailDialog : AbstractDialog() {
         )
     }
 
+    private fun detailContent(): MovieDetailContent {
+        val args = requireArguments()
+        val typed = args.getSerializable(ARG_TYPED_MOVIE) as? Movie
+        if (typed != null) {
+            return typed.toMovieDetailContent()
+        }
+        val hash = args.getSerializable(ARG_HASH_MOVIE) as HashMovie
+        return hash.toMovieDetailContent()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val movie = requireArguments().getSerializable(Movie::class.java.simpleName) as Movie
-        val content = movie.toMovieDetailContent()
+        val content = detailContent()
         val host = this
         return ComposeView(requireContext()).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -67,11 +78,23 @@ class MovieDetailDialog : AbstractDialog() {
     }
 
     companion object {
+        private const val ARG_TYPED_MOVIE = "typedMovie"
+        private const val ARG_HASH_MOVIE = "Movie"
+
         @JvmStatic
         fun newInstance(movie: Movie): MovieDetailDialog {
             val fragment = MovieDetailDialog()
             val args = Bundle()
-            args.putSerializable(Movie::class.java.simpleName, movie)
+            args.putSerializable(ARG_TYPED_MOVIE, movie)
+            fragment.arguments = args
+            return fragment
+        }
+
+        @JvmStatic
+        fun newInstance(movie: HashMovie): MovieDetailDialog {
+            val fragment = MovieDetailDialog()
+            val args = Bundle()
+            args.putSerializable(ARG_HASH_MOVIE, movie)
             fragment.arguments = args
             return fragment
         }

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListMapper.kt
@@ -46,3 +46,21 @@ fun movieToExtendedHashMap(movie: Movie): ExtendedHashMap {
     map.put(MovieKeys.KEY_FILE_SIZE_READABLE, movie.fileSizeReadable)
     return map
 }
+
+/** Inverse of [movieToExtendedHashMap] for Intent / legacy hash edges. */
+fun movieFromExtendedHashMap(map: ExtendedHashMap): Movie {
+    return Movie(
+        reference = map.getString(MovieKeys.KEY_REFERENCE).orEmpty(),
+        title = map.getString(MovieKeys.KEY_TITLE).orEmpty(),
+        description = map.getString(MovieKeys.KEY_DESCRIPTION).orEmpty(),
+        descriptionExtended = map.getString(MovieKeys.KEY_DESCRIPTION_EXTENDED).orEmpty(),
+        serviceName = map.getString(MovieKeys.KEY_SERVICE_NAME).orEmpty(),
+        time = map.getString(MovieKeys.KEY_TIME).orEmpty(),
+        timeReadable = map.getString(MovieKeys.KEY_TIME_READABLE).orEmpty(),
+        length = map.getString(MovieKeys.KEY_LENGTH).orEmpty(),
+        tags = map.getString(MovieKeys.KEY_TAGS).orEmpty(),
+        fileName = map.getString(MovieKeys.KEY_FILE_NAME).orEmpty(),
+        fileSize = map.getString(MovieKeys.KEY_FILE_SIZE).orEmpty(),
+        fileSizeReadable = map.getString(MovieKeys.KEY_FILE_SIZE_READABLE).orEmpty(),
+    )
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListMapper.kt
@@ -104,6 +104,61 @@ fun serviceNowNextToExtendedHashMap(row: ServiceNowNext): ExtendedHashMap {
     return map
 }
 
+/** Inverse of [serviceNowNextToExtendedHashMap] for Intent / legacy hash edges. */
+fun serviceNowNextFromExtendedHashMap(map: ExtendedHashMap): ServiceNowNext {
+    val serviceReference = map.getString(EventKeys.KEY_SERVICE_REFERENCE).orEmpty()
+    val serviceName = map.getString(EventKeys.KEY_SERVICE_NAME).orEmpty()
+    return ServiceNowNext(
+        serviceReference = serviceReference,
+        serviceName = serviceName,
+        now = eventFromPrefixedMap(map, ""),
+        next = eventFromPrefixedMap(map, EventKeys.PREFIX_NEXT),
+    )
+}
+
+private fun eventFromPrefixedMap(map: ExtendedHashMap, prefix: String): Event? {
+    val eventId = map.getString(prefix + EventKeys.KEY_EVENT_ID).orEmpty()
+    val title = map.getString(prefix + EventKeys.KEY_EVENT_TITLE).orEmpty()
+    val start = map.getString(prefix + EventKeys.KEY_EVENT_START).orEmpty()
+    val duration = map.getString(prefix + EventKeys.KEY_EVENT_DURATION).orEmpty()
+    val currentTime = map.getString(prefix + EventKeys.KEY_CURRENT_TIME).orEmpty()
+    val description = map.getString(prefix + EventKeys.KEY_EVENT_DESCRIPTION).orEmpty()
+    val descriptionExtended = map.getString(prefix + EventKeys.KEY_EVENT_DESCRIPTION_EXTENDED).orEmpty()
+    val startReadable = map.getString(prefix + EventKeys.KEY_EVENT_START_READABLE).orEmpty()
+    val startTimeReadable = map.getString(prefix + EventKeys.KEY_EVENT_START_TIME_READABLE).orEmpty()
+    val durationReadable = map.getString(prefix + EventKeys.KEY_EVENT_DURATION_READABLE).orEmpty()
+    if (eventId.isEmpty() && title.isEmpty() && start.isEmpty() && duration.isEmpty()
+        && currentTime.isEmpty() && description.isEmpty() && descriptionExtended.isEmpty()
+        && startReadable.isEmpty() && startTimeReadable.isEmpty() && durationReadable.isEmpty()
+    ) {
+        return null
+    }
+    val serviceReference = if (prefix.isEmpty()) {
+        map.getString(EventKeys.KEY_SERVICE_REFERENCE).orEmpty()
+    } else {
+        ""
+    }
+    val serviceName = if (prefix.isEmpty()) {
+        map.getString(EventKeys.KEY_SERVICE_NAME).orEmpty()
+    } else {
+        ""
+    }
+    return Event(
+        eventId = eventId,
+        title = title,
+        start = start,
+        duration = duration,
+        currentTime = currentTime,
+        description = description,
+        descriptionExtended = descriptionExtended,
+        serviceReference = serviceReference,
+        serviceName = serviceName,
+        startReadable = startReadable,
+        startTimeReadable = startTimeReadable,
+        durationReadable = durationReadable,
+    )
+}
+
 private fun putEventFields(map: ExtendedHashMap, prefix: String, event: Event?) {
     if (event == null) {
         return

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/MovieListMapperTest.java
@@ -54,6 +54,38 @@ public class MovieListMapperTest {
     }
 
     @Test
+    public void fromExtendedHashMapRoundTripsFields() {
+        Movie movie = new Movie(
+                "ref",
+                "Title",
+                "desc",
+                "ext",
+                "Service",
+                "100",
+                "readable",
+                "30",
+                "tag",
+                "/file.ts",
+                "1024",
+                "0 MB"
+        );
+        ExtendedHashMap map = MovieListMapperKt.movieToExtendedHashMap(movie);
+        Movie back = MovieListMapperKt.movieFromExtendedHashMap(map);
+        assertEquals(movie.getReference(), back.getReference());
+        assertEquals(movie.getTitle(), back.getTitle());
+        assertEquals(movie.getDescription(), back.getDescription());
+        assertEquals(movie.getDescriptionExtended(), back.getDescriptionExtended());
+        assertEquals(movie.getServiceName(), back.getServiceName());
+        assertEquals(movie.getTime(), back.getTime());
+        assertEquals(movie.getTimeReadable(), back.getTimeReadable());
+        assertEquals(movie.getLength(), back.getLength());
+        assertEquals(movie.getTags(), back.getTags());
+        assertEquals(movie.getFileName(), back.getFileName());
+        assertEquals(movie.getFileSize(), back.getFileSize());
+        assertEquals(movie.getFileSizeReadable(), back.getFileSizeReadable());
+    }
+
+    @Test
     public void emptyTypedListYieldsNoItems() {
         assertEquals(0, MovieListMapperKt.movieListItemsFromMovies(Collections.emptyList()).size());
     }

--- a/app/src/test/java/net/reichholf/dreamdroid/ui/services/ServiceListMapperTest.java
+++ b/app/src/test/java/net/reichholf/dreamdroid/ui/services/ServiceListMapperTest.java
@@ -84,6 +84,31 @@ public class ServiceListMapperTest {
     }
 
     @Test
+    public void fromExtendedHashMapRoundTripsNowAndNext() {
+        Event now = new Event(
+                "1", "Now", "100", "60", "100", "d", "x",
+                "1:0:1:1:1:1:0:0:0:0:", "TV", "r", "t", "1"
+        );
+        Event next = new Event(
+                "2", "Next", "160", "60", "100", "d2", "x2",
+                "", "", "r2", "t2", "1"
+        );
+        ServiceNowNext row = new ServiceNowNext("1:0:1:1:1:1:0:0:0:0:", "TV", now, next);
+        ExtendedHashMap map = ServiceListMapperKt.serviceNowNextToExtendedHashMap(row);
+        ServiceNowNext back = ServiceListMapperKt.serviceNowNextFromExtendedHashMap(map);
+        assertEquals(row.getServiceReference(), back.getServiceReference());
+        assertEquals(row.getServiceName(), back.getServiceName());
+        assertNotNull(back.getNow());
+        assertEquals("Now", back.getNow().getTitle());
+        assertEquals("1", back.getNow().getEventId());
+        assertEquals("100", back.getNow().getStart());
+        assertNotNull(back.getNext());
+        assertEquals("Next", back.getNext().getTitle());
+        assertEquals("2", back.getNext().getEventId());
+        assertEquals("t2", back.getNext().getStartTimeReadable());
+    }
+
+    @Test
     public void emptyTypedListYieldsNoItems() {
         assertEquals(0, ServiceListMapperKt.serviceListItemsFromNowNext(Collections.emptyList()).size());
     }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -85,7 +85,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | tv-compose-imagecard | [#240](https://github.com/sreichholf/dreamDroid/pull/240) | merged | Phase 3.1c-ii: Leanback service/settings image cards → Compose text + ImageView picons inside `BaseCardView`; keep rows/headers. Keep OkHttp 3.14.9. |
 | docs-tv-hub-shell-decision | [#241](https://github.com/sreichholf/dreamDroid/pull/241) | merged | Phase 3.1c-iii (docs only): keep Leanback shell + Compose cards (option B); defer full Compose hub (C / 3.1c-iv). No hub code. Keep OkHttp 3.14.9. |
 | room-backup-finish | [#242](https://github.com/sreichholf/dreamDroid/pull/242) | merged | Phase 2.4: Android BackupAgent includes Room `dreambox` (and legacy `dreamdroid` for restore compat); drop legacy file after migrate; widget stops using `DatabaseHelper` keys. Keep migrate-only `DatabaseHelper`. Keep OkHttp 3.14.9. |
-| docs-vlc-product-decision | this PR | open | Phase 2.5 (docs only): VLC/streaming inventory + product options; **decision A** keep libVLC + Compose overlay rewrite path. No player code. Keep OkHttp 3.14.9. |
+| docs-vlc-product-decision | [#243](https://github.com/sreichholf/dreamDroid/pull/243) | merged | Phase 2.5 (docs only): VLC/streaming inventory + product options; **decision A** keep libVLC + Compose overlay rewrite path. No player code. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -139,7 +139,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 3.1c-ii Compose service/settings image cards **merged** [#240](https://github.com/sreichholf/dreamDroid/pull/240).
 - Phase 3.1c-iii hub shell decision **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241) (keep Leanback + Compose cards; defer full Compose hub).
 - Phase 2.4 Room backup finish **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242).
-- Phase 2.5 VLC product decision — **this PR** (keep libVLC; Compose overlay rewrite path).
+- Phase 2.5 VLC product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (keep libVLC; Compose overlay rewrite path).
+- Phase 2.5b typed overlay state — **this PR** (`ServiceNowNext` / `Movie`; hash only at stream Intent / legacy edges).
 - Out of wave still: widgets, NavHost, state. See Appendix H.
 
 ## How to read this
@@ -675,12 +676,12 @@ One program each, still one PR (or small PR series) at a time:
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
 | 3 | State / rotation | Replace Evernote `@State` + Livefront Bridge (frozen today) with SavedStateHandle / rememberSaveable |
 | 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate. **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
-| 5 | VLC / streaming | Product decision **this PR** (option A: keep libVLC + Compose overlay). Implementation slices below. |
+| 5 | VLC / streaming | Product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (option A: keep libVLC + Compose overlay). **This PR:** 2.5b typed overlay state. |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
 
-### Phase 2.5 — VLC / streaming product decision (this PR; docs only)
+### Phase 2.5 — VLC / streaming (decision merged [#243](https://github.com/sreichholf/dreamDroid/pull/243); this PR = 2.5b typed overlay state)
 
-**No player / overlay code in this PR.** Implementation starts only after this decision is on `main`.
+**Decision A** (docs [#243](https://github.com/sreichholf/dreamDroid/pull/243)): keep libVLC; Compose overlay rewrite path. **This PR (2.5b):** typed `VideoOverlayFragment` state — `List<ServiceNowNext>` + optional `enigma.Movie`; hash only at stream Intent / legacy edges. No Compose overlay UI, no ButterKnife drop, no Media3.
 
 #### Inventory (current)
 
@@ -706,7 +707,7 @@ HTTP overlay loads already coroutine (#231). Stream **bytes** are not `EnigmaCli
 | **C. External-player only** | Delete integrated player; always `ACTION_VIEW` | Deletes ~1.6k LOC + VLC AAR + ButterKnife in one stroke | Loses in-app zap/EPG/PiP; worse TV UX |
 | **D. Defer indefinitely** | Leave as-is | Zero risk now; frees NavHost / state / widgets | ButterKnife stuck; VLC stays a modernization island |
 
-#### Decision (Phase 2.5 — this PR)
+#### Decision (Phase 2.5 — merged [#243](https://github.com/sreichholf/dreamDroid/pull/243))
 
 **Decision: option A** — keep libVLC; rewrite `VideoOverlayFragment` to Compose (typed overlay state first), then drop ButterKnife. Do **not** start B/C without a new operator ask.
 
@@ -722,8 +723,8 @@ Why:
 
 | Slice | Scope | Non-goals |
 | --- | --- | --- |
-| 2.5a | Docs decision on `main` | **this PR**. No player code |
-| 2.5b | Typed overlay state (`ServiceNowNext` / movie) — stop hashing for overlay UI lists | No Media3; no ButterKnife library drop yet |
+| 2.5a | Docs decision on `main` | **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243). No player code |
+| 2.5b | Typed overlay state (`ServiceNowNext` / movie) — stop hashing for overlay UI lists | **this PR**. No Media3; no ButterKnife library drop yet |
 | 2.5c | Compose overlay controls inside existing `VideoActivity` | Keep libVLC + Intent edge |
 | 2.5d | Drop ButterKnife binds + dependency (last phone binds) | No OkHttp 4; no NavHost drive-by |
 | 2.5e | Optional: thin Kotlin VLC wrapper + instrumented overlay smoke | No codec / server work |
@@ -749,7 +750,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Full library drop waits on phone `VideoOverlayFragment` (VLC). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). **This PR:** Phase 2.5 VLC decision (A — keep libVLC + Compose overlay). Next Appendix H: 2.5b typed overlay state, or Phase 2.1b NavHost dive / 2.3 state / 2.6 widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243). **This PR:** Phase 2.5b typed overlay state. Next Appendix H: 2.5c Compose overlay, or Phase 2.1b NavHost dive / 2.3 state / 2.6 widgets — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.5b**: typed VideoOverlay state after the Phase 2.5 product decision (#243).

- Bouquet list + current live selection held as `ServiceNowNext` (no hash for overlay UI lists)
- Recordings held as typed `enigma.Movie`
- Reverse mappers for Intent ingress; hash only at `IntentFactory` stream edge
- `ServiceAdapter` binds typed rows; vestigial hub adapter uses `mRows`
- TV detail dialogs gain typed `newInstance` overloads
- Docs: #243 merged; this PR is 2.5b

**Non-goals:** Compose overlay UI (2.5c), ButterKnife drop (2.5d), Media3, OkHttp 4.

## Test plan

- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] Bugbot clean
- [ ] CI green
- [ ] Manual: open integrated player from hub, zap via overlay list, info sheet live + recording
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

