### PR TITLE
fix(ui): Compose pull-to-refresh for service/swipe lists

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
@@ -1,0 +1,87 @@
+package net.reichholf.dreamdroid.ui.compose
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pull-to-refresh must not fire when the list is scrolled away from the top
+ * (the old SwipeRefreshLayout+ComposeView bug on service lists).
+ */
+class DreamDroidPullRefreshTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun scrollAwayFromTopDoesNotRefresh() {
+        val refreshCount = AtomicInteger(0)
+        val labels = (0 until 40).map { "Channel $it" }
+
+        composeRule.setContent {
+            DreamDroidTheme {
+                DreamDroidPullRefresh(
+                    refreshing = false,
+                    onRefresh = { refreshCount.incrementAndGet() },
+                ) {
+                    val listState = rememberLazyListState()
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("pull_list"),
+                    ) {
+                        items(labels) { label ->
+                            Text(text = label, modifier = Modifier.fillMaxWidth())
+                        }
+                    }
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Channel 0").assertIsDisplayed()
+        composeRule.onNodeWithTag("pull_list").performScrollToIndex(20)
+        composeRule.onNodeWithText("Channel 20").assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertEquals(0, refreshCount.get())
+    }
+
+    @Test
+    fun programmaticRefreshingKeepsContentVisible() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                DreamDroidPullRefresh(
+                    refreshing = true,
+                    onRefresh = {},
+                ) {
+                    Text("Still here")
+                }
+            }
+        }
+        composeRule.onNodeWithText("Still here").assertIsDisplayed()
+    }
+}

--- a/app/res/layout/compose_swipe_list.xml
+++ b/app/res/layout/compose_swipe_list.xml
@@ -1,26 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Compose lists own Material3 pull-to-refresh; do not wrap ComposeView in
+     SwipeRefreshLayout (FrameLayout/ComposeView always reports canScrollUp=false,
+     so scroll-back-up falsely reloads). -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/ptr_layout"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@android:id/list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@android:id/list"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:visibility="gone" />
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/compose_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-        </FrameLayout>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        android:layout_height="0dp"
+        android:visibility="gone" />
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <TextView
         android:id="@android:id/empty"
         android:layout_width="match_parent"

--- a/app/res/layout/current_service.xml
+++ b/app/res/layout/current_service.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-    android:id="@+id/ptr_layout"
+<!-- Compose owns Material3 pull-to-refresh; do not wrap ComposeView in SwipeRefreshLayout. -->
+<androidx.compose.ui.platform.ComposeView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/compose_current"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/compose_current"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    android:layout_height="match_parent" />

--- a/app/res/layout/device_info.xml
+++ b/app/res/layout/device_info.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-    android:id="@+id/ptr_layout"
+<!-- Compose owns Material3 pull-to-refresh; do not wrap ComposeView in SwipeRefreshLayout. -->
+<androidx.compose.ui.platform.ComposeView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/compose_device_info"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/compose_device_info"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    android:layout_height="match_parent" />

--- a/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/CurrentServiceFragment.java
@@ -29,6 +29,7 @@ import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.helpers.enigma2.Timer;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerAddByEventIdRequestHandler;
 import net.reichholf.dreamdroid.intents.IntentFactory;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.current.CurrentServiceScreenKt;
 import net.reichholf.dreamdroid.ui.current.CurrentServiceUiState;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
@@ -69,6 +70,7 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	private Job mLoadJob;
 
 	private CurrentServiceUiState mUiState;
+	private ComposeRefreshState mRefreshState;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -77,6 +79,7 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 
 		mCurrentServiceReady = false;
 		mUiState = new CurrentServiceUiState();
+		mRefreshState = new ComposeRefreshState();
 		if (savedInstanceState != null) {
 			@SuppressWarnings("deprecation")
 			CurrentService current = (CurrentService) savedInstanceState.getSerializable(KEY_CURRENT);
@@ -101,9 +104,15 @@ public class CurrentServiceFragment extends BaseHttpFragment {
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.current_service, container, false);
 		ComposeView compose = view.findViewById(R.id.compose_current);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		CurrentServiceScreenKt.bindCurrentServiceScreen(
 				compose,
 				mUiState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				() -> {
 					onItemSelected(Statics.ITEM_NOW);
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/DeviceInfoFragment.java
@@ -18,6 +18,7 @@ import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.enigma.DeviceInfo;
 import net.reichholf.dreamdroid.enigma.DeviceInfoLoadKt;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.device.DeviceInfoScreenKt;
 import net.reichholf.dreamdroid.ui.device.DeviceInfoUiState;
 
@@ -41,6 +42,7 @@ public class DeviceInfoFragment extends BaseHttpFragment {
 	private Job mLoadJob;
 
 	private DeviceInfoUiState mUiState;
+	private ComposeRefreshState mRefreshState;
 	private boolean mDeviceInfoReady;
 
 	@Override
@@ -48,6 +50,7 @@ public class DeviceInfoFragment extends BaseHttpFragment {
 		super.onCreate(savedInstanceState);
 		initTitles(getString(R.string.device_info));
 		mUiState = new DeviceInfoUiState();
+		mRefreshState = new ComposeRefreshState();
 		mDeviceInfoReady = false;
 		if (savedInstanceState != null) {
 			@SuppressWarnings("deprecation")
@@ -68,7 +71,16 @@ public class DeviceInfoFragment extends BaseHttpFragment {
 	public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.device_info, container, false);
 		ComposeView compose = view.findViewById(R.id.compose_device_info);
-		DeviceInfoScreenKt.bindDeviceInfoScreen(compose, mUiState);
+		mHttpHelper.setComposeRefresh(mRefreshState);
+		DeviceInfoScreenKt.bindDeviceInfoScreen(
+				compose,
+				mUiState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				}
+		);
 		return view;
 	}
 

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -33,6 +33,7 @@ import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.epg.EpgBouquetListState;
 import net.reichholf.dreamdroid.ui.epg.EpgBouquetListStateKt;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
@@ -56,6 +57,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 
 	private final ArrayList<Event> mEvents = new ArrayList<>();
 	private EpgBouquetListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 
@@ -70,6 +72,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 		mEnableReload = true;
 		super.onCreate(savedInstanceState);
 		mListState = new EpgBouquetListState();
+		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.epg));
 
 		int now = (int) (Calendar.getInstance().getTimeInMillis() / 1000);
@@ -149,9 +152,15 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		EpgBouquetListStateKt.bindEpgBouquetScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				event -> {
 					mCurrentItem = EpgListMapper.toExtendedHashMap(event);
 					EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(event);

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgSearchFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgSearchFragment.java
@@ -20,6 +20,7 @@ import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.epg.EpgBouquetListState;
 import net.reichholf.dreamdroid.ui.epg.EpgBouquetListStateKt;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
@@ -40,6 +41,7 @@ import kotlinx.coroutines.Job;
 public class EpgSearchFragment extends BaseHttpRecyclerEventFragment {
 	private final ArrayList<Event> mEvents = new ArrayList<>();
 	private EpgBouquetListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 	private String mNeedle;
@@ -49,6 +51,7 @@ public class EpgSearchFragment extends BaseHttpRecyclerEventFragment {
 		mCardListStyle = true;
 		super.onCreate(savedInstanceState);
 		mListState = new EpgBouquetListState();
+		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.epg_search));
 
 		String needle = getArguments().getString(SearchManager.QUERY);
@@ -69,9 +72,15 @@ public class EpgSearchFragment extends BaseHttpRecyclerEventFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		EpgBouquetListStateKt.bindEpgBouquetScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				event -> {
 					mCurrentItem = EpgListMapper.toExtendedHashMap(event);
 					EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(event);

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -44,6 +44,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Tag;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.MovieDeleteRequestHandler;
 import net.reichholf.dreamdroid.intents.IntentFactory;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.services.MovieListItem;
 import net.reichholf.dreamdroid.ui.services.MovieListMapperKt;
 import net.reichholf.dreamdroid.ui.services.MovieListState;
@@ -79,6 +80,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 	public ExtendedHashMap mMovie;
 	private final ArrayList<Movie> mMovies = new ArrayList<>();
 	private MovieListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 	@Nullable
@@ -126,6 +128,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 		}
 		setInitialLocation(savedInstanceState);
 		mListState = new MovieListState();
+		mRefreshState = new ComposeRefreshState();
 	}
 
 	@Override
@@ -169,9 +172,15 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		MovieListStateKt.bindMovieListScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				item -> {
 					onComposeClick(item, false);
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/PickServiceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/PickServiceFragment.java
@@ -19,6 +19,7 @@ import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.pick.PickServiceListState;
 import net.reichholf.dreamdroid.ui.pick.PickServiceListStateKt;
 import net.reichholf.dreamdroid.ui.zap.ZapListMapper;
@@ -39,6 +40,7 @@ public class PickServiceFragment extends BaseHttpRecyclerFragment {
 
 	private final ArrayList<Service> mServices = new ArrayList<>();
 	private PickServiceListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 
@@ -47,6 +49,7 @@ public class PickServiceFragment extends BaseHttpRecyclerFragment {
 		mReload = true;
 		super.onCreate(savedInstanceState);
 		mListState = new PickServiceListState();
+		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.services));
 	}
 
@@ -60,9 +63,15 @@ public class PickServiceFragment extends BaseHttpRecyclerFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		PickServiceListStateKt.bindPickServiceScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				service -> {
 					Intent data = new Intent();
 					data.putExtra(KEY_BOUQUET, ZapListMapper.toBouquetMap(service));

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
@@ -19,6 +19,7 @@ import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
 import net.reichholf.dreamdroid.ui.epg.ServiceEpgListState;
 import net.reichholf.dreamdroid.ui.epg.ServiceEpgListStateKt;
@@ -38,6 +39,7 @@ import kotlinx.coroutines.Job;
 public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 	private final ArrayList<Event> mEvents = new ArrayList<>();
 	private ServiceEpgListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 
@@ -47,6 +49,7 @@ public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 		mEnableReload = true;
 		super.onCreate(savedInstanceState);
 		mListState = new ServiceEpgListState();
+		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.epg));
 
 		mReference = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE);
@@ -63,9 +66,15 @@ public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		ServiceEpgListStateKt.bindServiceEpgScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				event -> {
 					mCurrentItem = EpgListMapper.toExtendedHashMap(event);
 					EpgDetailBottomSheet epgDetailBottomSheet = EpgDetailBottomSheet.newInstance(event);

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -39,6 +39,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Service;
 import net.reichholf.dreamdroid.intents.IntentFactory;
 import net.reichholf.dreamdroid.room.AppDatabase;
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.services.ServiceListItem;
 import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
 import net.reichholf.dreamdroid.ui.services.ServiceListState;
@@ -71,6 +72,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	private ArrayList<ExtendedHashMap> mHistory;
 	private final ArrayList<ServiceNowNext> mRows = new ArrayList<>();
 	private ServiceListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Job mLoadJob;
 
@@ -106,6 +108,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		mCurrentItem.put(Service.KEY_NAME, mName);
 		mHistory = new ArrayList<>();
 		mListState = new ServiceListState();
+		mRefreshState = new ComposeRefreshState();
 	}
 
 	@Override
@@ -135,9 +138,15 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		ServiceListStateKt.bindServiceListScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				item -> {
 					onComposeClick(item, false);
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerListFragment.java
@@ -36,6 +36,7 @@ import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerChangeRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerCleanupRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerDeleteRequestHandler;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.services.TimerListItem;
 import net.reichholf.dreamdroid.ui.services.TimerListMapper;
 import net.reichholf.dreamdroid.ui.services.TimerListMapperKt;
@@ -110,6 +111,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 	private ProgressDialog mProgress;
 	protected int mCurrentPos;
 	private TimerListState mListState;
+	private ComposeRefreshState mRefreshState;
 	private final ArrayList<Timer> mTimers = new ArrayList<>();
 	@Nullable
 	private Job mLoadJob;
@@ -134,6 +136,7 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		mIsActionMode = false;
 		mReload = true;
 		mListState = new TimerListState();
+		mRefreshState = new ComposeRefreshState();
 	}
 
 	@Override
@@ -156,9 +159,15 @@ public class TimerListFragment extends BaseHttpRecyclerFragment {
 		super.onViewCreated(view, savedInstanceState);
 		setAdapter();
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		TimerListStateKt.bindTimerListScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				item -> {
 					onComposeClick(item, false);
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerServicePickFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerServicePickFragment.java
@@ -22,6 +22,7 @@ import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
 import net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.pick.PickServiceListState;
 import net.reichholf.dreamdroid.ui.pick.PickServiceListStateKt;
 import net.reichholf.dreamdroid.ui.zap.ZapListMapper;
@@ -43,6 +44,7 @@ public class TimerServicePickFragment extends BaseHttpRecyclerFragment {
 	private final ArrayList<Service> mBouquets = new ArrayList<>();
 	private final ArrayList<Service> mServices = new ArrayList<>();
 	private PickServiceListState mListState;
+	private ComposeRefreshState mRefreshState;
 	@Nullable
 	private Service mCurrentBouquet;
 	@Nullable
@@ -60,6 +62,7 @@ public class TimerServicePickFragment extends BaseHttpRecyclerFragment {
 		mReload = true;
 		super.onCreate(savedInstanceState);
 		mListState = new PickServiceListState();
+		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.service));
 		if (savedInstanceState != null) {
 			String ref = savedInstanceState.getString("bouquetRef");
@@ -87,9 +90,15 @@ public class TimerServicePickFragment extends BaseHttpRecyclerFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		PickServiceListStateKt.bindPickServiceScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				service -> {
 					onRowClick(service);
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
@@ -26,6 +26,7 @@ import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
 import net.reichholf.dreamdroid.helpers.NameValuePair;
 import net.reichholf.dreamdroid.helpers.Statics;
 import net.reichholf.dreamdroid.intents.IntentFactory;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import net.reichholf.dreamdroid.ui.zap.ZapListMapper;
 import net.reichholf.dreamdroid.ui.zap.ZapListState;
 import net.reichholf.dreamdroid.ui.zap.ZapListStateKt;
@@ -50,6 +51,7 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 	private Service mCurrentBouquet;
 	private final ArrayList<Service> mServices = new ArrayList<>();
 	private ZapListState mListState;
+	private ComposeRefreshState mRefreshState;
 	private boolean mWaitingForPicker;
 	@Nullable
 	private Job mLoadJob;
@@ -59,6 +61,7 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 		mEnableReload = false;
 		super.onCreate(savedInstanceState);
 		mListState = new ZapListState();
+		mRefreshState = new ComposeRefreshState();
 		if (mCurrentBouquet == null) {
 			mReload = true;
 			initTitle("");
@@ -86,9 +89,15 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 	public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 		ComposeView compose = view.findViewById(R.id.compose_list);
+		mHttpHelper.setComposeRefresh(mRefreshState);
 		ZapListStateKt.bindZapScreen(
 				compose,
 				mListState,
+				mRefreshState,
+				() -> {
+					reload();
+					return kotlin.Unit.INSTANCE;
+				},
 				service -> {
 					zapTo(service.getReference());
 					return kotlin.Unit.INSTANCE;

--- a/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/abs/BaseRecyclerFragment.java
@@ -112,7 +112,9 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 		super.onActivityCreated(savedInstanceState);
 		//noinspection ConstantConditions
 		mSwipeRefreshLayout = getView().findViewById(R.id.ptr_layout);
-		mSwipeRefreshLayout.setOnRefreshListener(this);
+		if (mSwipeRefreshLayout != null) {
+			mSwipeRefreshLayout.setOnRefreshListener(this);
+		}
 		mHelper.onActivityCreated(savedInstanceState);
 	}
 
@@ -241,7 +243,9 @@ public abstract class BaseRecyclerFragment extends Fragment implements ActivityC
 
 	@Override
 	public void onRefresh() {
-		mSwipeRefreshLayout.setRefreshing(false);
+		if (mSwipeRefreshLayout != null) {
+			mSwipeRefreshLayout.setRefreshing(false);
+		}
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -40,6 +40,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult;
 import net.reichholf.dreamdroid.helpers.enigma2.Volume;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SimpleResultRequestHandler;
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ZapRequestHandler;
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,6 +52,8 @@ public class HttpFragmentHelper {
     private Fragment mFragment;
     @Nullable
 	private SwipeRefreshLayout mSwipeRefreshLayout;
+    @Nullable
+    private ComposeRefreshState mComposeRefresh;
 
     protected final String sData = "data";
     protected SimpleHttpClient mShc;
@@ -79,6 +82,11 @@ public class HttpFragmentHelper {
             mFragment = fragment;
         }
         mSwipeRefreshLayout = null;
+        mComposeRefresh = null;
+    }
+
+    public void setComposeRefresh(@Nullable ComposeRefreshState composeRefresh) {
+        mComposeRefresh = composeRefresh;
     }
 
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
@@ -312,7 +320,9 @@ public class HttpFragmentHelper {
         if (mIsReloading)
             return;
         mIsReloading = true;
-        if (mSwipeRefreshLayout != null) {
+        if (mComposeRefresh != null) {
+            mComposeRefresh.setRefreshing(true);
+        } else if (mSwipeRefreshLayout != null) {
             if (!mSwipeRefreshLayout.isRefreshing())
                 mSwipeRefreshLayout.setRefreshing(true);
         }
@@ -320,9 +330,12 @@ public class HttpFragmentHelper {
 
     public void onLoadFinished() {
         mIsReloading = false;
-        if (mSwipeRefreshLayout != null)
+        if (mComposeRefresh != null) {
+            mComposeRefresh.setRefreshing(false);
+        } else if (mSwipeRefreshLayout != null) {
             if (mSwipeRefreshLayout.isRefreshing())
                 mSwipeRefreshLayout.setRefreshing(false);
+        }
     }
 
     public void onProfileChanged() {

--- a/app/src/net/reichholf/dreamdroid/ui/compose/ComposeRefreshState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/compose/ComposeRefreshState.kt
@@ -1,0 +1,22 @@
+package net.reichholf.dreamdroid.ui.compose
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Bridge so [net.reichholf.dreamdroid.fragment.helper.HttpFragmentHelper] can drive a
+ * Compose pull-to-refresh indicator the same way it used to drive [androidx.swiperefreshlayout.widget.SwipeRefreshLayout].
+ */
+class ComposeRefreshState(
+    /** When false, gesture pull-to-refresh is off; programmatic [setRefreshing] still works. */
+    var enabled: Boolean = true,
+) {
+    private val refreshingState: MutableState<Boolean> = mutableStateOf(false)
+
+    val isRefreshing: Boolean
+        get() = refreshingState.value
+
+    fun setRefreshing(value: Boolean) {
+        refreshingState.value = value
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
@@ -1,0 +1,53 @@
+package net.reichholf.dreamdroid.ui.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
+/**
+ * Material 3 pull-to-refresh host for Compose lists formerly wrapped in View
+ * [androidx.swiperefreshlayout.widget.SwipeRefreshLayout]. That View parent treated a
+ * [androidx.compose.ui.platform.ComposeView] as never scrolled, so scrolling back up
+ * always fired reload.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DreamDroidPullRefresh(
+    refreshing: Boolean,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val state = rememberPullToRefreshState(enabled = { enabled })
+
+    LaunchedEffect(refreshing) {
+        if (refreshing) {
+            state.startRefresh()
+        } else if (state.isRefreshing) {
+            state.endRefresh()
+        }
+    }
+
+    LaunchedEffect(state.isRefreshing) {
+        if (state.isRefreshing && !refreshing) {
+            onRefresh()
+        }
+    }
+
+    Box(modifier.nestedScroll(state.nestedScrollConnection).fillMaxSize()) {
+        content()
+        PullToRefreshContainer(
+            state = state,
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceScreen.kt
@@ -35,6 +35,8 @@ import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.enigma.CurrentService
 import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.Picon
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class CurrentServiceUiState {
@@ -291,6 +293,8 @@ private fun ServicePicon(
 
 fun ComposeView.bindCurrentServiceScreen(
     state: CurrentServiceUiState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onNowClick: () -> Unit,
     onNextClick: () -> Unit,
     onStream: () -> Unit,
@@ -298,12 +302,18 @@ fun ComposeView.bindCurrentServiceScreen(
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            CurrentServiceScreen(
-                state = state,
-                onNowClick = onNowClick,
-                onNextClick = onNextClick,
-                onStream = onStream,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                CurrentServiceScreen(
+                    state = state,
+                    onNowClick = onNowClick,
+                    onNextClick = onNextClick,
+                    onStream = onStream,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/device/DeviceInfoScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/device/DeviceInfoScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.enigma.DeviceInfo
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 data class DeviceInfoRow(
@@ -208,11 +210,21 @@ private fun DeviceInfoSection(
     }
 }
 
-fun ComposeView.bindDeviceInfoScreen(state: DeviceInfoUiState) {
+fun ComposeView.bindDeviceInfoScreen(
+    state: DeviceInfoUiState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
+) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            DeviceInfoScreen(state = state)
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                DeviceInfoScreen(state = state)
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/EpgBouquetListState.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class EpgBouquetListState(initial: List<Event> = emptyList()) {
@@ -29,17 +31,25 @@ class EpgBouquetListState(initial: List<Event> = emptyList()) {
 
 fun ComposeView.bindEpgBouquetScreen(
     state: EpgBouquetListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (Event) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            EpgBouquetScreen(
-                items = state.items,
-                listState = state.listState,
-                scrollEpoch = state.scrollEpoch,
-                onItemClick = onItemClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                EpgBouquetScreen(
+                    items = state.items,
+                    listState = state.listState,
+                    scrollEpoch = state.scrollEpoch,
+                    onItemClick = onItemClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/epg/ServiceEpgListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/ServiceEpgListState.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class ServiceEpgListState(initial: List<Event> = emptyList()) {
@@ -18,15 +20,23 @@ class ServiceEpgListState(initial: List<Event> = emptyList()) {
 
 fun ComposeView.bindServiceEpgScreen(
     state: ServiceEpgListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (Event) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            ServiceEpgScreen(
-                items = state.items,
-                onItemClick = onItemClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                ServiceEpgScreen(
+                    items = state.items,
+                    onItemClick = onItemClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/pick/PickServiceListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/pick/PickServiceListState.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import net.reichholf.dreamdroid.enigma.Service
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class PickServiceListState(initial: List<Service> = emptyList()) {
@@ -18,15 +20,23 @@ class PickServiceListState(initial: List<Service> = emptyList()) {
 
 fun ComposeView.bindPickServiceScreen(
     state: PickServiceListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (Service) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            PickServiceScreen(
-                items = state.items,
-                onItemClick = onItemClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                PickServiceScreen(
+                    items = state.items,
+                    onItemClick = onItemClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class MovieListState(initial: List<MovieListItem> = emptyList()) {
@@ -17,17 +19,25 @@ class MovieListState(initial: List<MovieListItem> = emptyList()) {
 
 fun ComposeView.bindMovieListScreen(
     state: MovieListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (MovieListItem) -> Unit,
     onItemLongClick: (MovieListItem) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            MovieListScreen(
-                items = state.items,
-                onItemClick = onItemClick,
-                onItemLongClick = onItemLongClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                MovieListScreen(
+                    items = state.items,
+                    onItemClick = onItemClick,
+                    onItemLongClick = onItemLongClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class ServiceListState(initial: List<ServiceListItem> = emptyList()) {
@@ -17,17 +19,25 @@ class ServiceListState(initial: List<ServiceListItem> = emptyList()) {
 
 fun ComposeView.bindServiceListScreen(
     state: ServiceListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (ServiceListItem) -> Unit,
     onItemLongClick: (ServiceListItem) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            ServiceListScreen(
-                items = state.items,
-                onItemClick = onItemClick,
-                onItemLongClick = onItemLongClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                ServiceListScreen(
+                    items = state.items,
+                    onItemClick = onItemClick,
+                    onItemLongClick = onItemLongClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/services/TimerListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TimerListState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class TimerListState(initial: List<TimerListItem> = emptyList()) {
@@ -17,17 +19,25 @@ class TimerListState(initial: List<TimerListItem> = emptyList()) {
 
 fun ComposeView.bindTimerListScreen(
     state: TimerListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (TimerListItem) -> Unit,
     onItemLongClick: (TimerListItem) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            TimerListScreen(
-                items = state.items,
-                onItemClick = onItemClick,
-                onItemLongClick = onItemLongClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                TimerListScreen(
+                    items = state.items,
+                    onItemClick = onItemClick,
+                    onItemLongClick = onItemLongClick,
+                )
+            }
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/zap/ZapListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/zap/ZapListState.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import net.reichholf.dreamdroid.enigma.Service
+import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
+import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class ZapListState(initial: List<Service> = emptyList()) {
@@ -29,19 +31,27 @@ class ZapListState(initial: List<Service> = emptyList()) {
 
 fun ComposeView.bindZapScreen(
     state: ZapListState,
+    refresh: ComposeRefreshState,
+    onRefresh: () -> Unit,
     onItemClick: (Service) -> Unit,
     onItemLongClick: (Service) -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
-            ZapScreen(
-                items = state.items,
-                gridState = state.gridState,
-                scrollEpoch = state.scrollEpoch,
-                onItemClick = onItemClick,
-                onItemLongClick = onItemLongClick,
-            )
+            DreamDroidPullRefresh(
+                refreshing = refresh.isRefreshing,
+                onRefresh = onRefresh,
+                enabled = refresh.enabled,
+            ) {
+                ZapScreen(
+                    items = state.items,
+                    gridState = state.gridState,
+                    scrollEpoch = state.scrollEpoch,
+                    onItemClick = onItemClick,
+                    onItemLongClick = onItemLongClick,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Scrolling back up in Compose lists/screens wrapped by View `SwipeRefreshLayout` always triggered reload. The Compose child never reported `canChildScrollUp`, so any scroll-toward-top gesture was treated as pull-to-refresh.

## Fix

Replace View swipe-refresh with Material 3 `DreamDroidPullRefresh` + `ComposeRefreshState` (HTTP load indicator bridge):

- `compose_swipe_list` hosts (services, movies, timers, EPG, zap, pickers)
- Device Info and Current Service (scrollable Compose screens)

`card_recycler_content` keeps `SwipeRefreshLayout` — it still hosts a real `RecyclerView`.

## Proof

```text
bash .cursor/cloud/connected-test.sh \
  net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefreshTest,\
net.reichholf.dreamdroid.ui.device.DeviceInfoScreenTest,\
net.reichholf.dreamdroid.ui.current.CurrentServiceScreenTest,\
net.reichholf.dreamdroid.ui.services.ServiceListScreenTest
# OK (9 tests)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

