### PR TITLE
feat(state): drop Evernote/Bridge; MultiChoiceDialog Bundle (Phase 2.3f)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,9 +54,6 @@ dependencies {
     implementation project(':libraries:AttributionPresenter:library')
     implementation project(':libraries:simple-gauge-android:gaugelibrary')
     implementation 'com.google.code.gson:gson:2.9.0'
-    implementation 'com.evernote:android-state:1.4.1'
-    annotationProcessor 'com.evernote:android-state-processor:1.4.1'
-    implementation 'com.github.livefront:bridge:v2.0.2'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.2.0'
 
     def composeBom = platform('androidx.compose:compose-bom:2024.04.01')

--- a/app/src/net/reichholf/dreamdroid/DreamDroid.java
+++ b/app/src/net/reichholf/dreamdroid/DreamDroid.java
@@ -18,7 +18,6 @@ import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
-import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -27,10 +26,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
 
-import com.evernote.android.state.StateSaver;
 import com.google.android.material.color.DynamicColors;
-import com.livefront.bridge.Bridge;
-import com.livefront.bridge.SavedStateHandler;
 
 import net.reichholf.dreamdroid.helpers.DateTime;
 import net.reichholf.dreamdroid.helpers.SimpleHttpClient;
@@ -174,18 +170,6 @@ public class DreamDroid extends Application {
 		} catch (Exception e) {
 			DATE_LOCALE_WO = false;
 		}
-		Bridge.initialize(getApplicationContext(), new SavedStateHandler() {
-			@Override
-			public void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
-				StateSaver.saveInstanceState(target, state);
-			}
-
-			@Override
-			public void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
-				StateSaver.restoreInstanceState(target, state);
-			}
-		});
-
 
 		Profile.ProfileDao dao = AppDatabase.profiles(getAppContext());
 		if (dao.getProfiles().size() == 0) {

--- a/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
@@ -17,7 +17,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
-import com.livefront.bridge.Bridge;
 import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
@@ -115,7 +114,6 @@ public class BaseActivity extends AppCompatActivity implements ActionDialog.Dial
 			e.printStackTrace();
 		}
 		super.onCreate(savedInstanceState);
-		Bridge.restoreInstanceState(this, savedInstanceState);
 		if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean(
 				DreamDroid.PREFS_KEY_ENABLE_ANIMATIONS, true)) {
 			overridePendingTransition(R.animator.activity_open_translate, R.animator.activity_close_scale);
@@ -125,7 +123,6 @@ public class BaseActivity extends AppCompatActivity implements ActionDialog.Dial
 	@Override
 	protected void onSaveInstanceState(@NonNull Bundle outState) {
 		super.onSaveInstanceState(outState);
-		Bridge.saveInstanceState(this, outState);
 	}
 
 	@Override
@@ -160,7 +157,6 @@ public class BaseActivity extends AppCompatActivity implements ActionDialog.Dial
 	protected void onDestroy() {
 		super.onDestroy();
 		PreferenceManager.getDefaultSharedPreferences(this).unregisterOnSharedPreferenceChangeListener(this);
-		Bridge.clear(this);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseFragment.java
@@ -11,7 +11,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.livefront.bridge.Bridge;
 
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.app.AppCompatActivity;
@@ -50,7 +49,6 @@ public abstract class BaseFragment extends Fragment implements ActivityCallbackH
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		Bridge.restoreInstanceState(this, savedInstanceState);
 		if (mHelper == null)
 			mHelper = new FragmentHelper(this);
 		else
@@ -103,13 +101,6 @@ public abstract class BaseFragment extends Fragment implements ActivityCallbackH
 	public void onSaveInstanceState(@NonNull Bundle outState) {
 		mHelper.onSaveInstanceState(outState);
 		super.onSaveInstanceState(outState);
-		Bridge.saveInstanceState(this, outState);
-	}
-
-	@Override
-	public void onDestroy() {
-		super.onDestroy();
-		Bridge.clear(this);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.livefront.bridge.Bridge;
 
 import androidx.fragment.app.Fragment;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -65,7 +64,6 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		Bridge.restoreInstanceState(this, savedInstanceState);
 		if (mHelper == null)
 			mHelper = new FragmentHelper(this);
 		else
@@ -134,7 +132,6 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 	public void onSaveInstanceState(@NonNull Bundle outState) {
 		mHelper.onSaveInstanceState(outState);
 		super.onSaveInstanceState(outState);
-		Bridge.saveInstanceState(this, outState);
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/dialogs/DreamDroidAttributionPresenter.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/dialogs/DreamDroidAttributionPresenter.java
@@ -89,16 +89,6 @@ public class DreamDroidAttributionPresenter {
 						.addCopyrightNotice("Copyright (c) 2012 Evelina Vrabie")
 						.addLicense(License.APACHE)
 						.setWebsite("https://github.com/CodeAndMagic/GaugeView")
-						.build(),
-					new Attribution.Builder("Android-State")
-						.addCopyrightNotice("Copyright (c) 2017 Evernote Corporation.")
-						.addLicense("Eclipse Public License - v 1.0","https://www.eclipse.org/legal/epl-v10.html")
-						.setWebsite("https://github.com/evernote/android-state")
-						.build(),
-					new Attribution.Builder("Bridge")
-						.addCopyrightNotice("Copyright 2017 Livefront")
-						.addLicense(License.APACHE)
-						.setWebsite("https://github.com/livefront/bridge")
 						.build()
 				)
 				.build();

--- a/app/src/net/reichholf/dreamdroid/fragment/dialogs/MultiChoiceDialog.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/dialogs/MultiChoiceDialog.java
@@ -14,9 +14,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 
-import com.evernote.android.state.State;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.livefront.bridge.Bridge;
 
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.helpers.BundleHelper;
@@ -30,9 +28,9 @@ public class MultiChoiceDialog extends DialogFragment {
     private static final String KEY_TITLE_ID = "titleId";
     private static final String KEY_ITEMS = "items";
     private static final String KEY_CHECKED_ITEMS = "checkedItems";
+    private static final String KEY_CHECKED_STATE = "checkedItemsState";
     private static final String KEY_POSITIVE_STRING_ID = "positiveStringId";
 
-    @State
     public boolean[] mCheckedItems;
 
     private int mTitleId;
@@ -48,8 +46,10 @@ public class MultiChoiceDialog extends DialogFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Bridge.restoreInstanceState(this, savedInstanceState);
         setRetainInstance(true);
+        if (savedInstanceState != null) {
+            mCheckedItems = savedInstanceState.getBooleanArray(KEY_CHECKED_STATE);
+        }
     }
 
     @Override
@@ -62,7 +62,9 @@ public class MultiChoiceDialog extends DialogFragment {
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putString("WORKAROUND_FOR_BUG_19917_KEY", "WORKAROUND_FOR_BUG_19917_VALUE");
-        Bridge.saveInstanceState(this, outState);
+        if (mCheckedItems != null) {
+            outState.putBooleanArray(KEY_CHECKED_STATE, mCheckedItems);
+        }
         super.onSaveInstanceState(outState);
     }
 
@@ -89,7 +91,9 @@ public class MultiChoiceDialog extends DialogFragment {
         Bundle args = getArguments();
         mTitleId = args.getInt(KEY_TITLE_ID);
         mItems = BundleHelper.toCharSequenceArray(args.getStringArrayList((KEY_ITEMS)));
-        mCheckedItems = args.getBooleanArray(KEY_CHECKED_ITEMS);
+        if (mCheckedItems == null) {
+            mCheckedItems = args.getBooleanArray(KEY_CHECKED_ITEMS);
+        }
         mPositiveStringId = args.getInt(KEY_POSITIVE_STRING_ID);
     }
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -92,7 +92,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | state-deviceinfo-beachhead | [#247](https://github.com/sreichholf/dreamDroid/pull/247) | merged | Phase 2.3b: DeviceInfoFragment drops `@State`; save/restore typed `DeviceInfo` via fragment Bundle. Keep Bridge/Evernote for other consumers. Keep OkHttp 3.14.9. |
 | state-simple-fragments | [#249](https://github.com/sreichholf/dreamDroid/pull/249) | merged | Phase 2.3c: ServiceListPage / ServiceListPager / EpgBouquet drop `@State`; Bundle string/int save. Keep Bridge. Keep OkHttp 3.14.9. |
 | state-screenshot | [#250](https://github.com/sreichholf/dreamDroid/pull/250) | merged | Phase 2.3d: ScreenShotFragment drops `@State` on `mRawImage`; do not Bundle the bytes — reload on process death. Keep Bridge. Keep OkHttp 3.14.9. |
-| state-hash-fragments | this PR | open | Phase 2.3e: timers/movies/current/BaseHttpRecyclerEvent drop `@State`; Bundle selection + filters (typed `CurrentService`). Keep Bridge for MultiChoiceDialog. Keep OkHttp 3.14.9. |
+| state-hash-fragments | [#251](https://github.com/sreichholf/dreamDroid/pull/251) | merged | Phase 2.3e: timers/movies/current/BaseHttpRecyclerEvent drop `@State`; Bundle selection + filters (typed `CurrentService`). Keep Bridge for MultiChoiceDialog. Keep OkHttp 3.14.9. |
+| state-drop-bridge | this PR | open | Phase 2.3f: MultiChoiceDialog Bundle `boolean[]`; remove Livefront Bridge + Evernote android-state deps from bases/`DreamDroid`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -154,8 +154,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3b DeviceInfoFragment `@State` beachhead **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247).
 - Phase 2.3c hub/EPG string-int `@State` **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249).
 - Phase 2.3d ScreenShot `@State` drop **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250).
-- **This PR** = Phase 2.3e hash-heavy `@State` fragments (timers, movies, current, BaseHttpRecyclerEvent).
-- Out of wave still: widgets, NavHost, MultiChoiceDialog + Bridge dep drop (2.3f). See Appendix H.
+- Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
+- **This PR** = Phase 2.3f MultiChoiceDialog Bundle + delete Evernote/Bridge deps.
+- Out of wave still: widgets, NavHost dive (2.1b). See Appendix H.
 
 ## How to read this
 
@@ -430,7 +431,7 @@ Two database files historically. Room `dreambox` holds `profile` and is included
 
 First-start skip-Profiles race is fixed on `main` in #168. Still wait for `Demo` after Changelog, not the word Profiles inside changelog text.
 
-Evernote `@State` plus Livefront Bridge is still load-bearing on rotation. Migrate only via Phase 2.3 slices (one fragment at a time); keep Bridge until the last `@State` consumer is gone. Do not big-bang remove either dependency.
+Evernote `@State` + Livefront Bridge retired in Phase 2.3 (**this PR** / 2.3f). Fragments use fragment-local `onSaveInstanceState` Bundles. Do not re-add those deps.
 
 VLC `VideoActivity` is out of this program.
 
@@ -475,7 +476,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 | Mediaplayer | removed (#175) | Drawer entry was commented; UI stack deleted. `URIStore.MEDIA_PLAYER_PLAY` kept for `ShareActivity`. |
 | Streaming | `VideoActivity`, `VideoOverlayFragment`, VLC | Explicitly out of wave 1. |
 | Widget | `appwidget/` | |
-| Shell | `MainActivity`, `NavigationHelper`, drawer XML, `BaseFragment` tree, Evernote `@State` + Bridge | |
+| Shell | `MainActivity`, `NavigationHelper`, drawer XML, `BaseFragment` tree | Bridge/`@State` retired Phase 2.3 |
 
 ### Still the old data stack
 
@@ -487,7 +488,7 @@ Compose on `main`: About dialog, Profiles list + edit form (#184), TV & Movies *
 ### Explicitly frozen
 
 - `app/src/.../tv/` Leanback. Operator picked phone first.
-- Rotation via Evernote State + Livefront Bridge until Phase 2.3 slices finish (through [#250](https://github.com/sreichholf/dreamDroid/pull/250); **this PR** / 2.3e; last consumer MultiChoiceDialog → 2.3f).
+- Rotation: fragment-local Bundle save (Evernote/Bridge removed Phase 2.3f **this PR**).
 - VLC playback.
 
 ### Sensible wave-2 shapes (pick one, do not do all at once)
@@ -688,7 +689,7 @@ One program each, still one PR (or small PR series) at a time:
 | 2q | HTTP / async — VideoOverlay now/next | `VideoOverlayFragment` → `lifecycleScope` + reuse `EpgNowNextLoad` / `serviceNowNextToExtendedHashMap`; drop overlay LoaderCallbacks only. Keep ButterKnife/VLC UI. Keep OkHttp 3.14.9. **merged** [#231](https://github.com/sreichholf/dreamDroid/pull/231). |
 | 2r | HTTP / async — Leanback RootBrowse | `RootBrowseFragment` → `lifecycleScope` + reuse `ServiceListLoad` / `EpgNowNextLoad` / `MovieListLoad` (+ locs/tags); drop TV LoaderCallbacks; delete `AsyncListLoader` / `LoaderResult`. Keep Leanback UI + ExtendedHashMap. Keep OkHttp 3.14.9. **merged** [#232](https://github.com/sreichholf/dreamDroid/pull/232). |
 | 2 | HTTP / async stack (program) | Replace `HttpURLConnection` + executor/`Loader` with Kotlin coroutines + typed `EnigmaClient` everywhere; keep OkHttp 3.14.9 for Picasso until a dedicated bump. **Phone+TV Loader paths done through 2r.** Follow-ons: typed TV browse (3.1a) / VLC product decision / NavHost / state. |
-| 3 | State / rotation | Through ScreenShot **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250). Hash-heavy **this PR** (2.3e). Then 2.3f MultiChoiceDialog + Bridge/Evernote dep drop. |
+| 3 | State / rotation | **this PR** completes 2.3f: MultiChoiceDialog Bundle + delete Evernote/Bridge. Prior slices [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#251](https://github.com/sreichholf/dreamDroid/pull/251). |
 | 4 | Data | Finish Room migration; BackupAgent → Room; drop legacy file after migrate. **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Shrink/remove `DatabaseHelper` later when migrate path is retired. |
 | 5 | VLC / streaming | Product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (option A: keep libVLC + Compose overlay). Typed overlay **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244). Compose overlay + ButterKnife drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 | 6 | Widgets | `appwidget/` Virtual Remote — Compose Glance or keep XML |
@@ -751,48 +752,38 @@ Why:
 - No Enigma2 server / codec / stream-protocol work
 - No NavHost / widgets / full Compose hub (3.1c-iv) drive-bys
 
-### Phase 2.3 — State / rotation (through 2.3d [#250](https://github.com/sreichholf/dreamDroid/pull/250); 2.3e this PR)
+### Phase 2.3 — State / rotation (complete this PR / 2.3f)
 
-#### Chassis
+#### Chassis (after 2.3f)
 
-- Deps: `com.evernote:android-state:1.4.1` + processor; `com.github.livefront:bridge:v2.0.2`
-- `DreamDroid` initializes Bridge with StateSaver SavedStateHandler
-- Bridge.save/restore in `BaseFragment`, `BaseRecyclerFragment`, `BaseActivity`, `MultiChoiceDialog`; `Bridge.clear` only in `BaseFragment` and `BaseActivity`
+- Evernote `android-state` and Livefront Bridge **removed** (**this PR**)
+- Fragment/activity bases no longer call `Bridge.save/restore/clear`
+- `DreamDroid` no longer initializes Bridge/StateSaver
 
-#### @State inventory (remaining after 2.3e)
+#### @State inventory
 
-| File | Fields | Notes |
-| --- | --- | --- |
-| MultiChoiceDialog | boolean[] mCheckedItems | Dialog + Bridge — last consumer → 2.3f |
+None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle **this PR**).
 
-Done off `@State` this PR: `BaseHttpRecyclerEventFragment`, `CurrentServiceFragment` (typed `CurrentService` + hash item), `MovieListFragment` (location/tags/selected movie hash), `TimerListFragment`, `TimerEditFragment` (create-mode restore fixed). Lists still reload; selection/filters Bundled. Typed `Timer`/`Movie` selection rows deferred (hash still at edit/delete edges).
+#### Agreed approach (done)
 
-No SavedStateHandle / rememberSaveable in repo yet. Compose screens use ephemeral remember/mutableStateOf.
-
-#### Agreed approach
-
-**A → fragment-local save:** migrate one fragment at a time off `@State` onto `onSaveInstanceState` / `SavedStateHandle` (or `rememberSaveable` for Compose-owned state). Keep Bridge wiring until last `@State` consumer is gone, then delete Evernote + Bridge deps.
-
-Do **not** big-bang remove Bridge.
+**A → fragment-local save:** migrated one fragment at a time off `@State` onto `onSaveInstanceState`. Bridge kept until last consumer, then deleted with Evernote.
 
 #### Proposed PR slices
 
-| Slice | Scope | Non-goals |
+| Slice | Scope | Status |
 | --- | --- | --- |
 | 2.3a | Docs dive | **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246) |
-| 2.3b | DeviceInfoFragment beachhead — drop @State; Bundle Serializable `DeviceInfo` | **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247) |
-| 2.3c | Simple string/int fragments (ServiceListPage, ServiceListPager, EpgBouquet) | **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249) |
-| 2.3d | ScreenShotFragment byte[] — do not persist raw image; reload | **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250) |
-| 2.3e | Hash-heavy fragments (timers, movies, current, BaseHttpRecyclerEvent) | **this PR**; no Bridge dep drop |
-| 2.3f | MultiChoiceDialog + remove Bridge from bases; delete Evernote/Bridge deps | No OkHttp 4; no NavHost |
+| 2.3b | DeviceInfoFragment beachhead | **merged** [#247](https://github.com/sreichholf/dreamDroid/pull/247) |
+| 2.3c | Simple string/int fragments | **merged** [#249](https://github.com/sreichholf/dreamDroid/pull/249) |
+| 2.3d | ScreenShotFragment — no byte Bundle; reload | **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250) |
+| 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
+| 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **this PR** |
 
-#### Explicit non-goals of 2.3e (this PR)
+#### Explicit non-goals of 2.3f (this PR)
 
-- No Bridge/Evernote dependency removal
-- No MultiChoiceDialog `@State` migration
-- No full typed Timer/Movie selection rewrite (hash still at edges)
 - No NavHost / widgets / Media3
 - No OkHttp 4; do not merge master into main
+- No SavedStateHandle / rememberSaveable rollout beyond fragment Bundles
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -806,7 +797,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3a–d **merged** [#246](https://github.com/sreichholf/dreamDroid/pull/246)/[#247](https://github.com/sreichholf/dreamDroid/pull/247)/[#249](https://github.com/sreichholf/dreamDroid/pull/249)/[#250](https://github.com/sreichholf/dreamDroid/pull/250). **This PR:** Phase 2.3e hash-heavy `@State`. Next Appendix H: 2.3f MultiChoiceDialog + Bridge/Evernote dep drop, or NavHost dive / widgets — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete this PR** (2.3a–f through Bridge/Evernote drop). Next Appendix H: NavHost dive (2.1b) or widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase **2.3f** completes the state/rotation program:

- `MultiChoiceDialog` — Bundle `boolean[]` (prefer restored selection over args)
- Remove Livefront Bridge save/restore/clear from `BaseFragment`, `BaseRecyclerFragment`, `BaseActivity`
- Remove Bridge/StateSaver init from `DreamDroid`
- Delete `com.evernote:android-state` (+ processor) and `com.github.livefront:bridge` from Gradle
- Drop related About attributions

No OkHttp 4; no NavHost/widgets drive-bys.

## Test plan

- [x] `./gradlew :app:assembleGoogleDebug`
- [ ] CI unit+assemble green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

