### PR TITLE
fix(ui): align Compose and XML FABs

### DIFF
--- a/.cursor/skills/verify-dreamdroid/SKILL.md
+++ b/.cursor/skills/verify-dreamdroid/SKILL.md
@@ -65,7 +65,7 @@ Prefer resource ids and visible text over coordinates. `tap --text About` matche
 | TV & Movies | text `TV & Movies` |
 | EPG / Virtual Remote / Zap / Current event | text `EPG`, `Virtual Remote`, `Zap`, `Current event` |
 | About | text `About` (opens a dialog) |
-| Add Profile FAB | `...:id/fab_main` content-desc `Add Profile` |
+| Add Profile FAB | content-desc from `R.string.profile_add` (Compose Scaffold FAB; not XML `fab_main`) |
 | Autodiscovery | text `Dreambox Autodiscovery` |
 | TV/Radio/Movies/Timer tabs | text `TV`, `Radio`, `Movies`, `Timer` |
 

--- a/app/res/layout-sw720dp/dualpane.xml
+++ b/app/res/layout-sw720dp/dualpane.xml
@@ -68,17 +68,18 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
+        <!-- Gravity (not detail_view anchor): Compose nested scroll collapses the AppBar
+             and used to drag anchored FABs with the scrolling view (#248 reload; same for main). -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_main"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/fab_margin_right"
             android:src="@drawable/ic_action_fab_add"
             android:visibility="gone"
             app:elevation="6dp"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="bottom|end|right"
             app:pressedTranslationZ="12dp" />
 
         <!-- Gravity (not detail_view anchor): Compose LazyColumn nested scroll collapses

--- a/app/res/layout/dualpane.xml
+++ b/app/res/layout/dualpane.xml
@@ -46,16 +46,17 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
+        <!-- Gravity (not detail_view anchor): Compose nested scroll collapses the AppBar
+             and used to drag anchored FABs with the scrolling view (#248 reload; same for main). -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_main"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
             android:layout_margin="@dimen/fab_margin_right"
             android:visibility="gone"
             app:elevation="6dp"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="end|bottom"
             app:pressedTranslationZ="12dp"
             android:src="@drawable/ic_action_fab_add"/>
 

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileEditScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileEditScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,8 +41,10 @@ fun ProfileEditScreen(
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Hosted under simple_layout_with_toolbar which already fits system windows.
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             FloatingActionButton(onClick = onSave) {
                 Icon(

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -38,8 +39,11 @@ fun ProfilesScreen(
     onAddClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Hosted under MainActivity detail_view which already fits system windows.
+    // Default Scaffold safeDrawing insets would double-pad and lift the FAB.
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             FloatingActionButton(onClick = onAddClick) {
                 Icon(

--- a/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -51,8 +52,10 @@ fun TimerEditScreen(
     onPickTags: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Hosted under simple_layout_with_toolbar which already fits system windows.
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             FloatingActionButton(onClick = onSave) {
                 Icon(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Profile **add** FAB (Compose `Scaffold`) was lifted by Material3 default `safeDrawing` insets while `MainActivity` / `simple_layout_with_toolbar` already apply `fitsSystemWindows`.

### Fixes
- `ProfilesScreen`, `ProfileEditScreen`, `TimerEditScreen`: `contentWindowInsets = WindowInsets(0)` so Scaffold FABs sit in the host content box
- Phone + tablet `dualpane.xml`: `fab_main` uses `layout_gravity="bottom|end"` (same anti-anchor approach as reload FAB in #248) — Timer list add FAB was still anchored to scrolling `detail_view`

### Also affected (same class of bug)
| FAB | Host | Issue |
| --- | --- | --- |
| Profiles add | Compose Scaffold in MainActivity | Double insets |
| Profile edit save | Compose Scaffold in SimpleToolbar | Same |
| Timer edit save | Compose Scaffold in SimpleToolbar | Same |
| Timer list add (`fab_main`) | XML Coordinator | `detail_view` anchor + Compose nested scroll |
| Reload (`fab_reload`) | XML | Already fixed in #248 |

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: Profiles add FAB flush bottom-end; Timer list add FAB stays put when scrolling; Profile/Timer edit save FABs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

