### PR TITLE
Phase 2.1c: NavHost Device Info beachhead

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.activity:activity-compose'
+    implementation 'androidx.navigation:navigation-compose:2.7.7'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'

--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -8,5 +8,6 @@
     <item name="menu_navigation_profiles" type="id"/>
     <item name="menu_cancel" type="id"/>
     <item name="menu_check_connectivity" type="id"/>
+    <item name="phone_nav_device_info_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -46,6 +46,7 @@ import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.enigma.ProfileDetectLoadKt;
 import net.reichholf.dreamdroid.fragment.ActivityCallbackHandler;
 import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.ProfileEditFragment;
 import net.reichholf.dreamdroid.fragment.ProfileListFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
@@ -302,6 +303,21 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 		return mDetailFragment;
 	}
 
+	/**
+	 * Detail pane content for callbacks. When the pane hosts {@link PhoneNavHostFragment},
+	 * prefer the nested NavHost leaf (e.g. Device Info) over the wrapper.
+	 */
+	@Nullable
+	private Fragment getDetailContentFragment() {
+		Fragment detail = getCurrentDetailFragment();
+		if (detail instanceof PhoneNavHostFragment) {
+			Fragment leaf = ((PhoneNavHostFragment) detail).getActiveLeaf();
+			if (leaf != null)
+				return leaf;
+		}
+		return detail;
+	}
+
 	private void initViews() {
 		setContentView(R.layout.dualpane);
 		Toolbar toolbar = findViewById(R.id.toolbar);
@@ -501,8 +517,9 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 		}
 		if (mNavigationHelper != null)
 			mNavigationHelper.onProfileChanged();
-		if (mDetailFragment != null && mDetailFragment instanceof IHttpBase)
-			((IHttpBase) mDetailFragment).onProfileChanged();
+		Fragment content = getDetailContentFragment();
+		if (content instanceof IHttpBase)
+			((IHttpBase) content).onProfileChanged();
 	}
 
 	/**
@@ -586,7 +603,7 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
-		ActivityCallbackHandler callbackHandler = (ActivityCallbackHandler) getCurrentDetailFragment();
+		ActivityCallbackHandler callbackHandler = (ActivityCallbackHandler) getDetailContentFragment();
 		if (callbackHandler != null)
 			if (callbackHandler.onKeyDown(keyCode, event))
 				return true;
@@ -607,7 +624,7 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		ActivityCallbackHandler callbackHandler = (ActivityCallbackHandler) getCurrentDetailFragment();
+		ActivityCallbackHandler callbackHandler = (ActivityCallbackHandler) getDetailContentFragment();
 		if (callbackHandler != null)
 			if (callbackHandler.onKeyUp(keyCode, event))
 				return true;
@@ -696,7 +713,9 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 			if (mNavigationHelper != null)
 				mNavigationHelper.onDialogAction(action, details, dialogTag);
 		} else if (mDetailFragment != null) {
-			((ActionDialog.DialogActionListener) mDetailFragment).onDialogAction(action, details, dialogTag);
+			Fragment content = getDetailContentFragment();
+			if (content instanceof ActionDialog.DialogActionListener)
+				((ActionDialog.DialogActionListener) content).onDialogAction(action, details, dialogTag);
 		}
 		super.onDialogAction(action, details, dialogTag);
 	}
@@ -738,8 +757,10 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 			if (mNavigationHelper != null)
 				((MultiChoiceDialog.MultiChoiceDialogListener) mNavigationHelper).onMultiChoiceDialogSelection(dialogTag, dialog, selected);
 		} else if (mDetailFragment != null) {
-			((MultiChoiceDialog.MultiChoiceDialogListener) mDetailFragment).onMultiChoiceDialogSelection(dialogTag,
-					dialog, selected);
+			Fragment content = getDetailContentFragment();
+			if (content instanceof MultiChoiceDialog.MultiChoiceDialogListener)
+				((MultiChoiceDialog.MultiChoiceDialogListener) content).onMultiChoiceDialogSelection(dialogTag,
+						dialog, selected);
 		}
 	}
 
@@ -749,8 +770,10 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 			if (mNavigationHelper != null)
 				((MultiChoiceDialog.MultiChoiceDialogListener) mNavigationHelper).onMultiChoiceDialogFinish(dialogTag, result);
 		} else if (mDetailFragment != null) {
-			((MultiChoiceDialog.MultiChoiceDialogListener) mDetailFragment)
-					.onMultiChoiceDialogFinish(dialogTag, result);
+			Fragment content = getDetailContentFragment();
+			if (content instanceof MultiChoiceDialog.MultiChoiceDialogListener)
+				((MultiChoiceDialog.MultiChoiceDialogListener) content)
+						.onMultiChoiceDialogFinish(dialogTag, result);
 		}
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -1,0 +1,41 @@
+package net.reichholf.dreamdroid.fragment
+
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import net.reichholf.dreamdroid.fragment.abs.BaseFragment
+import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
+
+/**
+ * Phase 2.1c beachhead: hosts Compose [androidx.navigation.compose.NavHost] in the phone
+ * detail pane. Device Info is the first leaf route; other destinations still use
+ * [net.reichholf.dreamdroid.fragment.helper.NavigationHelper] + Fragment transactions.
+ */
+class PhoneNavHostFragment : BaseFragment() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        mShouldRetainInstance = false
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            bindPhoneNavHost(this@PhoneNavHostFragment)
+        }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean = false
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean = false
+}

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -6,13 +6,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
+import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 
 /**
  * Phase 2.1c beachhead: hosts Compose [androidx.navigation.compose.NavHost] in the phone
  * detail pane. Device Info is the first leaf route; other destinations still use
  * [net.reichholf.dreamdroid.fragment.helper.NavigationHelper] + Fragment transactions.
+ *
+ * Activity callbacks and profile HTTP hooks must target the nested leaf, not this wrapper —
+ * see [getActiveLeaf].
  */
 class PhoneNavHostFragment : BaseFragment() {
 
@@ -35,7 +41,25 @@ class PhoneNavHostFragment : BaseFragment() {
         }
     }
 
-    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean = false
+    /** Nested destination fragment currently shown under the NavHost (if any). */
+    fun getActiveLeaf(): Fragment? {
+        return childFragmentManager.findFragmentById(R.id.phone_nav_device_info_slot)
+            ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.DEVICE_INFO)
+    }
 
-    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean = false
+    override fun onDrawerOpened() {
+        (getActiveLeaf() as? ActivityCallbackHandler)?.onDrawerOpened()
+    }
+
+    override fun onDrawerClosed() {
+        (getActiveLeaf() as? ActivityCallbackHandler)?.onDrawerClosed()
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        return (getActiveLeaf() as? ActivityCallbackHandler)?.onKeyDown(keyCode, event) ?: false
+    }
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+        return (getActiveLeaf() as? ActivityCallbackHandler)?.onKeyUp(keyCode, event) ?: false
+    }
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -19,7 +19,7 @@ import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
 import net.reichholf.dreamdroid.fragment.BackupFragment;
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment;
-import net.reichholf.dreamdroid.fragment.DeviceInfoFragment;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.EpgBouquetFragment;
 import net.reichholf.dreamdroid.fragment.MyPreferenceFragment;
 import net.reichholf.dreamdroid.fragment.ProfileListFragment;
@@ -178,7 +178,7 @@ public class NavigationHelper {
 
             case R.id.menu_navigation_device_info:
                 clearBackStack();
-                getMainActivity().showDetails(DeviceInfoFragment.class);
+                getMainActivity().showDetails(PhoneNavHostFragment.class);
                 break;
 
             case R.id.menu_navigation_current:

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -52,14 +53,36 @@ private fun NestedDeviceInfoDestination(hostFragment: Fragment) {
             }
         },
         update = { container ->
-            val fm = hostFragment.childFragmentManager
-            if (fm.findFragmentById(container.id) == null) {
-                fm.beginTransaction()
-                    .replace(container.id, DeviceInfoFragment(), PhoneNavRoutes.DEVICE_INFO)
-                    .commitNowAllowingStateLoss()
-            }
+            ensureNestedDeviceInfo(hostFragment, container.id)
         },
     )
+}
+
+/**
+ * Mount [DeviceInfoFragment] under the host when missing. Never uses
+ * `commitNowAllowingStateLoss`; if the child FM has already saved state, defer via
+ * [android.view.View.post] until a safe window (e.g. after rotation restore).
+ */
+internal fun ensureNestedDeviceInfo(hostFragment: Fragment, containerId: Int) {
+    if (!hostFragment.isAdded) return
+    val fm = hostFragment.childFragmentManager
+    if (fm.findFragmentById(containerId) != null) return
+    if (!fm.isStateSaved) {
+        commitNestedDeviceInfo(fm, containerId)
+        return
+    }
+    hostFragment.view?.post {
+        if (!hostFragment.isAdded) return@post
+        val childFm = hostFragment.childFragmentManager
+        if (childFm.findFragmentById(containerId) != null || childFm.isStateSaved) return@post
+        commitNestedDeviceInfo(childFm, containerId)
+    }
+}
+
+private fun commitNestedDeviceInfo(fm: FragmentManager, containerId: Int) {
+    fm.beginTransaction()
+        .replace(containerId, DeviceInfoFragment(), PhoneNavRoutes.DEVICE_INFO)
+        .commitNow()
 }
 
 fun ComposeView.bindPhoneNavHost(hostFragment: Fragment) {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -1,0 +1,72 @@
+package net.reichholf.dreamdroid.ui.nav
+
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+/**
+ * Phone shell [NavHost] beachhead. Today only [PhoneNavRoutes.DEVICE_INFO]; other drawer
+ * destinations still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
+ */
+@Composable
+fun PhoneNavHost(
+    hostFragment: Fragment,
+    navController: NavHostController = rememberNavController(),
+    startDestination: String = PhoneNavRoutes.DEVICE_INFO,
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        composable(PhoneNavRoutes.DEVICE_INFO) {
+            NestedDeviceInfoDestination(hostFragment = hostFragment)
+        }
+    }
+}
+
+@Composable
+private fun NestedDeviceInfoDestination(hostFragment: Fragment) {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { context ->
+            FragmentContainerView(context).apply {
+                id = R.id.phone_nav_device_info_slot
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        },
+        update = { container ->
+            val fm = hostFragment.childFragmentManager
+            if (fm.findFragmentById(container.id) == null) {
+                fm.beginTransaction()
+                    .replace(container.id, DeviceInfoFragment(), PhoneNavRoutes.DEVICE_INFO)
+                    .commitNowAllowingStateLoss()
+            }
+        },
+    )
+}
+
+fun ComposeView.bindPhoneNavHost(hostFragment: Fragment) {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    setContent {
+        DreamDroidTheme {
+            PhoneNavHost(hostFragment = hostFragment)
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -1,0 +1,9 @@
+package net.reichholf.dreamdroid.ui.nav
+
+/**
+ * Compose Navigation route ids for the phone shell beachhead (Phase 2.1c).
+ * Expand as more drawer destinations migrate off [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
+ */
+object PhoneNavRoutes {
+    const val DEVICE_INFO = "device_info"
+}

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -121,7 +121,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Full Compose Navigation / `NavHost` still later — dive **this PR** (2.1b).
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **this PR** (2.1c).
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -158,8 +158,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3d ScreenShot `@State` drop **merged** [#250](https://github.com/sreichholf/dreamDroid/pull/250).
 - Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
-- **This PR** = Phase 2.1b NavHost dive (docs only).
-- Out of wave still: widgets (2.6); NavHost implementation after this dive. See Appendix H.
+- Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
+- **This PR** = Phase 2.1c NavHost Device Info beachhead (`navigation-compose` + nested `DeviceInfoFragment`).
+- Out of wave still: widgets (2.6); more NavHost roots (2.1d+). See Appendix H.
 
 ## How to read this
 
@@ -593,7 +594,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: **this PR** NavHost dive → 2.1c beachhead, or widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); **this PR** = 2.1c beachhead; then 2.1d+ or widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -672,7 +673,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Dive **this PR**; implementation slices below. `MainActivity` + destinations → Compose Navigation / `NavHost` gradually. |
+| 1b | Drawer Navigation | Dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). Beachhead **this PR** (2.1c Device Info). |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -782,9 +783,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation dive (this PR; docs only)
-
-**No NavHost code in this PR.** Chrome (2.1a / [#212](https://github.com/sreichholf/dreamDroid/pull/212)) is stable; implementation starts after this dive is on `main`.
+### Phase 2.1b — NavHost / Compose Navigation (dive merged [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead this PR)
 
 #### Chassis (current)
 
@@ -794,44 +793,31 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Shell | `MainActivity` + `dualpane.xml` | `DrawerLayout` + `detail_view` + FABs; profile header XML; drawer `ComposeView` |
 | Drawer chrome | `ui/drawer/DrawerScreen.kt` | Compose destinations; menu ids from `res/menu/navigation.xml` |
 | Router | `NavigationHelper` | Switch on menu ids → `showDetails` / side activities / dialogs; drawer roots `clearBackStack` |
+| NavHost beachhead | `PhoneNavHostFragment` + `ui/nav/PhoneNavHost.kt` | **this PR**: `navigation-compose` 2.7.7; Device Info leaf nests existing `DeviceInfoFragment` |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
 | Profiles | Profile header XML + first-start | Not in `DrawerScreen` / `navigation.xml`; opens `ProfileListFragment`, clears drawer selection |
 
-**No `androidx.navigation` / `NavHost` dependency yet.** Phone destinations are Fragments hosting Compose via `ComposeView`.
-
-#### Risks
-
-- Drawer roots clear FM stack; nested pushes (EPG search, service EPG, pick-service) must stay distinct under Compose Nav
-- `isMultiPane()` means in-activity detail — wrong abstraction breaks pickers
-- DialogFragment policy vs Compose dialog routes
-- `VideoActivity` / VLC stays a separate activity (product decision A)
-- Side activities (settings, profile/timer edit, phone-only remote) remain islands unless later converged; tablet remote is in-host
-- Profiles is a top-level route outside the Compose drawer list (header / first-start); must clear or map selection without a menu highlight
-- Hub `ServiceListPager` (ViewPager2 + nested fragments) is a heavy first target — migrate leaves first
-- XML FABs, AppBar, volume keys bind to current detail fragment
-
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` (or a `ComposeView`); migrate **one leaf** destination while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate **one leaf** (Device Info) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph.
 
 #### Proposed PR slices
 
 | Slice | Scope | Non-goals |
 | --- | --- | --- |
-| 2.1b | Docs dive (this PR) | No code |
-| 2.1c | Beachhead: `navigation-compose` + one leaf route (Device Info or Signal) | No hub; no dialog rewrite |
+| 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
+| 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **this PR**; no hub; no dialog rewrite |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | Keep XML drawer chrome host |
 | 2.1e | More drawer roots (leaves before `ServiceListPager`) | No VideoActivity |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
-#### Explicit non-goals of this dive
+#### Explicit non-goals of 2.1c (this PR)
 
-- No NavHost / navigation-compose dependency yet
-- No fragment host rewrite
+- No other drawer destinations on NavHost
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -847,7 +833,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). **This PR:** Phase 2.1b NavHost dive. Next Appendix H: 2.1c NavHost beachhead, or widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). **This PR:** Phase 2.1c NavHost Device Info beachhead. Next Appendix H: more NavHost roots (2.1d+) or widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -94,7 +94,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | state-screenshot | [#250](https://github.com/sreichholf/dreamDroid/pull/250) | merged | Phase 2.3d: ScreenShotFragment drops `@State` on `mRawImage`; do not Bundle the bytes — reload on process death. Keep Bridge. Keep OkHttp 3.14.9. |
 | state-hash-fragments | [#251](https://github.com/sreichholf/dreamDroid/pull/251) | merged | Phase 2.3e: timers/movies/current/BaseHttpRecyclerEvent drop `@State`; Bundle selection + filters (typed `CurrentService`). Keep Bridge for MultiChoiceDialog. Keep OkHttp 3.14.9. |
 | state-drop-bridge | [#252](https://github.com/sreichholf/dreamDroid/pull/252) | merged | Phase 2.3f: MultiChoiceDialog Bundle `boolean[]`; remove Livefront Bridge + Evernote android-state deps. Keep OkHttp 3.14.9. |
-| docs-navhost-dive | this PR | open | Phase 2.1b (docs only): phone NavHost / Compose Navigation inventory + agreed hybrid slices. No NavHost code. Keep OkHttp 3.14.9. |
+| docs-navhost-dive | [#254](https://github.com/sreichholf/dreamDroid/pull/254) | merged | Phase 2.1b (docs only): phone NavHost / Compose Navigation inventory + agreed hybrid slices. Keep OkHttp 3.14.9. |
+| navhost-deviceinfo-beachhead | this PR | open | Phase 2.1c: `navigation-compose` + `PhoneNavHostFragment` Device Info leaf; other drawer destinations still Fragment/`NavigationHelper`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Phase **2.1c** beachhead after the [#254](https://github.com/sreichholf/dreamDroid/pull/254) NavHost dive.

- Add `androidx.navigation:navigation-compose:2.7.7`
- `PhoneNavHostFragment` hosts Compose `NavHost` in the phone detail pane
- Device Info drawer destination opens that host; nested `DeviceInfoFragment` stays the real UI
- Other drawer destinations still use `NavigationHelper` + Fragment transactions
- Keep DrawerLayout, DialogFragments, side activities, and `VideoActivity` out of this PR

## Bugbot follow-up
- Nested attach no longer uses `commitNowAllowingStateLoss`; defers via `View.post` when the child `FragmentManager` has saved state
- `PhoneNavHostFragment.getActiveLeaf()` + `MainActivity.getDetailContentFragment()` so profile/keys/dialogs hit the nested Device Info leaf

## Non-goals
- No other NavHost routes (2.1d+)
- No hub / ServiceListPager
- No OkHttp 4; do not merge `master` into `main`

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open Device Info from drawer; rotate; title/content still load; other destinations unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

