### PR TITLE
fix(ui): reload FAB, picon gap, and virtual remote layout

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreenTest.kt
@@ -1,13 +1,18 @@
 package net.reichholf.dreamdroid.ui.remote
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -75,5 +80,28 @@ class VirtualRemoteScreenTest {
         composeRule.onNodeWithText("B-").assertIsDisplayed()
         composeRule.onNodeWithText("1").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Play").assertDoesNotExist()
+    }
+
+    @Test
+    fun fullRemoteIsHorizontallyCenteredInWideHost() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                VirtualRemoteScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    layout = VirtualRemoteLayout.Full,
+                    playButtonAsPlayPause = false,
+                    onKey = { _, _ -> },
+                )
+            }
+        }
+        val root = composeRule.onRoot().getBoundsInRoot()
+        val ok = composeRule.onNodeWithText("OK").getBoundsInRoot()
+        val okCenterX = (ok.left + ok.right) / 2
+        val rootCenterX = (root.left + root.right) / 2
+        // OK sits in the middle of the 3-wide nav pad, which is centered in the host.
+        assertTrue(
+            "OK center=$okCenterX root center=$rootCenterX",
+            kotlin.math.abs((okCenterX - rootCenterX).value) < 24f,
+        )
     }
 }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
@@ -80,7 +80,8 @@ class ServiceListScreenTest {
             }
         }
         // Card padding 12dp + list horizontal padding 8dp = 20dp from root.
-        composeRule.onNodeWithText("ZDF")
+        // useUnmergedTree: combinedClickable merges semantics up to the Card (left=8dp).
+        composeRule.onNodeWithText("ZDF", useUnmergedTree = true)
             .assertIsDisplayed()
             .assertLeftPositionInRootIsEqualTo(20.dp)
     }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
@@ -1,8 +1,10 @@
 package net.reichholf.dreamdroid.ui.services
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
@@ -51,5 +53,35 @@ class ServiceListScreenTest {
         composeRule.onNodeWithText("ARD").assertIsDisplayed()
         composeRule.onNodeWithText("20:00  Tagesschau  15").assertIsDisplayed()
         composeRule.onNodeWithText("20:15  Wetter  5").assertIsDisplayed()
+    }
+
+    @Test
+    fun withoutPiconsChannelTitleSitsAtLeadingEdge() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .putBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, false)
+            .commit()
+
+        composeRule.setContent {
+            DreamDroidTheme {
+                ServiceListScreen(
+                    items = listOf(
+                        ServiceListItem(
+                            index = 0,
+                            reference = "1:0:1:1:1:1:1:0:0:0:",
+                            name = "ZDF",
+                            kind = ServiceRowKind.CHANNEL,
+                        ),
+                    ),
+                    onItemClick = {},
+                    onItemLongClick = {},
+                )
+            }
+        }
+        // Card padding 12dp + list horizontal padding 8dp = 20dp from root.
+        composeRule.onNodeWithText("ZDF")
+            .assertIsDisplayed()
+            .assertLeftPositionInRootIsEqualTo(20.dp)
     }
 }

--- a/app/res/layout-sw720dp/dualpane.xml
+++ b/app/res/layout-sw720dp/dualpane.xml
@@ -33,17 +33,6 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-        <LinearLayout
-            android:id="@+id/fab_layout"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="?attr/actionBarSize"
-            android:layout_marginEnd="@dimen/fab_margin_right"
-            android:layout_marginRight="@dimen/fab_margin_right"
-            android:orientation="horizontal"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="top|end" />
-
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appbar"
             android:layout_width="match_parent"
@@ -92,18 +81,21 @@
             app:layout_anchorGravity="bottom|end|right"
             app:pressedTranslationZ="12dp" />
 
+        <!-- Gravity (not detail_view anchor): Compose LazyColumn nested scroll collapses
+             the AppBar and used to drag the top-anchored reload FAB off-screen. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_reload"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_margin_right"
+            android:layout_gravity="top|end"
+            android:layout_marginTop="?attr/actionBarSize"
+            android:layout_marginEnd="@dimen/fab_margin_right"
+            android:layout_marginRight="@dimen/fab_margin_right"
             android:src="@drawable/ic_action_refresh"
             android:visibility="gone"
             app:elevation="6dp"
             app:fabSize="mini"
-            app:layout_anchor="@+id/fab_layout"
-            app:layout_anchorGravity="bottom|end"
             app:layout_behavior="net.reichholf.dreamdroid.widget.behaviour.ScrollAwareFABBehavior"
             app:pressedTranslationZ="12dp" />
 

--- a/app/res/layout/dualpane.xml
+++ b/app/res/layout/dualpane.xml
@@ -59,29 +59,21 @@
             app:pressedTranslationZ="12dp"
             android:src="@drawable/ic_action_fab_add"/>
 
-        <LinearLayout
-            android:id="@+id/fab_layout"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginEnd="@dimen/fab_margin_right"
-            android:layout_marginRight="@dimen/fab_margin_right"
-            android:layout_marginTop="?attr/actionBarSize"
-            android:orientation="horizontal"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="top|end"/>
-
+        <!-- Gravity (not detail_view anchor): Compose LazyColumn nested scroll collapses
+             the AppBar and used to drag the top-anchored reload FAB off-screen. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_reload"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_margin_right"
+            android:layout_gravity="top|end"
+            android:layout_marginTop="?attr/actionBarSize"
+            android:layout_marginEnd="@dimen/fab_margin_right"
+            android:layout_marginRight="@dimen/fab_margin_right"
             android:src="@drawable/ic_action_refresh"
             android:visibility="gone"
             app:elevation="6dp"
             app:fabSize="mini"
-            app:layout_anchor="@+id/fab_layout"
-            app:layout_anchorGravity="bottom|end"
             app:layout_behavior="net.reichholf.dreamdroid.widget.behaviour.ScrollAwareFABBehavior"
             app:pressedTranslationZ="12dp"/>
 

--- a/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteScreen.kt
@@ -7,20 +7,23 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -53,6 +56,17 @@ private val KeyBlue = Color(0xFF1565C0)
 private val KeyOnDark = Color.White
 private val KeyOnYellow = Color(0xFF212121)
 
+private data class RemoteMetrics(
+    val keyWidth: Dp,
+    val keyHeight: Dp,
+    val keyHeightLow: Dp,
+    val gap: Dp,
+)
+
+private val LocalRemoteMetrics = compositionLocalOf {
+    RemoteMetrics(keyWidth = 56.dp, keyHeight = 48.dp, keyHeightLow = 36.dp, gap = 4.dp)
+}
+
 @Composable
 fun VirtualRemoteScreen(
     layout: VirtualRemoteLayout,
@@ -60,22 +74,45 @@ fun VirtualRemoteScreen(
     onKey: (keyCode: Int, longClick: Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .wrapContentWidth()
-            .widthIn(max = 320.dp)
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
     ) {
-        when (layout) {
-            VirtualRemoteLayout.QuickZap -> QuickZapPad(onKey = onKey)
-            VirtualRemoteLayout.Simple -> SimplePad(onKey = onKey)
-            VirtualRemoteLayout.Full -> FullPad(
-                playButtonAsPlayPause = playButtonAsPlayPause,
-                onKey = onKey,
-            )
+        val horizontalPad = 16.dp
+        val available = maxWidth - horizontalPad * 2
+        // Full/simple pads are five columns (side + 3 digits + side); quick-zap is also five.
+        val gap = 4.dp
+        val rawKey = (available - gap * 4) / 5
+        val keyWidth = rawKey.coerceIn(52.dp, 72.dp)
+        val keyHeight = (keyWidth * 0.86f).coerceIn(44.dp, 64.dp)
+        val keyHeightLow = (keyHeight * 0.75f).coerceIn(32.dp, 48.dp)
+        val metrics = RemoteMetrics(
+            keyWidth = keyWidth,
+            keyHeight = keyHeight,
+            keyHeightLow = keyHeightLow,
+            gap = gap,
+        )
+        val padMaxWidth = keyWidth * 5 + gap * 4
+
+        CompositionLocalProvider(LocalRemoteMetrics provides metrics) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = padMaxWidth)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = horizontalPad, vertical = 12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(metrics.gap * 2 + 2.dp),
+            ) {
+                when (layout) {
+                    VirtualRemoteLayout.QuickZap -> QuickZapPad(onKey = onKey)
+                    VirtualRemoteLayout.Simple -> SimplePad(onKey = onKey)
+                    VirtualRemoteLayout.Full -> FullPad(
+                        playButtonAsPlayPause = playButtonAsPlayPause,
+                        onKey = onKey,
+                    )
+                }
+            }
         }
     }
 }
@@ -104,58 +141,60 @@ private fun SimplePad(onKey: (Int, Boolean) -> Unit) {
 
 @Composable
 private fun QuickZapPad(onKey: (Int, Boolean) -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = 36.dp)
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    val m = LocalRemoteMetrics.current
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
+        RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = m.keyHeightLow)
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
             RemoteKey(label = "V+", keyCode = Remote.KEY_VOLP, onKey = onKey, container = KeyLight)
             RemoteKey(label = "V-", keyCode = Remote.KEY_VOLM, onKey = onKey, container = KeyLight)
         }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
             RemoteKey(label = "Mute", keyCode = Remote.KEY_MUTE, onKey = onKey)
             RemoteKey(label = "Exit", keyCode = Remote.KEY_EXIT, onKey = onKey, container = KeyRed)
         }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
             RemoteKey(label = "B+", keyCode = Remote.KEY_BOUP, onKey = onKey, container = KeyLight)
             RemoteKey(label = "B-", keyCode = Remote.KEY_BOUM, onKey = onKey, container = KeyLight)
         }
-        RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = 36.dp)
+        RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = m.keyHeightLow)
     }
     NavigationPad(onKey = onKey, big = true)
-    ColorKeysRow(onKey = onKey, height = 36.dp)
+    ColorKeysRow(onKey = onKey, height = m.keyHeightLow)
 }
 
 @Composable
 private fun NumberVolumeBouquetPad(onKey: (Int, Boolean) -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = 36.dp)
+    val m = LocalRemoteMetrics.current
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
+            RemoteKey(label = "Help", keyCode = Remote.KEY_HELP, onKey = onKey, height = m.keyHeightLow)
             RemoteKey(label = "V+", keyCode = Remote.KEY_VOLP, onKey = onKey, container = KeyLight)
             RemoteKey(label = "V-", keyCode = Remote.KEY_VOLM, onKey = onKey, container = KeyLight)
         }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
                 DigitKey("1", Remote.KEY_1, onKey)
                 DigitKey("2", Remote.KEY_2, onKey)
                 DigitKey("3", Remote.KEY_3, onKey)
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
                 DigitKey("4", Remote.KEY_4, onKey)
                 DigitKey("5", Remote.KEY_5, onKey)
                 DigitKey("6", Remote.KEY_6, onKey)
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
                 DigitKey("7", Remote.KEY_7, onKey)
                 DigitKey("8", Remote.KEY_8, onKey)
                 DigitKey("9", Remote.KEY_9, onKey)
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
                 DigitKey("<", Remote.KEY_PREV, onKey)
                 DigitKey("0", Remote.KEY_0, onKey)
                 DigitKey(">", Remote.KEY_NEXT, onKey)
             }
         }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = 36.dp)
+        Column(verticalArrangement = Arrangement.spacedBy(m.gap)) {
+            RemoteKey(label = "PWR", keyCode = Remote.KEY_POWER, onKey = onKey, container = KeyRed, height = m.keyHeightLow)
             RemoteKey(label = "B+", keyCode = Remote.KEY_BOUP, onKey = onKey, container = KeyLight)
             RemoteKey(label = "B-", keyCode = Remote.KEY_BOUM, onKey = onKey, container = KeyLight)
         }
@@ -163,23 +202,26 @@ private fun NumberVolumeBouquetPad(onKey: (Int, Boolean) -> Unit) {
 }
 
 @Composable
-private fun ColorKeysRow(onKey: (Int, Boolean) -> Unit, height: Dp = 30.dp) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        RemoteKey(label = "Red", keyCode = Remote.KEY_RED, onKey = onKey, container = KeyRed, height = height, showLabel = false)
-        RemoteKey(label = "Green", keyCode = Remote.KEY_GREEN, onKey = onKey, container = KeyGreen, height = height, showLabel = false)
-        RemoteKey(label = "Yellow", keyCode = Remote.KEY_YELLOW, onKey = onKey, container = KeyYellow, height = height, showLabel = false, contentColor = KeyOnYellow)
-        RemoteKey(label = "Blue", keyCode = Remote.KEY_BLUE, onKey = onKey, container = KeyBlue, height = height, showLabel = false)
+private fun ColorKeysRow(onKey: (Int, Boolean) -> Unit, height: Dp? = null) {
+    val m = LocalRemoteMetrics.current
+    val rowHeight = height ?: m.keyHeightLow
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
+        RemoteKey(label = "Red", keyCode = Remote.KEY_RED, onKey = onKey, container = KeyRed, height = rowHeight, showLabel = false)
+        RemoteKey(label = "Green", keyCode = Remote.KEY_GREEN, onKey = onKey, container = KeyGreen, height = rowHeight, showLabel = false)
+        RemoteKey(label = "Yellow", keyCode = Remote.KEY_YELLOW, onKey = onKey, container = KeyYellow, height = rowHeight, showLabel = false, contentColor = KeyOnYellow)
+        RemoteKey(label = "Blue", keyCode = Remote.KEY_BLUE, onKey = onKey, container = KeyBlue, height = rowHeight, showLabel = false)
     }
 }
 
 @Composable
 private fun NavigationPad(onKey: (Int, Boolean) -> Unit, big: Boolean = false) {
-    val size = if (big) 64.dp else 52.dp
+    val m = LocalRemoteMetrics.current
+    val size = if (big) (m.keyWidth * 1.15f).coerceAtMost(72.dp) else m.keyWidth
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(m.gap),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
             RemoteKey(label = "Info", keyCode = Remote.KEY_INFO, onKey = onKey, width = size, height = size)
             IconRemoteKey(
                 description = "Up",
@@ -192,7 +234,7 @@ private fun NavigationPad(onKey: (Int, Boolean) -> Unit, big: Boolean = false) {
             )
             RemoteKey(label = "Menu", keyCode = Remote.KEY_MENU, onKey = onKey, width = size, height = size)
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
             IconRemoteKey(
                 description = "Left",
                 keyCode = Remote.KEY_LEFT,
@@ -213,7 +255,7 @@ private fun NavigationPad(onKey: (Int, Boolean) -> Unit, big: Boolean = false) {
                 container = KeyLight,
             )
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
             RemoteKey(label = "Audio", keyCode = Remote.KEY_AUDIO, onKey = onKey, width = size, height = size)
             IconRemoteKey(
                 description = "Down",
@@ -231,22 +273,25 @@ private fun NavigationPad(onKey: (Int, Boolean) -> Unit, big: Boolean = false) {
 
 @Composable
 private fun MuteExitRow(onKey: (Int, Boolean) -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        RemoteKey(label = "Mute", keyCode = Remote.KEY_MUTE, onKey = onKey, width = 88.dp, height = 36.dp)
-        RemoteKey(label = "Exit", keyCode = Remote.KEY_EXIT, onKey = onKey, width = 88.dp, height = 36.dp, container = KeyRed)
+    val m = LocalRemoteMetrics.current
+    val width = m.keyWidth * 1.7f
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
+        RemoteKey(label = "Mute", keyCode = Remote.KEY_MUTE, onKey = onKey, width = width, height = m.keyHeightLow)
+        RemoteKey(label = "Exit", keyCode = Remote.KEY_EXIT, onKey = onKey, width = width, height = m.keyHeightLow, container = KeyRed)
     }
 }
 
 @Composable
 private fun TransportPad(playButtonAsPlayPause: Boolean, onKey: (Int, Boolean) -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    val m = LocalRemoteMetrics.current
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
         IconRemoteKey(
             description = "Rewind",
             keyCode = Remote.KEY_REWIND,
             iconRes = R.drawable.ic_media_previous_dark,
             onKey = onKey,
-            width = 56.dp,
-            height = 48.dp,
+            width = m.keyWidth,
+            height = m.keyHeight,
         )
         if (playButtonAsPlayPause) {
             IconRemoteKey(
@@ -254,8 +299,8 @@ private fun TransportPad(playButtonAsPlayPause: Boolean, onKey: (Int, Boolean) -
                 keyCode = Remote.KEY_PLAYPAUSE,
                 iconRes = R.drawable.ic_media_play_pause_dark,
                 onKey = onKey,
-                width = 56.dp,
-                height = 48.dp,
+                width = m.keyWidth,
+                height = m.keyHeight,
             )
         } else {
             IconRemoteKey(
@@ -263,8 +308,8 @@ private fun TransportPad(playButtonAsPlayPause: Boolean, onKey: (Int, Boolean) -
                 keyCode = Remote.KEY_PLAY,
                 iconRes = R.drawable.ic_media_play_dark,
                 onKey = onKey,
-                width = 56.dp,
-                height = 48.dp,
+                width = m.keyWidth,
+                height = m.keyHeight,
             )
         }
         IconRemoteKey(
@@ -272,32 +317,33 @@ private fun TransportPad(playButtonAsPlayPause: Boolean, onKey: (Int, Boolean) -
             keyCode = Remote.KEY_STOP,
             iconRes = R.drawable.ic_media_stop_dark,
             onKey = onKey,
-            width = 56.dp,
-            height = 48.dp,
+            width = m.keyWidth,
+            height = m.keyHeight,
         )
         IconRemoteKey(
             description = "Forward",
             keyCode = Remote.KEY_FORWARD,
             iconRes = R.drawable.ic_media_next_dark,
             onKey = onKey,
-            width = 56.dp,
-            height = 48.dp,
+            width = m.keyWidth,
+            height = m.keyHeight,
         )
     }
 }
 
 @Composable
 private fun SourcePad(onKey: (Int, Boolean) -> Unit) {
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        RemoteKey(label = "TV", keyCode = Remote.KEY_TV, onKey = onKey, width = 56.dp, height = 48.dp)
-        RemoteKey(label = "RADIO", keyCode = Remote.KEY_RADIO, onKey = onKey, width = 56.dp, height = 48.dp)
-        RemoteKey(label = "TEXT", keyCode = Remote.KEY_TEXT, onKey = onKey, width = 56.dp, height = 48.dp)
+    val m = LocalRemoteMetrics.current
+    Row(horizontalArrangement = Arrangement.spacedBy(m.gap)) {
+        RemoteKey(label = "TV", keyCode = Remote.KEY_TV, onKey = onKey, width = m.keyWidth, height = m.keyHeight)
+        RemoteKey(label = "RADIO", keyCode = Remote.KEY_RADIO, onKey = onKey, width = m.keyWidth, height = m.keyHeight)
+        RemoteKey(label = "TEXT", keyCode = Remote.KEY_TEXT, onKey = onKey, width = m.keyWidth, height = m.keyHeight)
         RemoteKey(
             label = "REC",
             keyCode = Remote.KEY_RECORD,
             onKey = onKey,
-            width = 56.dp,
-            height = 48.dp,
+            width = m.keyWidth,
+            height = m.keyHeight,
             contentColor = KeyRed,
         )
     }
@@ -320,17 +366,20 @@ private fun RemoteKey(
     keyCode: Int,
     onKey: (Int, Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    width: Dp = 52.dp,
-    height: Dp = 48.dp,
+    width: Dp? = null,
+    height: Dp? = null,
     container: Color = KeyDark,
     contentColor: Color = KeyOnDark,
     showLabel: Boolean = true,
     fontWeight: FontWeight = FontWeight.Normal,
 ) {
+    val m = LocalRemoteMetrics.current
+    val keyWidth = width ?: m.keyWidth
+    val keyHeight = height ?: m.keyHeight
     Box(
         modifier = modifier
-            .width(width)
-            .height(height)
+            .width(keyWidth)
+            .height(keyHeight)
             .clip(RoundedCornerShape(6.dp))
             .background(container)
             .semantics { contentDescription = label }

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.preference.PreferenceManager
+import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.Event
@@ -78,7 +80,6 @@ private fun ServiceRow(
                     text = item.name,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(start = 8.dp),
                 )
             }
             if (item.kind == ServiceRowKind.CHANNEL) {
@@ -114,9 +115,16 @@ private fun ServiceRow(
 @Composable
 private fun ServicePicon(item: ServiceListItem) {
     val context = LocalContext.current
+    val piconsEnabled = PreferenceManager.getDefaultSharedPreferences(context)
+        .getBoolean(DreamDroid.PREFS_KEY_PICONS_ENABLED, DreamDroid.isTV(context))
+    if (!piconsEnabled) {
+        return
+    }
     AndroidView(
         factory = { ctx -> ImageView(ctx) },
-        modifier = Modifier.size(48.dp),
+        modifier = Modifier
+            .padding(end = 8.dp)
+            .size(48.dp),
         update = { view ->
             val map = ExtendedHashMap()
             map.put(Service.KEY_REFERENCE, item.reference)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three phone UI regressions noticed during modernization testing:

1. **Reload FAB off-screen** — Compose `LazyColumn` nested scroll collapses the AppBar and used to drag the top-anchored reload FAB (via `fab_layout` → `detail_view`) out of view. Position it with `layout_gravity="top|end"` under the toolbar instead.
2. **Picon gap when disabled** — `ServiceListScreen` always reserved a 48dp `AndroidView` for picons; `View.GONE` inside does not free Compose space. Skip the picon composable when picons are off so the channel title moves left.
3. **Virtual Remote** — Pad was top-start with a hard 320dp cap. Fill the host, center the pad, and scale key sizes from available width (clamped).

## Tests

```bash
bash .cursor/cloud/connected-test.sh \
  net.reichholf.dreamdroid.ui.services.ServiceListScreenTest,net.reichholf.dreamdroid.ui.remote.VirtualRemoteScreenTest
```

Result: **OK (6 tests)** — including `withoutPiconsChannelTitleSitsAtLeadingEdge` and `fullRemoteIsHorizontallyCenteredInWideHost`.

Cloud emulator System UI ANR blocked a reliable in-app screenshot look (TCG); instrumented Compose tests are the verification path per `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

