### PR TITLE
ci: cut PR unit-job wall time (config cache, -Pci, no emu)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,10 +18,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: temurin
@@ -31,7 +31,7 @@ jobs:
       # and was even pulling the emulator package on the unit job.
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           # Same-repo PRs may write caches; forks stay read-only.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -39,7 +39,7 @@ jobs:
       # Configuration cache lives under the project tree, not ~/.gradle — cache it
       # explicitly so PR/main runs can skip the ~10–15 min cold configure.
       - name: Cache Gradle configuration cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .gradle/configuration-cache
           key: gradle-config-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload unit test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-test-reports
           path: |
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable KVM
         run: |
@@ -89,16 +89,16 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Cache Gradle configuration cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .gradle/configuration-cache
           key: gradle-config-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload instrumented test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: androidTest-reports
           path: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -31,8 +31,10 @@ jobs:
       # and was even pulling the emulator package on the unit job.
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
+          # Open-source cache provider (v6 default pulls proprietary gradle-actions-caching).
+          cache-provider: basic
           # Same-repo PRs may write caches; forks stay read-only.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
@@ -95,7 +97,9 @@ jobs:
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
 
       - name: Cache Gradle configuration cache
         uses: actions/cache@v5

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -26,21 +26,37 @@ jobs:
           java-version: "17"
           distribution: temurin
 
-      # ubuntu-latest ships an Android SDK; this accepts licenses and ensures cmdline tools.
+      # Unit job does not need the emulator package (setup-android installs it by default).
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          packages: tools platform-tools platforms;android-34 build-tools;34.0.0
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          # Same-repo PRs may write caches; forks stay read-only.
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+      # Configuration cache lives under the project tree, not ~/.gradle — cache it
+      # explicitly so PR/main runs can skip the ~10–15 min cold configure.
+      - name: Cache Gradle configuration cache
+        uses: actions/cache@v4
+        with:
+          path: .gradle/configuration-cache
+          key: gradle-config-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
+          restore-keys: |
+            gradle-config-cache-${{ runner.os }}-
 
       - name: Make gradlew executable
         run: chmod +x gradlew
 
       # One Gradle invocation keeps the daemon warm (do not pass --no-daemon with setup-gradle).
+      # -Pci disables ABI splits so we assemble one APK (libvlc natives × 5 was wasteful on PRs).
       # Compiling androidTest catches broken Compose tests without an emulator.
       - name: Unit tests + assemble + compile androidTest
         run: >
-          ./gradlew
+          ./gradlew -Pci
           :app:testGoogleDebugUnitTest
           :app:assembleGoogleDebug
           :app:compileGoogleDebugAndroidTestKotlin
@@ -82,6 +98,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache Gradle configuration cache
+        uses: actions/cache@v4
+        with:
+          path: .gradle/configuration-cache
+          key: gradle-config-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
+          restore-keys: |
+            gradle-config-cache-${{ runner.os }}-
 
       - name: Make gradlew executable
         run: chmod +x gradlew

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -26,11 +26,9 @@ jobs:
           java-version: "17"
           distribution: temurin
 
-      # Unit job does not need the emulator package (setup-android installs it by default).
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          packages: tools platform-tools platforms;android-34 build-tools;34.0.0
+      # ubuntu-latest already ships Android SDK (platforms 34+, build-tools 34+,
+      # ANDROID_HOME). No setup-android — that action re-downloads cmdline-tools
+      # and was even pulling the emulator package on the unit job.
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Use `JAVA_HOME` pointing at JDK 17. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile. Emulator `connectedGoogleDebugAndroidTest` (API 30, `-Pci`) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile (all with `-Pci` to skip ABI splits). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` is for a single look when you need a screenshot or a shell-only path that has no test yet. It is not the verification loop.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,7 +132,7 @@ android {
     }
     splits {
         abi {
-            // CI passes -Pci so connectedGoogleDebugAndroidTest installs one APK.
+            // CI passes -Pci (unit + androidTest jobs) so we build one APK.
             enable !project.hasProperty("ci")
             reset()
             include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 BUILD_TOOLS_VERSION 34.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why CI feels slow

On PR #248’s 15m unit job, setup was ~35s. The Gradle step was **~14m**, and of that:

- **~13m** — cold configuration (`Calculating task graph as no configuration cache is available…` then silence until the first task)
- **~1m** — actual compile / unit tests / assemble

Dependency caches were already restoring (~480MB). The configuration cache lives under the **project** `.gradle/configuration-cache`, which `setup-gradle` does **not** restore — so every PR paid a full AGP configure. ABI splits were also still **on** for the unit job (only the emulator job passed `-Pci`).

## Changes

- **Node 24 action bumps** (fix Node 20 deprecation warnings):
  - `actions/checkout` v4 → v5
  - `actions/setup-java` v4 → v5
  - `gradle/actions/setup-gradle` v4 → **v6** with `cache-provider: basic` (open-source; avoids proprietary `gradle-actions-caching`)
  - `actions/cache` v4 → v5
  - `actions/upload-artifact` v4 → v6 (v5 still Node 20)
  - `reactivecircus/android-emulator-runner@v2` already Node 24
- **Drop `setup-android` on the unit job** — `ubuntu-latest` already ships Android SDK 34+, build-tools, and `ANDROID_HOME`
- Cache `.gradle/configuration-cache` via `actions/cache`
- Pass `-Pci` on the unit job (one APK, no ABI-split matrix)
- Same-repo PRs can write the Gradle home cache (forks stay read-only)
- `org.gradle.parallel=true` + `org.gradle.caching=true`

## Expected

- First run after this lands: still a cold configure (populates cache), but cheaper without ABI splits / SDK reinstall; v6 also invalidates old Gradle home cache keys once
- Later PRs: should reuse configuration cache and drop most of that ~13m configure tax
- No more `Node 20 is being deprecated` warnings from these steps

Emulator job on `main` is unchanged in scope (still slow; still PR-skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

