### PR TITLE
Phase 2.1e: Signal leaf on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -9,5 +9,6 @@
     <item name="menu_cancel" type="id"/>
     <item name="menu_check_connectivity" type="id"/>
     <item name="phone_nav_device_info_slot" type="id"/>
+    <item name="phone_nav_signal_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -12,13 +12,27 @@ import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
+import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
 
 /**
  * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
- * Device Info is the first leaf route; drawer re-selection uses [navigateToRoute]
- * instead of replacing this fragment (Phase 2.1d).
+ * Migrated leaves: Device Info, Signal. Drawer selection uses [navigateToRoute] when this
+ * host is already shown; [ARG_START_ROUTE] picks the first leaf when mounting.
  */
 class PhoneNavHostFragment : BaseFragment() {
+
+    companion object {
+        const val ARG_START_ROUTE = "phone_nav_start_route"
+
+        @JvmStatic
+        fun newInstance(startRoute: String): PhoneNavHostFragment {
+            return PhoneNavHostFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_START_ROUTE, startRoute)
+                }
+            }
+        }
+    }
 
     @Volatile
     private var navController: NavHostController? = null
@@ -42,10 +56,22 @@ class PhoneNavHostFragment : BaseFragment() {
         }
     }
 
-    /** Nested destination fragment currently shown under the NavHost (if any). */
+    fun startRoute(): String {
+        return arguments?.getString(ARG_START_ROUTE) ?: PhoneNavRoutes.DEVICE_INFO
+    }
+
+    /** Nested destination fragment for the current NavHost route (if any). */
     fun getActiveLeaf(): Fragment? {
-        return childFragmentManager.findFragmentById(R.id.phone_nav_device_info_slot)
-            ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.DEVICE_INFO)
+        val route = navController?.currentDestination?.route ?: startRoute()
+        return when (route) {
+            PhoneNavRoutes.DEVICE_INFO ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_device_info_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.DEVICE_INFO)
+            PhoneNavRoutes.SIGNAL ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_signal_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.SIGNAL)
+            else -> null
+        }
     }
 
     fun attachNavController(controller: NavHostController) {
@@ -67,12 +93,7 @@ class PhoneNavHostFragment : BaseFragment() {
      */
     fun navigateToRoute(route: String): Boolean {
         val controller = navController ?: return false
-        controller.navigate(route) {
-            launchSingleTop = true
-            popUpTo(controller.graph.startDestinationId) {
-                inclusive = false
-            }
-        }
+        controller.navigateDrawerRoot(route)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -26,7 +26,6 @@ import net.reichholf.dreamdroid.fragment.MyPreferenceFragment;
 import net.reichholf.dreamdroid.fragment.ProfileListFragment;
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment;
 import net.reichholf.dreamdroid.fragment.ServiceListPager;
-import net.reichholf.dreamdroid.fragment.SignalFragment;
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment;
 import net.reichholf.dreamdroid.fragment.ZapFragment;
 import net.reichholf.dreamdroid.ui.about.AboutComposeDialog;
@@ -107,6 +106,21 @@ public class NavigationHelper {
         }
     }
 
+    /**
+     * Open a migrated phone NavHost leaf. If {@link PhoneNavHostFragment} is already the
+     * detail pane, navigate in-graph; otherwise mount the host with [route] as start.
+     */
+    protected void navigatePhoneNavRoot(@NonNull String route) {
+        Fragment detail = getMainActivity().getSupportFragmentManager()
+                .findFragmentById(R.id.detail_view);
+        if (detail instanceof PhoneNavHostFragment
+                && ((PhoneNavHostFragment) detail).navigateToRoute(route)) {
+            return;
+        }
+        clearBackStack();
+        getMainActivity().showDetails(PhoneNavHostFragment.newInstance(route));
+    }
+
     public void onDestroy() {
         if (mPowerStateJob != null) {
             mPowerStateJob.cancel(null);
@@ -179,16 +193,7 @@ public class NavigationHelper {
                 break;
 
             case R.id.menu_navigation_device_info:
-                // Phase 2.1d: if NavHost is already the detail pane, navigate in-graph
-                // instead of clearBackStack + replace.
-                Fragment detail = getMainActivity().getSupportFragmentManager()
-                        .findFragmentById(R.id.detail_view);
-                if (detail instanceof PhoneNavHostFragment
-                        && ((PhoneNavHostFragment) detail).navigateToRoute(PhoneNavRoutes.DEVICE_INFO)) {
-                    break;
-                }
-                clearBackStack();
-                getMainActivity().showDetails(PhoneNavHostFragment.class);
+                navigatePhoneNavRoot(PhoneNavRoutes.DEVICE_INFO);
                 break;
 
             case R.id.menu_navigation_current:
@@ -268,8 +273,7 @@ public class NavigationHelper {
                 break;
 
             case R.id.menu_navigation_signal:
-                clearBackStack();
-                getMainActivity().showDetails(SignalFragment.class);
+                navigatePhoneNavRoot(PhoneNavRoutes.SIGNAL);
                 break;
             case R.id.menu_navigation_zap:
                 clearBackStack();

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -18,17 +19,18 @@ import androidx.navigation.compose.rememberNavController
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
+import net.reichholf.dreamdroid.fragment.SignalFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost] beachhead. Today only [PhoneNavRoutes.DEVICE_INFO]; other drawer
- * destinations still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
+ * Phone shell [NavHost]. Migrated drawer leaves: Device Info, Signal. Other destinations still
+ * go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
  */
 @Composable
 fun PhoneNavHost(
     hostFragment: PhoneNavHostFragment,
     navController: NavHostController = rememberNavController(),
-    startDestination: String = PhoneNavRoutes.DEVICE_INFO,
+    startDestination: String = hostFragment.startRoute(),
 ) {
     DisposableEffect(navController) {
         hostFragment.attachNavController(navController)
@@ -40,18 +42,36 @@ fun PhoneNavHost(
         modifier = Modifier.fillMaxSize(),
     ) {
         composable(PhoneNavRoutes.DEVICE_INFO) {
-            NestedDeviceInfoDestination(hostFragment = hostFragment)
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_device_info_slot,
+                routeTag = PhoneNavRoutes.DEVICE_INFO,
+                createFragment = { DeviceInfoFragment() },
+            )
+        }
+        composable(PhoneNavRoutes.SIGNAL) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_signal_slot,
+                routeTag = PhoneNavRoutes.SIGNAL,
+                createFragment = { SignalFragment() },
+            )
         }
     }
 }
 
 @Composable
-private fun NestedDeviceInfoDestination(hostFragment: Fragment) {
+private fun NestedFragmentDestination(
+    hostFragment: Fragment,
+    containerId: Int,
+    routeTag: String,
+    createFragment: () -> Fragment,
+) {
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = { context ->
             FragmentContainerView(context).apply {
-                id = R.id.phone_nav_device_info_slot
+                id = containerId
                 layoutParams = ViewGroup.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.MATCH_PARENT,
@@ -59,36 +79,57 @@ private fun NestedDeviceInfoDestination(hostFragment: Fragment) {
             }
         },
         update = { container ->
-            ensureNestedDeviceInfo(hostFragment, container.id)
+            ensureNestedFragment(hostFragment, container.id, routeTag, createFragment)
         },
     )
 }
 
 /**
- * Mount [DeviceInfoFragment] under the host when missing. Never uses
+ * Mount [createFragment] under the host when missing. Never uses
  * `commitNowAllowingStateLoss`; if the child FM has already saved state, defer via
  * [android.view.View.post] until a safe window (e.g. after rotation restore).
  */
-internal fun ensureNestedDeviceInfo(hostFragment: Fragment, containerId: Int) {
+internal fun ensureNestedFragment(
+    hostFragment: Fragment,
+    containerId: Int,
+    routeTag: String,
+    createFragment: () -> Fragment,
+) {
     if (!hostFragment.isAdded) return
     val fm = hostFragment.childFragmentManager
     if (fm.findFragmentById(containerId) != null) return
     if (!fm.isStateSaved) {
-        commitNestedDeviceInfo(fm, containerId)
+        commitNestedFragment(fm, containerId, routeTag, createFragment)
         return
     }
     hostFragment.view?.post {
         if (!hostFragment.isAdded) return@post
         val childFm = hostFragment.childFragmentManager
         if (childFm.findFragmentById(containerId) != null || childFm.isStateSaved) return@post
-        commitNestedDeviceInfo(childFm, containerId)
+        commitNestedFragment(childFm, containerId, routeTag, createFragment)
     }
 }
 
-private fun commitNestedDeviceInfo(fm: FragmentManager, containerId: Int) {
+private fun commitNestedFragment(
+    fm: FragmentManager,
+    containerId: Int,
+    routeTag: String,
+    createFragment: () -> Fragment,
+) {
     fm.beginTransaction()
-        .replace(containerId, DeviceInfoFragment(), PhoneNavRoutes.DEVICE_INFO)
+        .replace(containerId, createFragment(), routeTag)
         .commitNow()
+}
+
+/** Drawer-style top-level navigate: single-top + save/restore under the start destination. */
+fun NavHostController.navigateDrawerRoot(route: String) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
 }
 
 fun ComposeView.bindPhoneNavHost(hostFragment: PhoneNavHostFragment) {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -6,4 +6,5 @@ package net.reichholf.dreamdroid.ui.nav
  */
 object PhoneNavRoutes {
     const val DEVICE_INFO = "device_info"
+    const val SIGNAL = "signal"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -96,7 +96,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | state-drop-bridge | [#252](https://github.com/sreichholf/dreamDroid/pull/252) | merged | Phase 2.3f: MultiChoiceDialog Bundle `boolean[]`; remove Livefront Bridge + Evernote android-state deps. Keep OkHttp 3.14.9. |
 | docs-navhost-dive | [#254](https://github.com/sreichholf/dreamDroid/pull/254) | merged | Phase 2.1b (docs only): phone NavHost / Compose Navigation inventory + agreed hybrid slices. Keep OkHttp 3.14.9. |
 | navhost-deviceinfo-beachhead | [#255](https://github.com/sreichholf/dreamDroid/pull/255) | merged | Phase 2.1c: `navigation-compose` + `PhoneNavHostFragment` Device Info leaf; other drawer destinations still Fragment/`NavigationHelper`. Keep OkHttp 3.14.9. |
-| navhost-drawer-navcontroller | this PR | open | Phase 2.1d: drawer Device Info uses `NavController` when `PhoneNavHostFragment` is already shown (no `clearBackStack`+`showDetails`). Keep OkHttp 3.14.9. |
+| navhost-drawer-navcontroller | [#256](https://github.com/sreichholf/dreamDroid/pull/256) | merged | Phase 2.1d: drawer Device Info uses `NavController` when `PhoneNavHostFragment` is already shown (no `clearBackStack`+`showDetails`). Keep OkHttp 3.14.9. |
+| navhost-signal-leaf | this PR | open | Phase 2.1e: Signal drawer root on `PhoneNavHost` (sibling of Device Info); `ARG_START_ROUTE` + drawer-style navigate. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -122,7 +123,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255); drawer→NavController **this PR** (2.1d).
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–d NavHost **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)/[#255](https://github.com/sreichholf/dreamDroid/pull/255)/[#256](https://github.com/sreichholf/dreamDroid/pull/256); Signal leaf **this PR** (2.1e).
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -161,8 +162,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
 - Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
 - Phase 2.1c NavHost Device Info beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255).
-- **This PR** = Phase 2.1d drawer → `NavController` for Device Info when `PhoneNavHostFragment` is already the detail pane.
-- Out of wave still: widgets (2.6); more NavHost roots (2.1e+). See Appendix H.
+- Phase 2.1d drawer → `NavController` **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256).
+- **This PR** = Phase 2.1e Signal leaf on `PhoneNavHost` (more leaves before hub later).
+- Out of wave still: widgets (2.6); more NavHost roots / hub (2.1e+). See Appendix H.
 
 ## How to read this
 
@@ -596,7 +598,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255); **this PR** = 2.1d drawer→NavController; then 2.1e+ or widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H next after Phase 2.3: NavHost through 2.1d **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#256](https://github.com/sreichholf/dreamDroid/pull/256); **this PR** = 2.1e Signal leaf; then more leaves / hub or widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -675,7 +677,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254). Beachhead **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255). Drawer→NavController **this PR** (2.1d). |
+| 1b | Drawer Navigation | Dive–drawer NavController **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#256](https://github.com/sreichholf/dreamDroid/pull/256). Signal leaf **this PR** (2.1e). |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -785,7 +787,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation (dive [#254](https://github.com/sreichholf/dreamDroid/pull/254); beachhead [#255](https://github.com/sreichholf/dreamDroid/pull/255); drawer→NavController this PR)
+### Phase 2.1b — NavHost / Compose Navigation (through 2.1d merged; Signal leaf this PR)
 
 #### Chassis (current)
 
@@ -796,7 +798,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Drawer chrome | `ui/drawer/DrawerScreen.kt` | Compose destinations; menu ids from `res/menu/navigation.xml` |
 | Router | `NavigationHelper` | Switch on menu ids → `showDetails` / side activities / dialogs; drawer roots `clearBackStack` |
 | NavHost beachhead | `PhoneNavHostFragment` + `ui/nav/PhoneNavHost.kt` | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255): `navigation-compose` 2.7.7; Device Info leaf nests existing `DeviceInfoFragment` |
-| Drawer → NavController | `NavigationHelper` + `PhoneNavHostFragment.navigateToRoute` | **this PR** (2.1d): Device Info re-select uses in-graph navigate when host already shown |
+| Drawer → NavController | `NavigationHelper` + `PhoneNavHostFragment.navigateToRoute` | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256): Device Info re-select uses in-graph navigate when host already shown |
+| Signal leaf | `PhoneNavRoutes.SIGNAL` + nested `SignalFragment` | **this PR** (2.1e): second drawer root on NavHost; `ARG_START_ROUTE` |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -804,7 +807,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate **one leaf** (Device Info) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Phase 2.1d: drawer Device Info calls `navigateToRoute` when the host is already visible (skip `clearBackStack`+`showDetails`).
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info, Signal) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Drawer migrated roots call `navigatePhoneNavRoot` / `navigateToRoute` when the host is already visible.
 
 #### Proposed PR slices
 
@@ -812,15 +815,16 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | --- | --- | --- |
 | 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
-| 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **this PR**; Keep XML drawer chrome host |
-| 2.1e | More drawer roots (leaves before `ServiceListPager`) | No VideoActivity |
+| 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
+| 2.1e | More drawer roots (leaves before `ServiceListPager`) | **this PR**: Signal; no hub; no VideoActivity |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
-#### Explicit non-goals of 2.1d (this PR)
+#### Explicit non-goals of 2.1e (this PR)
 
-- No new drawer destinations on NavHost (Signal / Screenshot / etc. → 2.1e)
+- No hub / `ServiceListPager` on NavHost
+- No Screenshot / Current / Zap / Backup in this PR (later leaves)
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -836,7 +840,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–c **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)/[#255](https://github.com/sreichholf/dreamDroid/pull/255). **This PR:** Phase 2.1d drawer→NavController for Device Info. Next Appendix H: more NavHost roots (2.1e+) or widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–d **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#256](https://github.com/sreichholf/dreamDroid/pull/256). **This PR:** Phase 2.1e Signal leaf on NavHost. Next Appendix H: more leaves / hub (2.1e+) or widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Phase **2.1e** after [#256](https://github.com/sreichholf/dreamDroid/pull/256): second drawer leaf on `PhoneNavHost`.

- `PhoneNavRoutes.SIGNAL` + nested `SignalFragment` (same FragmentContainerView pattern as Device Info)
- `PhoneNavHostFragment.ARG_START_ROUTE` / `newInstance(route)` so Signal can be the first mount
- `NavigationHelper.navigatePhoneNavRoot` shared by Device Info and Signal
- Drawer-style `navigateDrawerRoot` (`launchSingleTop` + `saveState`/`restoreState`)

## Non-goals
- No hub / `ServiceListPager`
- No Screenshot / Current / Zap / Backup in this PR
- No OkHttp 4; do not merge `master` into `main`

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open Signal from drawer; switch Device Info ↔ Signal without blank pane; open Signal after Services
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

