### PR TITLE
feat(state): drop ScreenShot @State; reload instead of Bundle bytes (2.3d)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/fragment/ScreenShotFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ScreenShotFragment.java
@@ -33,8 +33,6 @@ import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.core.content.FileProvider;
 
-import com.evernote.android.state.State;
-
 import kotlinx.coroutines.Job;
 
 import net.reichholf.dreamdroid.DreamDroid;
@@ -79,7 +77,12 @@ public class ScreenShotFragment extends BaseFragment {
 	private int mFormat;
 	private int mSize;
 	private String mFilename;
-	@State
+	/**
+	 * Last screenshot bytes. Not persisted across process death (Bundle size risk);
+	 * {@link #onResume} reloads when empty. Config-change retention still keeps the field
+	 * when {@code mShouldRetainInstance} is true.
+	 */
+	@Nullable
 	public byte[] mRawImage;
 	@Nullable
 	private MediaScannerConnection mScannerConn;

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -90,7 +90,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | vlc-overlay-compose | [#245](https://github.com/sreichholf/dreamDroid/pull/245) | merged | Phase 2.5c Compose overlay chrome (+ ButterKnife drop / 2.5d). Keep OkHttp 3.14.9. |
 | docs-state-rotation-dive | [#246](https://github.com/sreichholf/dreamDroid/pull/246) | merged | Phase 2.3a (docs only): Evernote @State + Livefront Bridge inventory + agreed migration slices. Keep OkHttp 3.14.9. |
 | state-deviceinfo-beachhead | [#247](https://github.com/sreichholf/dreamDroid/pull/247) | merged | Phase 2.3b: DeviceInfoFragment drops `@State`; save/restore typed `DeviceInfo` via fragment Bundle. Keep Bridge/Evernote for other consumers. Keep OkHttp 3.14.9. |
-| state-simple-fragments | this PR | open | Phase 2.3c: ServiceListPage / ServiceListPager / EpgBouquet drop `@State`; Bundle string/int save. Keep Bridge. Keep OkHttp 3.14.9. |
+| state-simple-fragments | [#249](https://github.com/sreichholf/dreamDroid/pull/249) | merged | Phase 2.3c: ServiceListPage / ServiceListPager / EpgBouquet drop `@State`; Bundle string/int save. Keep Bridge. Keep OkHttp 3.14.9. |
+| state-screenshot | this PR | open | Phase 2.3d: ScreenShotFragment drops `@State` on `mRawImage`; do not Bundle the bytes — reload on process death. Keep Bridge. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -149,8 +150,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.5c Compose overlay **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (ComposeView host; ButterKnife library dropped / 2.5d folded).
 - Phase 2.3a state/rotation dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246).
 - Phase 2.3b DeviceInfoFragment `@State` beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247).
-- **This PR** = Phase 2.3c simple string/int `@State` fragments (ServiceListPage, ServiceListPager, EpgBouquet).
-- Out of wave still: widgets, NavHost, remaining `@State` consumers (2.3d–f). See Appendix H.
+- Phase 2.3c hub/EPG string-int `@State` **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249).
+- **This PR** = Phase 2.3d ScreenShotFragment: drop `@State` on `mRawImage`; reload instead of Bundle bytes.
+- Out of wave still: widgets, NavHost, remaining `@State` consumers (2.3e–f). See Appendix H.
 
 ## How to read this
 
@@ -482,7 +484,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Explicitly frozen
 
 - `app/src/.../tv/` Leanback. Operator picked phone first.
-- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); **this PR** / 2.3c).
+- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); simple [#249](https://github.com/sreichholf/dreamDroid/pull/249); **this PR** / 2.3d).
 - VLC playback.
 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
@@ -683,7 +685,7 @@ One program each, still one PR (or small PR series) at a time:
 | 2q | HTTP / async — VideoOverlay now/next | `VideoOverlayFragment` → `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`; drop overlay LoaderCallbacks only. Keep ButterKnife/VLC UI. Keep OkHttp 3.14.9. **merged** [#231](https://github.com/sreichholf/dreamDroid/pull/231). |
 | 2r | HTTP / async — Leanback RootBrowse | `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV LoaderCallbacks; delete `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + ExtendedHashMap. Keep OkHttp 3.14.9. **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). |
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
-| 3 | State / rotation | Dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). Beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247). Simple fragments **this PR** (2.3c). Replace Evernote `@State` + Livefront Bridge via fragment-local Bundle / SavedStateHandle / rememberSaveable |
+| 3 | State / rotation | Dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). Beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247). Simple **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249). ScreenShot **this PR** (2.3d). Replace Evernote `@State` + Livefront Bridge via fragment-local Bundle / SavedStateHandle / rememberSaveable |
 | 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate. **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
 | 5 | VLC / streaming | Product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (option A: keep libVLC + Compose overlay). Typed overlay **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244). Compose overlay + ButterKnife drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
@@ -746,7 +748,7 @@ Why:
 - No Enigma2 server / codec / stream-protocol work
 - No NavHost / widgets / full Compose hub (3.1c-iv) drive-bys
 
-### Phase 2.3 — State / rotation (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); 2.3c this PR)
+### Phase 2.3 — State / rotation (through 2.3c [#249](https://github.com/sreichholf/dreamDroid/pull/249); 2.3d this PR)
 
 #### Chassis
 
@@ -754,11 +756,10 @@ Why:
 - `DreamDroid` initializes Bridge with StateSaver SavedStateHandler
 - Bridge.save/restore in `BaseFragment`, `BaseRecyclerFragment`, `BaseActivity`, `MultiChoiceDialog`; `Bridge.clear` only in `BaseFragment` and `BaseActivity`
 
-#### @State inventory (remaining after 2.3c)
+#### @State inventory (remaining after 2.3d)
 
 | File | Fields | Notes |
 | --- | --- | --- |
-| ScreenShotFragment | byte[] mRawImage | Bundle size risk |
 | BaseHttpRecyclerEventFragment | mReference, mName, mCurrentItem hash | Shared EPG base |
 | CurrentServiceFragment | CurrentService + ExtendedHashMap | Mixed |
 | MovieListFragment | location, tags lists, hash movie | Multi-field |
@@ -766,7 +767,7 @@ Why:
 | TimerEditFragment | tags + two timer hashes | |
 | MultiChoiceDialog | boolean[] mCheckedItems | Dialog + Bridge |
 
-Done off `@State`: `DeviceInfoFragment` ([#247](https://github.com/sreichholf/dreamDroid/pull/247)); `ServiceListPageFragment` / `ServiceListPager` / `EpgBouquetFragment` (**this PR**). Bridge wiring unchanged for remaining consumers.
+Done off `@State`: DeviceInfo [#247](https://github.com/sreichholf/dreamDroid/pull/247); hub/EPG simple [#249](https://github.com/sreichholf/dreamDroid/pull/249); `ScreenShotFragment` (**this PR** — bytes not Bundled; reload on process death). Bridge wiring unchanged for remaining consumers.
 
 No SavedStateHandle / rememberSaveable in repo yet. Compose screens use ephemeral remember/mutableStateOf.
 
@@ -782,15 +783,15 @@ Do **not** big-bang remove Bridge.
 | --- | --- | --- |
 | 2.3a | Docs dive | **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246) |
 | 2.3b | DeviceInfoFragment beachhead — drop @State; Bundle Serializable `DeviceInfo` | **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247) |
-| 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | **this PR**; no Bridge dep drop |
-| 2.3d | ScreenShotFragment byte[] — consider not persisting raw image (reload) | |
+| 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249) |
+| 2.3d | ScreenShotFragment byte[] — do not persist raw image; reload | **this PR**; no Bridge dep drop |
 | 2.3e | Hash-heavy fragments (timers, movies, current, BaseHttpRecyclerEvent) | Prefer typed fields where possible |
 | 2.3f | MultiChoiceDialog + remove Bridge from bases; delete Evernote/Bridge deps | No OkHttp 4; no NavHost |
 
-#### Explicit non-goals of 2.3c (this PR)
+#### Explicit non-goals of 2.3d (this PR)
 
 - No Bridge/Evernote dependency removal
-- No ScreenShot / hash-heavy / MultiChoiceDialog `@State` consumers
+- No hash-heavy / MultiChoiceDialog `@State` consumers
 - No NavHost / widgets / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -806,7 +807,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–b **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247). **This PR:** Phase 2.3c simple string/int `@State` fragments. Next Appendix H: 2.3d ScreenShot, or 2.3e hash-heavy, or NavHost dive / widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–c **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247)/[#249](https://github.com/sreichholf/dreamDroid/pull/249). **This PR:** Phase 2.3d ScreenShot `@State` drop (reload, no byte Bundle). Next Appendix H: 2.3e hash-heavy fragments, or NavHost dive / widgets — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.3d**: drop Evernote `@State` on `ScreenShotFragment.mRawImage`.

- Do **not** put screenshot bytes in the Bundle (TransactionTooLarge / size risk)
- Process death → empty bytes → existing `onResume` reload path
- Config change still keeps the field when retain-instance is enabled
- Bridge/Evernote stay for remaining `@State` consumers

## Test plan

- [x] `./gradlew :app:assembleGoogleDebug`
- [ ] CI unit+assemble green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

