### PR TITLE
feat(state): Bundle save for hash-heavy fragments (Phase 2.3e)

### DIFF
--- a/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
@@ -16,8 +16,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.enigma.CurrentService;
@@ -49,6 +47,8 @@ import kotlinx.coroutines.Job;
 public class CurrentServiceFragment extends BaseHttpFragment {
 	@SuppressWarnings("unused")
 	private static final String LOG_TAG = "CurrentServiceFragment";
+	private static final String KEY_CURRENT = "current_service";
+	private static final String KEY_CURRENT_ITEM = "current_item";
 
 	protected ProgressDialog mProgress;
 
@@ -61,9 +61,9 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	private boolean mCurrentServiceReady;
 
 	@Nullable
-	@State public CurrentService mCurrent;
+	public CurrentService mCurrent;
 	@Nullable
-	@State public ExtendedHashMap mCurrentItem;
+	public ExtendedHashMap mCurrentItem;
 
 	@Nullable
 	private Job mLoadJob;
@@ -77,6 +77,25 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 
 		mCurrentServiceReady = false;
 		mUiState = new CurrentServiceUiState();
+		if (savedInstanceState != null) {
+			@SuppressWarnings("deprecation")
+			CurrentService current = (CurrentService) savedInstanceState.getSerializable(KEY_CURRENT);
+			mCurrent = current;
+			@SuppressWarnings("deprecation")
+			ExtendedHashMap item = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_CURRENT_ITEM);
+			mCurrentItem = item;
+		}
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		if (mCurrent != null) {
+			outState.putSerializable(KEY_CURRENT, mCurrent);
+		}
+		if (mCurrentItem != null) {
+			outState.putSerializable(KEY_CURRENT_ITEM, mCurrentItem);
+		}
+		super.onSaveInstanceState(outState);
 	}
 
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -25,8 +25,6 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.SimpleTextAdapter;
@@ -67,13 +65,18 @@ import kotlinx.coroutines.Job;
 public class MovieListFragment extends BaseHttpRecyclerFragment
 		implements MultiChoiceDialog.MultiChoiceDialogListener {
 	public static String ARGUMENT_LOCATION = "location";
+	private static final String KEY_LOCATION = "movie_location";
+	private static final String KEY_SELECTED_TAGS = "movie_selected_tags";
+	private static final String KEY_OLD_TAGS = "movie_old_tags";
+	private static final String KEY_MOVIE = "movie_selected";
+
 	private boolean mTagsChanged;
 	private boolean mReloadOnSimpleResult;
 
-	@State public String mCurrentLocation;
-	@State public ArrayList<String> mSelectedTags;
-	@State public ArrayList<String> mOldTags;
-	@State public ExtendedHashMap mMovie;
+	public String mCurrentLocation;
+	public ArrayList<String> mSelectedTags;
+	public ArrayList<String> mOldTags;
+	public ExtendedHashMap mMovie;
 	private final ArrayList<Movie> mMovies = new ArrayList<>();
 	private MovieListState mListState;
 	@Nullable
@@ -103,13 +106,37 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 		//mHasFabMain = true;
 		super.onCreate(savedInstanceState);
 		initTitle(getString(R.string.movies));
-		mCurrentLocation = null;
-		if (savedInstanceState == null) {
+		if (savedInstanceState != null) {
+			mCurrentLocation = savedInstanceState.getString(KEY_LOCATION);
+			mSelectedTags = savedInstanceState.getStringArrayList(KEY_SELECTED_TAGS);
+			mOldTags = savedInstanceState.getStringArrayList(KEY_OLD_TAGS);
+			@SuppressWarnings("deprecation")
+			ExtendedHashMap movie = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_MOVIE);
+			mMovie = movie;
+		} else {
+			mCurrentLocation = null;
 			mSelectedTags = new ArrayList<>();
+			mOldTags = new ArrayList<>();
+		}
+		if (mSelectedTags == null) {
+			mSelectedTags = new ArrayList<>();
+		}
+		if (mOldTags == null) {
 			mOldTags = new ArrayList<>();
 		}
 		setInitialLocation(savedInstanceState);
 		mListState = new MovieListState();
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		outState.putString(KEY_LOCATION, mCurrentLocation);
+		outState.putStringArrayList(KEY_SELECTED_TAGS, mSelectedTags);
+		outState.putStringArrayList(KEY_OLD_TAGS, mOldTags);
+		if (mMovie != null) {
+			outState.putSerializable(KEY_MOVIE, mMovie);
+		}
+		super.onSaveInstanceState(outState);
 	}
 
 	protected void setInitialLocation(@Nullable Bundle savedInstanceState) {

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
@@ -158,25 +158,8 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 			}
 
 			mSelectedTags = new ArrayList<>();
-
-			if (DreamDroid.getLocations().size() == 0 || DreamDroid.getTags().size() == 0) {
-				mLocationsAndTagsJob = LocationsAndTagsLoadKt.launchLocationsAndTagsLoad(
-						this,
-						(title, progress) -> {
-							onGetLocationsAndTagsProgress(title, progress);
-							return Unit.INSTANCE;
-						},
-						() -> {
-							mLocationsAndTagsJob = null;
-							onLocationsAndTagsReady();
-							return Unit.INSTANCE;
-						});
-			} else {
-				reload();
-			}
-		} else {
-			reload();
 		}
+		ensureLocationsAndTagsThenReload();
 
 		ComposeView composeView = new ComposeView(requireContext());
 		composeView.setLayoutParams(new ViewGroup.LayoutParams(
@@ -575,6 +558,27 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 			mLocationsAndTagsProgress = ProgressDialog.show(getAppCompatActivity(), title, progress);
 		}
 
+	}
+
+	private void ensureLocationsAndTagsThenReload() {
+		if (DreamDroid.getLocations().size() == 0 || DreamDroid.getTags().size() == 0) {
+			if (mLocationsAndTagsJob != null) {
+				return;
+			}
+			mLocationsAndTagsJob = LocationsAndTagsLoadKt.launchLocationsAndTagsLoad(
+					this,
+					(title, progress) -> {
+						onGetLocationsAndTagsProgress(title, progress);
+						return Unit.INSTANCE;
+					},
+					() -> {
+						mLocationsAndTagsJob = null;
+						onLocationsAndTagsReady();
+						return Unit.INSTANCE;
+					});
+		} else {
+			reload();
+		}
 	}
 
 	private void onLocationsAndTagsReady() {

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
 
-import com.evernote.android.state.State;
 import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.timepicker.MaterialTimePicker;
 import com.google.android.material.timepicker.TimeFormat;
@@ -65,6 +64,10 @@ import kotlinx.coroutines.Job;
 public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDialog.MultiChoiceDialogListener {
 
 	private static final String TAG = TimerEditFragment.class.getSimpleName();
+	private static final String KEY_TIMER = "timer_edit";
+	private static final String KEY_TIMER_OLD = "timer_edit_old";
+	private static final String KEY_TAGS = "timer_edit_tags";
+	private static final String KEY_CREATE = "timer_edit_is_create";
 
 	private static final int[] sRepeatedValues = {1, 2, 4, 8, 16, 32, 64};
 
@@ -73,13 +76,11 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 
 	private boolean mTagsChanged;
 
-	@State
 	public ArrayList<String> mSelectedTags;
-	@State
 	public ExtendedHashMap mTimer;
 	@Nullable
-	@State
 	public ExtendedHashMap mTimerOld;
+	private boolean mIsCreate;
 
 	@Nullable
 	private ProgressDialog mLocationsAndTagsProgress;
@@ -100,6 +101,36 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 		initTitles(getString(R.string.timer));
 		mLocationsAndTagsProgress = null;
 		mEditState = new TimerEditState();
+		if (savedInstanceState != null) {
+			@SuppressWarnings("deprecation")
+			ExtendedHashMap timer = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_TIMER);
+			mTimer = timer;
+			@SuppressWarnings("deprecation")
+			ExtendedHashMap timerOld = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_TIMER_OLD);
+			mTimerOld = timerOld;
+			mSelectedTags = savedInstanceState.getStringArrayList(KEY_TAGS);
+			mIsCreate = savedInstanceState.getBoolean(KEY_CREATE, mTimerOld == null);
+		}
+		if (mSelectedTags == null) {
+			mSelectedTags = new ArrayList<>();
+		}
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		if (mProgress != null) {
+			if (mProgress.isShowing())
+				mProgress.dismiss();
+		}
+		if (mTimer != null) {
+			outState.putSerializable(KEY_TIMER, mTimer);
+		}
+		if (mTimerOld != null) {
+			outState.putSerializable(KEY_TIMER_OLD, mTimerOld);
+		}
+		outState.putStringArrayList(KEY_TAGS, mSelectedTags);
+		outState.putBoolean(KEY_CREATE, mIsCreate || mTimerOld == null);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override
@@ -114,14 +145,16 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 	@SuppressWarnings("unchecked")
 	@Override
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		if (mTimer == null || mTimerOld == null) {
+		if (mTimer == null) {
 			ExtendedHashMap data = ((ExtendedHashMap) getArguments().get(sData)).clone();
 			mTimer = ((ExtendedHashMap) data.get("timer")).clone();
 
 			if (Intent.ACTION_EDIT.equals(data.get("action"))) {
 				mTimerOld = mTimer.clone();
+				mIsCreate = false;
 			} else {
 				mTimerOld = null;
+				mIsCreate = true;
 			}
 
 			mSelectedTags = new ArrayList<>();
@@ -206,16 +239,6 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 				mEditState.setServiceName(mTimer.getString(Timer.KEY_SERVICE_NAME));
 			}
 		}
-	}
-
-	@Override
-	public void onSaveInstanceState(@NonNull Bundle outState) {
-		if (mProgress != null) {
-			if (mProgress.isShowing()) {
-				mProgress.dismiss();
-			}
-		}
-		super.onSaveInstanceState(outState);
 	}
 
 	protected void pickRepeatings() {

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -23,8 +23,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.adapter.recyclerview.TimerAdapter;
@@ -60,6 +58,8 @@ import kotlinx.coroutines.Job;
  * @author sreichholf
  */
 public class TimerListFragment extends BaseHttpRecyclerFragment {
+	private static final String KEY_TIMER = "timer_selected";
+
 	@NonNull
 	private ActionMode.Callback mActionModeCallback = new ActionMode.Callback() {
 
@@ -105,7 +105,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 			getRecyclerView().post(() -> mSelectionSupport.setChoiceMode(ItemSelectionSupport.ChoiceMode.SINGLE));
 		}
 	};
-	@State public ExtendedHashMap mTimer;
+	public ExtendedHashMap mTimer;
 	@Nullable
 	private ProgressDialog mProgress;
 	protected int mCurrentPos;
@@ -124,10 +124,24 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		super.onCreate(savedInstanceState);
 		initTitle(getString(R.string.timer));
 
+		if (savedInstanceState != null) {
+			@SuppressWarnings("deprecation")
+			ExtendedHashMap timer = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_TIMER);
+			mTimer = timer;
+		}
+
 		mCurrentPos = -1;
 		mIsActionMode = false;
 		mReload = true;
 		mListState = new TimerListState();
+	}
+
+	@Override
+	public void onSaveInstanceState(@NonNull Bundle outState) {
+		if (mTimer != null) {
+			outState.putSerializable(KEY_TIMER, mTimer);
+		}
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseHttpRecyclerEventFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseHttpRecyclerEventFragment.java
@@ -9,8 +9,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.view.View;
 
-import com.evernote.android.state.State;
-
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
 import net.reichholf.dreamdroid.fragment.dialogs.EpgDetailBottomSheet;
@@ -27,13 +25,14 @@ import net.reichholf.dreamdroid.intents.IntentFactory;
 public abstract class BaseHttpRecyclerEventFragment extends BaseHttpRecyclerFragment implements
         ActionDialog.DialogActionListener {
 
+    private static final String KEY_REFERENCE = "reference";
+    private static final String KEY_NAME = "name";
+    private static final String KEY_CURRENT_ITEM = "currentItem";
+
     @Nullable
-	@State
     public String mReference;
     @Nullable
-	@State
     public String mName;
-    @State
     public ExtendedHashMap mCurrentItem;
 
     protected ProgressDialog mProgress;
@@ -41,13 +40,23 @@ public abstract class BaseHttpRecyclerEventFragment extends BaseHttpRecyclerFrag
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            mReference = savedInstanceState.getString(KEY_REFERENCE);
+            mName = savedInstanceState.getString(KEY_NAME);
+            @SuppressWarnings("deprecation")
+            ExtendedHashMap item = (ExtendedHashMap) savedInstanceState.getSerializable(KEY_CURRENT_ITEM);
+            mCurrentItem = item;
+        }
+        if (mCurrentItem == null) {
+            mCurrentItem = new ExtendedHashMap();
+        }
     }
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
-        outState.putString("reference", mReference);
-        outState.putString("name", mName);
-        outState.putSerializable("currentItem", mCurrentItem);
+        outState.putString(KEY_REFERENCE, mReference);
+        outState.putString(KEY_NAME, mName);
+        outState.putSerializable(KEY_CURRENT_ITEM, mCurrentItem);
 
         super.onSaveInstanceState(outState);
     }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -152,8 +152,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3a state/rotation dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246).
 - Phase 2.3b DeviceInfoFragment `@State` beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247).
 - Phase 2.3c hub/EPG string-int `@State` **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249).
-- **This PR** = Phase 2.3d ScreenShotFragment: drop `@State` on `mRawImage`; reload instead of Bundle bytes.
-- Out of wave still: widgets, NavHost, remaining `@State` consumers (2.3e–f). See Appendix H.
+- Phase 2.3d ScreenShot `@State` drop **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250).
+- **This PR** = Phase 2.3e hash-heavy `@State` fragments (timers, movies, current, BaseHttpRecyclerEvent).
+- Out of wave still: widgets, NavHost, MultiChoiceDialog + Bridge dep drop (2.3f). See Appendix H.
 
 ## How to read this
 
@@ -485,7 +486,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Explicitly frozen
 
 - `app/src/.../tv/` Leanback. Operator picked phone first.
-- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (dive [#246](https://github.com/sreichholf/dreamDroid/pull/246); beachhead [#247](https://github.com/sreichholf/dreamDroid/pull/247); simple [#249](https://github.com/sreichholf/dreamDroid/pull/249); **this PR** / 2.3d).
+- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (through [#250](https://github.com/sreichholf/dreamDroid/pull/250); **this PR** / 2.3e; last consumer MultiChoiceDialog → 2.3f).
 - VLC playback.
 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
@@ -686,7 +687,7 @@ One program each, still one PR (or small PR series) at a time:
 | 2q | HTTP / async — VideoOverlay now/next | `VideoOverlayFragment` → `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`; drop overlay LoaderCallbacks only. Keep ButterKnife/VLC UI. Keep OkHttp 3.14.9. **merged** [#231](https://github.com/sreichholf/dreamDroid/pull/231). |
 | 2r | HTTP / async — Leanback RootBrowse | `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV LoaderCallbacks; delete `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + ExtendedHashMap. Keep OkHttp 3.14.9. **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). |
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
-| 3 | State / rotation | Dive **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246). Beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247). Simple **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249). ScreenShot **this PR** (2.3d). Replace Evernote `@State` + Livefront Bridge via fragment-local Bundle / SavedStateHandle / rememberSaveable |
+| 3 | State / rotation | Through ScreenShot **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250). Hash-heavy **this PR** (2.3e). Then 2.3f MultiChoiceDialog + Bridge/Evernote dep drop. |
 | 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate. **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
 | 5 | VLC / streaming | Product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (option A: keep libVLC + Compose overlay). Typed overlay **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244). Compose overlay + ButterKnife drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
@@ -749,7 +750,7 @@ Why:
 - No Enigma2 server / codec / stream-protocol work
 - No NavHost / widgets / full Compose hub (3.1c-iv) drive-bys
 
-### Phase 2.3 — State / rotation (through 2.3c [#249](https://github.com/sreichholf/dreamDroid/pull/249); 2.3d this PR)
+### Phase 2.3 — State / rotation (through 2.3d [#250](https://github.com/sreichholf/dreamDroid/pull/250); 2.3e this PR)
 
 #### Chassis
 
@@ -757,18 +758,13 @@ Why:
 - `DreamDroid` initializes Bridge with StateSaver SavedStateHandler
 - Bridge.save/restore in `BaseFragment`, `BaseRecyclerFragment`, `BaseActivity`, `MultiChoiceDialog`; `Bridge.clear` only in `BaseFragment` and `BaseActivity`
 
-#### @State inventory (remaining after 2.3d)
+#### @State inventory (remaining after 2.3e)
 
 | File | Fields | Notes |
 | --- | --- | --- |
-| BaseHttpRecyclerEventFragment | mReference, mName, mCurrentItem hash | Shared EPG base |
-| CurrentServiceFragment | CurrentService + ExtendedHashMap | Mixed |
-| MovieListFragment | location, tags lists, hash movie | Multi-field |
-| TimerListFragment | ExtendedHashMap mTimer | |
-| TimerEditFragment | tags + two timer hashes | |
-| MultiChoiceDialog | boolean[] mCheckedItems | Dialog + Bridge |
+| MultiChoiceDialog | boolean[] mCheckedItems | Dialog + Bridge — last consumer → 2.3f |
 
-Done off `@State`: DeviceInfo [#247](https://github.com/sreichholf/dreamDroid/pull/247); hub/EPG simple [#249](https://github.com/sreichholf/dreamDroid/pull/249); `ScreenShotFragment` (**this PR** — bytes not Bundled; reload on process death). Bridge wiring unchanged for remaining consumers.
+Done off `@State` this PR: `BaseHttpRecyclerEventFragment`, `CurrentServiceFragment` (typed `CurrentService` + hash item), `MovieListFragment` (location/tags/selected movie hash), `TimerListFragment`, `TimerEditFragment` (create-mode restore fixed). Lists still reload; selection/filters Bundled. Typed `Timer`/`Movie` selection rows deferred (hash still at edit/delete edges).
 
 No SavedStateHandle / rememberSaveable in repo yet. Compose screens use ephemeral remember/mutableStateOf.
 
@@ -785,14 +781,15 @@ Do **not** big-bang remove Bridge.
 | 2.3a | Docs dive | **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246) |
 | 2.3b | DeviceInfoFragment beachhead — drop @State; Bundle Serializable `DeviceInfo` | **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247) |
 | 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249) |
-| 2.3d | ScreenShotFragment byte[] — do not persist raw image; reload | **this PR**; no Bridge dep drop |
-| 2.3e | Hash-heavy fragments (timers, movies, current, BaseHttpRecyclerEvent) | Prefer typed fields where possible |
+| 2.3d | ScreenShotFragment byte[] — do not persist raw image; reload | **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250) |
+| 2.3e | Hash-heavy fragments (timers, movies, current, BaseHttpRecyclerEvent) | **this PR**; no Bridge dep drop |
 | 2.3f | MultiChoiceDialog + remove Bridge from bases; delete Evernote/Bridge deps | No OkHttp 4; no NavHost |
 
-#### Explicit non-goals of 2.3d (this PR)
+#### Explicit non-goals of 2.3e (this PR)
 
 - No Bridge/Evernote dependency removal
-- No hash-heavy / MultiChoiceDialog `@State` consumers
+- No MultiChoiceDialog `@State` migration
+- No full typed Timer/Movie selection rewrite (hash still at edges)
 - No NavHost / widgets / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -808,7 +805,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–c **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247)/[#249](https://github.com/sreichholf/dreamDroid/pull/249). **This PR:** Phase 2.3d ScreenShot `@State` drop (reload, no byte Bundle). Next Appendix H: 2.3e hash-heavy fragments, or NavHost dive / widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–d **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247)/[#249](https://github.com/sreichholf/dreamDroid/pull/249)/[#250](https://github.com/sreichholf/dreamDroid/pull/250). **This PR:** Phase 2.3e hash-heavy `@State`. Next Appendix H: 2.3f MultiChoiceDialog + Bridge/Evernote dep drop, or NavHost dive / widgets — one PR at a time.
 
 ### Phase 4 — Operator usertests
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -91,7 +91,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | docs-state-rotation-dive | [#246](https://github.com/sreichholf/dreamDroid/pull/246) | merged | Phase 2.3a (docs only): Evernote @State + Livefront Bridge inventory + agreed migration slices. Keep OkHttp 3.14.9. |
 | state-deviceinfo-beachhead | [#247](https://github.com/sreichholf/dreamDroid/pull/247) | merged | Phase 2.3b: DeviceInfoFragment drops `@State`; save/restore typed `DeviceInfo` via fragment Bundle. Keep Bridge/Evernote for other consumers. Keep OkHttp 3.14.9. |
 | state-simple-fragments | [#249](https://github.com/sreichholf/dreamDroid/pull/249) | merged | Phase 2.3c: ServiceListPage / ServiceListPager / EpgBouquet drop `@State`; Bundle string/int save. Keep Bridge. Keep OkHttp 3.14.9. |
-| state-screenshot | this PR | open | Phase 2.3d: ScreenShotFragment drops `@State` on `mRawImage`; do not Bundle the bytes — reload on process death. Keep Bridge. Keep OkHttp 3.14.9. |
+| state-screenshot | [#250](https://github.com/sreichholf/dreamDroid/pull/250) | merged | Phase 2.3d: ScreenShotFragment drops `@State` on `mRawImage`; do not Bundle the bytes — reload on process death. Keep Bridge. Keep OkHttp 3.14.9. |
+| state-hash-fragments | this PR | open | Phase 2.3e: timers/movies/current/BaseHttpRecyclerEvent drop `@State`; Bundle selection + filters (typed `CurrentService`). Keep Bridge for MultiChoiceDialog. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.3e**: migrate hash-heavy `@State` fields off Evernote.

- `BaseHttpRecyclerEventFragment` — restore existing Bundle keys (reference/name/currentItem)
- `CurrentServiceFragment` — typed `CurrentService` + hash item via Bundle
- `MovieListFragment` — location/tags/selected movie; stop wiping restored location
- `TimerListFragment` — selected timer hash
- `TimerEditFragment` — timer/old/tags + create-mode flag; fix create restore; always ensure locations/tags after restore
- Keep Bridge/Evernote for last consumer: `MultiChoiceDialog` (2.3f)
- Lists still reload; selection/filters only Bundled

## Test plan

- [x] `./gradlew :app:assembleGoogleDebug`
- [x] Bugbot: locations/tags restore fix
- [ ] CI unit+assemble green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

