### PR TITLE
feat(state): Bundle save for hub/EPG string-int fields (Phase 2.3c)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -17,7 +17,6 @@ import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.evernote.android.state.State;
 import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.timepicker.MaterialTimePicker;
 import com.google.android.material.timepicker.TimeFormat;
@@ -53,6 +52,7 @@ import kotlinx.coroutines.Job;
  */
 public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 	private static final String LOG_TAG = EpgBouquetFragment.class.getSimpleName();
+	private static final String KEY_TIME = "epg_bouquet_time";
 
 	private final ArrayList<Event> mEvents = new ArrayList<>();
 	private EpgBouquetListState mListState;
@@ -62,7 +62,6 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 	private TextView mDateView;
 	private TextView mTimeView;
 	private boolean mWaitingForPicker;
-	@State
 	public int mTime;
 
 	@Override
@@ -73,10 +72,14 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 		mListState = new EpgBouquetListState();
 		initTitle(getString(R.string.epg));
 
-		int now = mTime = (int) (Calendar.getInstance().getTimeInMillis() / 1000);
+		int now = (int) (Calendar.getInstance().getTimeInMillis() / 1000);
 		if (savedInstanceState != null) {
-			if (mTime < now)
+			mTime = savedInstanceState.getInt(KEY_TIME, now);
+			if (mTime < now) {
 				mTime = now;
+			}
+		} else {
+			mTime = now;
 		}
 		if (mReference == null || mName == null) {
 			mReference = getArguments().getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE, null);
@@ -85,6 +88,12 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 
 		mWaitingForPicker = false;
 		mReload = true;
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		outState.putInt(KEY_TIME, mTime);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -22,8 +22,6 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
@@ -62,11 +60,12 @@ import java.util.List;
  * @author sreichholf
  */
 public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
+	private static final String KEY_REF = "service_list_ref";
+	private static final String KEY_NAME = "service_list_name";
+
 	@Nullable
-	@State
 	public String mName;
 	@Nullable
-	@State
 	public String mRef;
 
 	private ArrayList<ExtendedHashMap> mHistory;
@@ -79,26 +78,41 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		mName = getString(R.string.services);
 		mHasFabMain = false;
 		mEnableReload = false;
 
-		Bundle args = getArguments();
-		if (args != null)  {
-			mRef = args.getString(Service.KEY_REFERENCE, null);
-			mName = args.getString(Service.KEY_NAME, "-");
+		if (savedInstanceState != null) {
+			mRef = savedInstanceState.getString(KEY_REF);
+			mName = savedInstanceState.getString(KEY_NAME);
+		} else {
+			mName = getString(R.string.services);
+			Bundle args = getArguments();
+			if (args != null) {
+				mRef = args.getString(Service.KEY_REFERENCE, null);
+				mName = args.getString(Service.KEY_NAME, "-");
+			}
+		}
+
+		if (mRef == null) {
+			mRef = DreamDroid.getCurrentProfile().getDefaultBouquetTv();
+			mName = DreamDroid.getCurrentProfile().getDefaultBouquetTvName();
+		}
+		if (mName == null) {
+			mName = getString(R.string.services);
 		}
 
 		mCurrentItem = new ExtendedHashMap();
 		mCurrentItem.put(Service.KEY_REFERENCE, mRef);
 		mCurrentItem.put(Service.KEY_NAME, mName);
 		mHistory = new ArrayList<>();
-
-		if (mRef == null) {
-			mRef = DreamDroid.getCurrentProfile().getDefaultBouquetTv();
-			mName = DreamDroid.getCurrentProfile().getDefaultBouquetTvName();
-		}
 		mListState = new ServiceListState();
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		outState.putString(KEY_REF, mRef);
+		outState.putString(KEY_NAME, mName);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -13,8 +13,6 @@ import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.enigma.BouquetListLoadKt;
@@ -38,17 +36,14 @@ public class ServiceListPager extends BaseHttpFragment {
 	private static final String MODE_MOVIES = "Movies";
 	private static final String MODE_TIMER = "Timer";
 
+	private static final String KEY_MODE = "hub_mode";
+	private static final String KEY_CURRENT_TV = "hub_current_tv";
+	private static final String KEY_CURRENT_RADIO = "hub_current_radio";
+	private static final String KEY_CURRENT_MOVIE = "hub_current_movie";
 
-	@State
 	public String mMode;
-
-	@State
 	public String mCurrentTv;
-
-	@State
 	public String mCurrentRadio;
-
-	@State
 	public String mCurrentMovie;
 
 	ViewPager2 mPager;
@@ -196,8 +191,23 @@ public class ServiceListPager extends BaseHttpFragment {
 		mHasFabReload = false;
 		mBouquets = null;
 		mHubState = new TvMoviesHubState();
+		if (savedInstanceState != null) {
+			mMode = savedInstanceState.getString(KEY_MODE);
+			mCurrentTv = savedInstanceState.getString(KEY_CURRENT_TV);
+			mCurrentRadio = savedInstanceState.getString(KEY_CURRENT_RADIO);
+			mCurrentMovie = savedInstanceState.getString(KEY_CURRENT_MOVIE);
+		}
 		if (mMode == null)
 			mMode = MODE_TV;
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		outState.putString(KEY_MODE, mMode);
+		outState.putString(KEY_CURRENT_TV, mCurrentTv);
+		outState.putString(KEY_CURRENT_RADIO, mCurrentRadio);
+		outState.putString(KEY_CURRENT_MOVIE, mCurrentMovie);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -89,7 +89,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | vlc-overlay-typed-state | [#244](https://github.com/sreichholf/dreamDroid/pull/244) | merged | Phase 2.5b typed VideoOverlay state (`ServiceNowNext` / `Movie`); hash only at stream Intent / legacy edges. Keep OkHttp 3.14.9. |
 | vlc-overlay-compose | [#245](https://github.com/sreichholf/dreamDroid/pull/245) | merged | Phase 2.5c Compose overlay chrome (+ ButterKnife drop / 2.5d). Keep OkHttp 3.14.9. |
 | docs-state-rotation-dive | [#246](https://github.com/sreichholf/dreamDroid/pull/246) | merged | Phase 2.3a (docs only): Evernote @State + Livefront Bridge inventory + agreed migration slices. Keep OkHttp 3.14.9. |
-| state-deviceinfo-beachhead | this PR | open | Phase 2.3b: DeviceInfoFragment drops `@State`; save/restore typed `DeviceInfo` via fragment Bundle. Keep Bridge/Evernote for other consumers. Keep OkHttp 3.14.9. |
+| state-deviceinfo-beachhead | [#247](https://github.com/sreichholf/dreamDroid/pull/247) | merged | Phase 2.3b: DeviceInfoFragment drops `@State`; save/restore typed `DeviceInfo` via fragment Bundle. Keep Bridge/Evernote for other consumers. Keep OkHttp 3.14.9. |
+| state-simple-fragments | this PR | open | Phase 2.3c: ServiceListPage / ServiceListPager / EpgBouquet drop `@State`; Bundle string/int save. Keep Bridge. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -147,8 +148,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.5b typed overlay state **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244) (`ServiceNowNext` / `Movie`; hash only at stream Intent / legacy edges).
 - Phase 2.5c Compose overlay **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (ComposeView host; ButterKnife library dropped / 2.5d folded).
 - Phase 2.3a state/rotation dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246).
-- **This PR** = Phase 2.3b DeviceInfoFragment `@State` beachhead (Bundle save/restore; Bridge stays).
-- Out of wave still: widgets, NavHost, remaining `@State` consumers (2.3c–f). See Appendix H.
+- Phase 2.3b DeviceInfoFragment `@State` beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247).
+- **This PR** = Phase 2.3c simple string/int `@State` fragments (ServiceListPage, ServiceListPager, EpgBouquet).
+- Out of wave still: widgets, NavHost, remaining `@State` consumers (2.3d–f). See Appendix H.
 
 ## How to read this
 
@@ -480,7 +482,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Explicitly frozen
 
 - `app/src/.../tv/` Leanback. Operator picked phone first.
-- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead **this PR** / 2.3b).
+- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); **this PR** / 2.3c).
 - VLC playback.
 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
@@ -681,7 +683,7 @@ One program each, still one PR (or small PR series) at a time:
 | 2q | HTTP / async — VideoOverlay now/next | `VideoOverlayFragment` → `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`; drop overlay LoaderCallbacks only. Keep ButterKnife/VLC UI. Keep OkHttp 3.14.9. **merged** [#231](https://github.com/sreichholf/dreamDroid/pull/231). |
 | 2r | HTTP / async — Leanback RootBrowse | `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV LoaderCallbacks; delete `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + ExtendedHashMap. Keep OkHttp 3.14.9. **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). |
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
-| 3 | State / rotation | Dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). Beachhead **this PR** (2.3b). Replace Evernote `@State` + Livefront Bridge via fragment-local Bundle / SavedStateHandle / rememberSaveable |
+| 3 | State / rotation | Dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). Beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247). Simple fragments **this PR** (2.3c). Replace Evernote `@State` + Livefront Bridge via fragment-local Bundle / SavedStateHandle / rememberSaveable |
 | 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate. **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
 | 5 | VLC / streaming | Product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (option A: keep libVLC + Compose overlay). Typed overlay **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244). Compose overlay + ButterKnife drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
@@ -744,7 +746,7 @@ Why:
 - No Enigma2 server / codec / stream-protocol work
 - No NavHost / widgets / full Compose hub (3.1c-iv) drive-bys
 
-### Phase 2.3 — State / rotation (dive merged [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead this PR)
+### Phase 2.3 — State / rotation (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); 2.3c this PR)
 
 #### Chassis
 
@@ -752,14 +754,11 @@ Why:
 - `DreamDroid` initializes Bridge with StateSaver SavedStateHandler
 - Bridge.save/restore in `BaseFragment`, `BaseRecyclerFragment`, `BaseActivity`, `MultiChoiceDialog`; `Bridge.clear` only in `BaseFragment` and `BaseActivity`
 
-#### @State inventory (remaining after 2.3b)
+#### @State inventory (remaining after 2.3c)
 
 | File | Fields | Notes |
 | --- | --- | --- |
 | ScreenShotFragment | byte[] mRawImage | Bundle size risk |
-| ServiceListPageFragment | mName, mRef strings | Hub page |
-| ServiceListPager | mMode, mCurrentTv/Radio/Movie strings | Pager |
-| EpgBouquetFragment | int mTime | Simple |
 | BaseHttpRecyclerEventFragment | mReference, mName, mCurrentItem hash | Shared EPG base |
 | CurrentServiceFragment | CurrentService + ExtendedHashMap | Mixed |
 | MovieListFragment | location, tags lists, hash movie | Multi-field |
@@ -767,7 +766,7 @@ Why:
 | TimerEditFragment | tags + two timer hashes | |
 | MultiChoiceDialog | boolean[] mCheckedItems | Dialog + Bridge |
 
-`DeviceInfoFragment` (**this PR / 2.3b**): no `@State`; typed `DeviceInfo` via `onSaveInstanceState` / `getSerializable`. Bridge wiring unchanged for other consumers.
+Done off `@State`: `DeviceInfoFragment` ([#247](https://github.com/sreichholf/dreamDroid/pull/247)); `ServiceListPageFragment` / `ServiceListPager` / `EpgBouquetFragment` (**this PR**). Bridge wiring unchanged for remaining consumers.
 
 No SavedStateHandle / rememberSaveable in repo yet. Compose screens use ephemeral remember/mutableStateOf.
 
@@ -782,16 +781,16 @@ Do **not** big-bang remove Bridge.
 | Slice | Scope | Non-goals |
 | --- | --- | --- |
 | 2.3a | Docs dive | **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246) |
-| 2.3b | DeviceInfoFragment beachhead — drop @State; Bundle Serializable `DeviceInfo` | **this PR**; no Bridge dep drop |
-| 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | |
+| 2.3b | DeviceInfoFragment beachhead — drop @State; Bundle Serializable `DeviceInfo` | **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247) |
+| 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | **this PR**; no Bridge dep drop |
 | 2.3d | ScreenShotFragment byte[] — consider not persisting raw image (reload) | |
 | 2.3e | Hash-heavy fragments (timers, movies, current, BaseHttpRecyclerEvent) | Prefer typed fields where possible |
 | 2.3f | MultiChoiceDialog + remove Bridge from bases; delete Evernote/Bridge deps | No OkHttp 4; no NavHost |
 
-#### Explicit non-goals of 2.3b (this PR)
+#### Explicit non-goals of 2.3c (this PR)
 
 - No Bridge/Evernote dependency removal
-- No other `@State` consumers
+- No ScreenShot / hash-heavy / MultiChoiceDialog `@State` consumers
 - No NavHost / widgets / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -807,7 +806,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). **This PR:** Phase 2.3b DeviceInfo `@State` beachhead. Next Appendix H: 2.3c simple string/int fragments, or NavHost dive / widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–b **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247). **This PR:** Phase 2.3c simple string/int `@State` fragments. Next Appendix H: 2.3d ScreenShot, or 2.3e hash-heavy, or NavHost dive / widgets — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.3c**: migrate simple string/int `@State` fields off Evernote.

- `ServiceListPageFragment` — Bundle `mRef` / `mName` (prefer restore over args on process death so directory drill-down survives)
- `ServiceListPager` — Bundle hub `mMode` + current TV/Radio/Movie refs
- `EpgBouquetFragment` — Bundle `mTime`; fix restore that previously overwrote Bridge-restored time with “now”
- Keep Livefront Bridge + Evernote for remaining consumers
- Docs: mark #247 merged; inventory/slices updated

## Test plan

- [x] `./gradlew :app:assembleGoogleDebug`
- [ ] CI unit+assemble green
- [ ] Manual: rotate hub / EPG bouquet date-time if convenient

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

