### PR TITLE
Phase 2.1d: drawer Device Info → NavController

### DIFF
--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -7,20 +7,21 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavHostController
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 
 /**
- * Phase 2.1c beachhead: hosts Compose [androidx.navigation.compose.NavHost] in the phone
- * detail pane. Device Info is the first leaf route; other destinations still use
- * [net.reichholf.dreamdroid.fragment.helper.NavigationHelper] + Fragment transactions.
- *
- * Activity callbacks and profile HTTP hooks must target the nested leaf, not this wrapper —
- * see [getActiveLeaf].
+ * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
+ * Device Info is the first leaf route; drawer re-selection uses [navigateToRoute]
+ * instead of replacing this fragment (Phase 2.1d).
  */
 class PhoneNavHostFragment : BaseFragment() {
+
+    @Volatile
+    private var navController: NavHostController? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         mShouldRetainInstance = false
@@ -45,6 +46,34 @@ class PhoneNavHostFragment : BaseFragment() {
     fun getActiveLeaf(): Fragment? {
         return childFragmentManager.findFragmentById(R.id.phone_nav_device_info_slot)
             ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.DEVICE_INFO)
+    }
+
+    fun attachNavController(controller: NavHostController) {
+        navController = controller
+    }
+
+    fun detachNavController(controller: NavHostController) {
+        if (navController === controller) {
+            navController = null
+        }
+    }
+
+    /**
+     * Navigate within the hosted [androidx.navigation.NavHost] without replacing this
+     * fragment. No-op if the controller is not ready yet (first show still uses
+     * [net.reichholf.dreamdroid.activities.MainActivity.showDetails]).
+     *
+     * @return true if a navigation was requested
+     */
+    fun navigateToRoute(route: String): Boolean {
+        val controller = navController ?: return false
+        controller.navigate(route) {
+            launchSingleTop = true
+            popUpTo(controller.graph.startDestinationId) {
+                inclusive = false
+            }
+        }
+        return true
     }
 
     override fun onDrawerOpened() {

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -8,6 +8,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
 import net.reichholf.dreamdroid.DreamDroid;
@@ -46,6 +47,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.MessageRequestHan
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SimpleResultRequestHandler;
 import net.reichholf.dreamdroid.ui.drawer.DrawerListState;
 import net.reichholf.dreamdroid.ui.drawer.DrawerScreenKt;
+import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes;
 
 import java.util.ArrayList;
 
@@ -177,6 +179,14 @@ public class NavigationHelper {
                 break;
 
             case R.id.menu_navigation_device_info:
+                // Phase 2.1d: if NavHost is already the detail pane, navigate in-graph
+                // instead of clearBackStack + replace.
+                Fragment detail = getMainActivity().getSupportFragmentManager()
+                        .findFragmentById(R.id.detail_view);
+                if (detail instanceof PhoneNavHostFragment
+                        && ((PhoneNavHostFragment) detail).navigateToRoute(PhoneNavRoutes.DEVICE_INFO)) {
+                    break;
+                }
                 clearBackStack();
                 getMainActivity().showDetails(PhoneNavHostFragment.class);
                 break;

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -3,6 +3,7 @@ package net.reichholf.dreamdroid.ui.nav
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -16,6 +17,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
@@ -24,10 +26,14 @@ import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
  */
 @Composable
 fun PhoneNavHost(
-    hostFragment: Fragment,
+    hostFragment: PhoneNavHostFragment,
     navController: NavHostController = rememberNavController(),
     startDestination: String = PhoneNavRoutes.DEVICE_INFO,
 ) {
+    DisposableEffect(navController) {
+        hostFragment.attachNavController(navController)
+        onDispose { hostFragment.detachNavController(navController) }
+    }
     NavHost(
         navController = navController,
         startDestination = startDestination,
@@ -85,7 +91,7 @@ private fun commitNestedDeviceInfo(fm: FragmentManager, containerId: Int) {
         .commitNow()
 }
 
-fun ComposeView.bindPhoneNavHost(hostFragment: Fragment) {
+fun ComposeView.bindPhoneNavHost(hostFragment: PhoneNavHostFragment) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -1,7 +1,7 @@
 package net.reichholf.dreamdroid.ui.nav
 
 /**
- * Compose Navigation route ids for the phone shell beachhead (Phase 2.1c).
+ * Compose Navigation route ids for the phone shell NavHost.
  * Expand as more drawer destinations migrate off [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
  */
 object PhoneNavRoutes {

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -95,7 +95,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | state-hash-fragments | [#251](https://github.com/sreichholf/dreamDroid/pull/251) | merged | Phase 2.3e: timers/movies/current/BaseHttpRecyclerEvent drop `@State`; Bundle selection + filters (typed `CurrentService`). Keep Bridge for MultiChoiceDialog. Keep OkHttp 3.14.9. |
 | state-drop-bridge | [#252](https://github.com/sreichholf/dreamDroid/pull/252) | merged | Phase 2.3f: MultiChoiceDialog Bundle `boolean[]`; remove Livefront Bridge + Evernote android-state deps. Keep OkHttp 3.14.9. |
 | docs-navhost-dive | [#254](https://github.com/sreichholf/dreamDroid/pull/254) | merged | Phase 2.1b (docs only): phone NavHost / Compose Navigation inventory + agreed hybrid slices. Keep OkHttp 3.14.9. |
-| navhost-deviceinfo-beachhead | this PR | open | Phase 2.1c: `navigation-compose` + `PhoneNavHostFragment` Device Info leaf; other drawer destinations still Fragment/`NavigationHelper`. Keep OkHttp 3.14.9. |
+| navhost-deviceinfo-beachhead | [#255](https://github.com/sreichholf/dreamDroid/pull/255) | merged | Phase 2.1c: `navigation-compose` + `PhoneNavHostFragment` Device Info leaf; other drawer destinations still Fragment/`NavigationHelper`. Keep OkHttp 3.14.9. |
+| navhost-drawer-navcontroller | this PR | open | Phase 2.1d: drawer Device Info uses `NavController` when `PhoneNavHostFragment` is already shown (no `clearBackStack`+`showDetails`). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -121,7 +122,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **this PR** (2.1c).
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255); drawer→NavController **this PR** (2.1d).
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -159,8 +160,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
 - Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
-- **This PR** = Phase 2.1c NavHost Device Info beachhead (`navigation-compose` + nested `DeviceInfoFragment`).
-- Out of wave still: widgets (2.6); more NavHost roots (2.1d+). See Appendix H.
+- Phase 2.1c NavHost Device Info beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255).
+- **This PR** = Phase 2.1d drawer → `NavController` for Device Info when `PhoneNavHostFragment` is already the detail pane.
+- Out of wave still: widgets (2.6); more NavHost roots (2.1e+). See Appendix H.
 
 ## How to read this
 
@@ -594,7 +596,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); **this PR** = 2.1c beachhead; then 2.1d+ or widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255); **this PR** = 2.1d drawer→NavController; then 2.1e+ or widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -673,7 +675,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). Beachhead **this PR** (2.1c Device Info). |
+| 1b | Drawer Navigation | Dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). Beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255). Drawer→NavController **this PR** (2.1d). |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -783,7 +785,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation (dive merged [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead this PR)
+### Phase 2.1b — NavHost / Compose Navigation (dive [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead [#255](https://github.com/sreichholf/dreamDroid/pull/255); drawer→NavController this PR)
 
 #### Chassis (current)
 
@@ -793,7 +795,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Shell | `MainActivity` + `dualpane.xml` | `DrawerLayout` + `detail_view` + FABs; profile header XML; drawer `ComposeView` |
 | Drawer chrome | `ui/drawer/DrawerScreen.kt` | Compose destinations; menu ids from `res/menu/navigation.xml` |
 | Router | `NavigationHelper` | Switch on menu ids → `showDetails` / side activities / dialogs; drawer roots `clearBackStack` |
-| NavHost beachhead | `PhoneNavHostFragment` + `ui/nav/PhoneNavHost.kt` | **this PR**: `navigation-compose` 2.7.7; Device Info leaf nests existing `DeviceInfoFragment` |
+| NavHost beachhead | `PhoneNavHostFragment` + `ui/nav/PhoneNavHost.kt` | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255): `navigation-compose` 2.7.7; Device Info leaf nests existing `DeviceInfoFragment` |
+| Drawer → NavController | `NavigationHelper` + `PhoneNavHostFragment.navigateToRoute` | **this PR** (2.1d): Device Info re-select uses in-graph navigate when host already shown |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -801,23 +804,23 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate **one leaf** (Device Info) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate **one leaf** (Device Info) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Phase 2.1d: drawer Device Info calls `navigateToRoute` when the host is already visible (skip `clearBackStack`+`showDetails`).
 
 #### Proposed PR slices
 
 | Slice | Scope | Non-goals |
 | --- | --- | --- |
 | 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
-| 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **this PR**; no hub; no dialog rewrite |
-| 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | Keep XML drawer chrome host |
+| 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
+| 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **this PR**; Keep XML drawer chrome host |
 | 2.1e | More drawer roots (leaves before `ServiceListPager`) | No VideoActivity |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
-#### Explicit non-goals of 2.1c (this PR)
+#### Explicit non-goals of 2.1d (this PR)
 
-- No other drawer destinations on NavHost
+- No new drawer destinations on NavHost (Signal / Screenshot / etc. → 2.1e)
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -833,7 +836,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). **This PR:** Phase 2.1c NavHost Device Info beachhead. Next Appendix H: more NavHost roots (2.1d+) or widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–c **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)/[#255](https://github.com/sreichholf/dreamDroid/pull/255). **This PR:** Phase 2.1d drawer→NavController for Device Info. Next Appendix H: more NavHost roots (2.1e+) or widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Phase **2.1d** after [#255](https://github.com/sreichholf/dreamDroid/pull/255) Device Info NavHost beachhead.

- `PhoneNavHostFragment` holds the `NavHostController` and exposes `navigateToRoute`
- Drawer Device Info: if the NavHost host is already the detail pane, navigate in-graph (`launchSingleTop`) — **no** `clearBackStack` + `showDetails`
- First open (or after another destination) still mounts `PhoneNavHostFragment` as before
- No new NavHost destinations (Signal / Screenshot → 2.1e)

## Non-goals
- No additional drawer roots on NavHost
- No OkHttp 4; do not merge `master` into `main`

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open Device Info; leave to Services; return; re-tap Device Info while already there — no blank pane / no unnecessary fragment replace
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

