### PR TITLE
fix(ui): FAB gravity + service/movie popup anchors

### DIFF
--- a/.cursor/skills/verify-dreamdroid/SKILL.md
+++ b/.cursor/skills/verify-dreamdroid/SKILL.md
@@ -65,7 +65,7 @@ Prefer resource ids and visible text over coordinates. `tap --text About` matche
 | TV & Movies | text `TV & Movies` |
 | EPG / Virtual Remote / Zap / Current event | text `EPG`, `Virtual Remote`, `Zap`, `Current event` |
 | About | text `About` (opens a dialog) |
-| Add Profile FAB | `...:id/fab_main` content-desc `Add Profile` |
+| Add Profile FAB | `...:id/fab_main` content-desc from `R.string.profile_add` (shell XML FAB) |
 | Autodiscovery | text `Dreambox Autodiscovery` |
 | TV/Radio/Movies/Timer tabs | text `TV`, `Radio`, `Movies`, `Timer` |
 

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/profiles/ProfilesScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/profiles/ProfilesScreenTest.kt
@@ -2,7 +2,6 @@ package net.reichholf.dreamdroid.ui.profiles
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
@@ -24,7 +23,7 @@ class ProfilesScreenTest {
     }
 
     @Test
-    fun showsDemoRowAndAddProfileFab() {
+    fun showsDemoRow() {
         composeRule.setContent {
             DreamDroidTheme {
                 ProfilesScreen(
@@ -36,15 +35,12 @@ class ProfilesScreenTest {
                             active = true,
                         ),
                     ),
-                    addLabel = "Add Profile",
                     onProfileClick = {},
                     onProfileLongClick = {},
-                    onAddClick = {},
                 )
             }
         }
         composeRule.onNodeWithText("Demo").assertIsDisplayed()
         composeRule.onNodeWithText("dreamdroid.org").assertIsDisplayed()
-        composeRule.onNodeWithContentDescription("Add Profile").assertIsDisplayed()
     }
 }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/MovieListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/MovieListScreenTest.kt
@@ -37,8 +37,8 @@ class MovieListScreenTest {
                             length = "90",
                         ),
                     ),
-                    onItemClick = {},
-                    onItemLongClick = {},
+                    onItemClick = { _, _, _ -> },
+                    onItemLongClick = { _, _, _ -> },
                 )
             }
         }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
@@ -4,11 +4,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,8 +47,8 @@ class ServiceListScreenTest {
                             progress = 3,
                         ),
                     ),
-                    onItemClick = {},
-                    onItemLongClick = {},
+                    onItemClick = { _, _, _ -> },
+                    onItemLongClick = { _, _, _ -> },
                 )
             }
         }
@@ -74,8 +76,8 @@ class ServiceListScreenTest {
                             kind = ServiceRowKind.CHANNEL,
                         ),
                     ),
-                    onItemClick = {},
-                    onItemLongClick = {},
+                    onItemClick = { _, _, _ -> },
+                    onItemLongClick = { _, _, _ -> },
                 )
             }
         }
@@ -84,5 +86,41 @@ class ServiceListScreenTest {
         composeRule.onNodeWithText("ZDF", useUnmergedTree = true)
             .assertIsDisplayed()
             .assertLeftPositionInRootIsEqualTo(20.dp)
+    }
+
+    @Test
+    fun channelTapReportsWindowPositionOfRowNotOrigin() {
+        var tapX = -1
+        var tapY = -1
+        composeRule.setContent {
+            DreamDroidTheme {
+                ServiceListScreen(
+                    items = listOf(
+                        ServiceListItem(
+                            index = 0,
+                            reference = "1:0:1:1:1:1:1:0:0:0:",
+                            name = "ARD",
+                            kind = ServiceRowKind.CHANNEL,
+                        ),
+                        ServiceListItem(
+                            index = 1,
+                            reference = "1:0:1:2:1:1:1:0:0:0:",
+                            name = "ZDF",
+                            kind = ServiceRowKind.CHANNEL,
+                        ),
+                    ),
+                    onItemClick = { _, x, y ->
+                        tapX = x
+                        tapY = y
+                    },
+                    onItemLongClick = { _, _, _ -> },
+                )
+            }
+        }
+        composeRule.onNodeWithText("ZDF").performClick()
+        composeRule.waitForIdle()
+        // Second row must not report the fragment-root origin (0,0) used by the old PopupMenu bug.
+        assertTrue("expected tapX >= 0, got $tapX", tapX >= 0)
+        assertTrue("expected second-row tapY > 0, got $tapY", tapY > 0)
     }
 }

--- a/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
@@ -1,0 +1,35 @@
+package net.reichholf.dreamdroid.widget
+
+import android.view.Gravity
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import net.reichholf.dreamdroid.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DualpaneFabLayoutTest {
+    @Test
+    fun mainAndReloadFabsUseGravityNotDetailAnchor() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val root = android.view.LayoutInflater.from(context)
+            .inflate(R.layout.dualpane, null, false)
+        val fabMain = root.findViewById<FloatingActionButton>(R.id.fab_main)
+        val fabReload = root.findViewById<FloatingActionButton>(R.id.fab_reload)
+        val mainLp = fabMain.layoutParams as CoordinatorLayout.LayoutParams
+        val reloadLp = fabReload.layoutParams as CoordinatorLayout.LayoutParams
+
+        assertEquals(View.NO_ID, mainLp.anchorId)
+        assertTrue((mainLp.gravity and Gravity.BOTTOM) == Gravity.BOTTOM)
+        assertTrue((mainLp.gravity and Gravity.END) == Gravity.END)
+
+        assertEquals(View.NO_ID, reloadLp.anchorId)
+        assertTrue((reloadLp.gravity and Gravity.TOP) == Gravity.TOP)
+        assertTrue((reloadLp.gravity and Gravity.END) == Gravity.END)
+    }
+}

--- a/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
@@ -1,5 +1,6 @@
 package net.reichholf.dreamdroid.widget
 
+import android.view.ContextThemeWrapper
 import android.view.Gravity
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -16,7 +17,8 @@ import org.junit.runner.RunWith
 class DualpaneFabLayoutTest {
     @Test
     fun mainAndReloadFabsUseGravityNotDetailAnchor() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val base = InstrumentationRegistry.getInstrumentation().targetContext
+        val context = ContextThemeWrapper(base, R.style.Theme_DreamDroid_Night)
         val root = android.view.LayoutInflater.from(context)
             .inflate(R.layout.dualpane, null, false)
         val fabMain = root.findViewById<FloatingActionButton>(R.id.fab_main)

--- a/app/res/layout-sw720dp/dualpane.xml
+++ b/app/res/layout-sw720dp/dualpane.xml
@@ -68,21 +68,21 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
+        <!-- Gravity (not detail_view anchor): AppBarLayout.ScrollingViewBehavior makes
+             detail_view taller than the visible area, so anchored / in-content FABs clip. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_main"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_margin_right"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="@dimen/fab_margin_right"
+            android:layout_marginBottom="@dimen/fab_margin_bottom"
             android:src="@drawable/ic_action_fab_add"
             android:visibility="gone"
             app:elevation="6dp"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="bottom|end|right"
             app:pressedTranslationZ="12dp" />
 
-        <!-- Gravity (not detail_view anchor): Compose LazyColumn nested scroll collapses
-             the AppBar and used to drag the top-anchored reload FAB off-screen. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_reload"

--- a/app/res/layout/dualpane.xml
+++ b/app/res/layout/dualpane.xml
@@ -46,21 +46,21 @@
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
+        <!-- Gravity (not detail_view anchor): AppBarLayout.ScrollingViewBehavior makes
+             detail_view taller than the visible area, so anchored / in-content FABs clip. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_main"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/fab_margin_right"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="@dimen/fab_margin_right"
+            android:layout_marginBottom="@dimen/fab_margin_bottom"
             android:visibility="gone"
             app:elevation="6dp"
-            app:layout_anchor="@+id/detail_view"
-            app:layout_anchorGravity="end|bottom"
             app:pressedTranslationZ="12dp"
             android:src="@drawable/ic_action_fab_add"/>
 
-        <!-- Gravity (not detail_view anchor): Compose LazyColumn nested scroll collapses
-             the AppBar and used to drag the top-anchored reload FAB off-screen. -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/Widget.Material3.FloatingActionButton.Primary"
             android:id="@+id/fab_reload"

--- a/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MovieListFragment.java
@@ -21,7 +21,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.PopupMenu;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -49,6 +48,7 @@ import net.reichholf.dreamdroid.ui.services.MovieListItem;
 import net.reichholf.dreamdroid.ui.services.MovieListMapperKt;
 import net.reichholf.dreamdroid.ui.services.MovieListState;
 import net.reichholf.dreamdroid.ui.services.MovieListStateKt;
+import net.reichholf.dreamdroid.widget.AnchorPopup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -181,12 +181,12 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 					reload();
 					return kotlin.Unit.INSTANCE;
 				},
-				item -> {
-					onComposeClick(item, false);
+				(item, windowX, windowY) -> {
+					onComposeClick(item, false, windowX, windowY);
 					return kotlin.Unit.INSTANCE;
 				},
-				item -> {
-					onComposeClick(item, true);
+				(item, windowX, windowY) -> {
+					onComposeClick(item, true, windowX, windowY);
 					return kotlin.Unit.INSTANCE;
 				}
 		);
@@ -283,7 +283,7 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 		return true;
 	}
 
-	private void onMovieItemClick(@NonNull View view, int position, boolean isLong) {
+	private void onMovieItemClick(int position, boolean isLong, int windowX, int windowY) {
 		if (position < 0 || position >= mMovies.size()) {
 			return;
 		}
@@ -294,15 +294,19 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 		if ((isInsta && !isLong) || (!isInsta && isLong)) {
 			zapTo(typed.getReference());
 		} else {
-			showPopupMenu(view);
+			showPopupMenu(windowX, windowY);
 		}
 	}
 
-	public void showPopupMenu(@NonNull View v) {
-		PopupMenu menu = new PopupMenu(getAppCompatActivity(), v);
-		menu.getMenuInflater().inflate(R.menu.popup_movielist, menu.getMenu());
-		menu.setOnMenuItemClickListener(menuItem -> onMovieAction(menuItem.getItemId()));
-		menu.show();
+	public void showPopupMenu(int windowX, int windowY) {
+		View root = getView();
+		if (!(root instanceof ViewGroup)) {
+			return;
+		}
+		AnchorPopup.showAtWindow((ViewGroup) root, windowX, windowY, menu -> {
+			menu.getMenuInflater().inflate(R.menu.popup_movielist, menu.getMenu());
+			menu.setOnMenuItemClickListener(menuItem -> onMovieAction(menuItem.getItemId()));
+		});
 	}
 
 	/**
@@ -410,12 +414,8 @@ public class MovieListFragment extends BaseHttpRecyclerFragment
 		}
 	}
 
-	private void onComposeClick(@NonNull MovieListItem item, boolean isLong) {
-		View host = getView();
-		if (host == null) {
-			return;
-		}
-		onMovieItemClick(host, item.getIndex(), isLong);
+	private void onComposeClick(@NonNull MovieListItem item, boolean isLong, int windowX, int windowY) {
+		onMovieItemClick(item.getIndex(), isLong, windowX, windowY);
 	}
 
 	public void setLocation(int index) {

--- a/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
@@ -195,7 +195,7 @@ public class ProfileListFragment extends BaseFragment {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		mHasFabMain = false;
+		mHasFabMain = true;
 		super.onCreate(savedInstanceState);
 		setHasOptionsMenu(true);
 		initTitles(getString(R.string.profiles));
@@ -214,7 +214,6 @@ public class ProfileListFragment extends BaseFragment {
 		ProfilesListStateKt.bindProfilesScreen(
 			composeView,
 			mListState,
-			getString(R.string.profile_add),
 			item -> {
 				onProfileRowClick(item);
 				return kotlin.Unit.INSTANCE;
@@ -222,13 +221,15 @@ public class ProfileListFragment extends BaseFragment {
 			item -> {
 				onProfileRowLongClick(item);
 				return kotlin.Unit.INSTANCE;
-			},
-			() -> {
-				createProfile();
-				return kotlin.Unit.INSTANCE;
 			}
 		);
 		return composeView;
+	}
+
+	@Override
+	public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+		registerFab(R.id.fab_main, R.string.profile_add, R.drawable.ic_action_fab_add, v -> createProfile());
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -18,7 +18,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.PopupMenu;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -44,6 +43,7 @@ import net.reichholf.dreamdroid.ui.services.ServiceListItem;
 import net.reichholf.dreamdroid.ui.services.ServiceListMapperKt;
 import net.reichholf.dreamdroid.ui.services.ServiceListState;
 import net.reichholf.dreamdroid.ui.services.ServiceListStateKt;
+import net.reichholf.dreamdroid.widget.AnchorPopup;
 
 import java.util.ArrayList;
 
@@ -147,12 +147,12 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 					reload();
 					return kotlin.Unit.INSTANCE;
 				},
-				item -> {
-					onComposeClick(item, false);
+				(item, windowX, windowY) -> {
+					onComposeClick(item, false, windowX, windowY);
 					return kotlin.Unit.INSTANCE;
 				},
-				item -> {
-					onComposeClick(item, true);
+				(item, windowX, windowY) -> {
+					onComposeClick(item, true, windowX, windowY);
 					return kotlin.Unit.INSTANCE;
 				}
 		);
@@ -194,15 +194,11 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		return true;
 	}
 
-	private void onComposeClick(@NonNull ServiceListItem item, boolean isLong) {
-		View host = getView();
-		if (host == null) {
-			return;
-		}
-		onItemClick(host, item.getIndex(), isLong);
+	private void onComposeClick(@NonNull ServiceListItem item, boolean isLong, int windowX, int windowY) {
+		onItemClick(item.getIndex(), isLong, windowX, windowY);
 	}
 
-	private void onItemClick(@NonNull View v, int position, boolean isLong) {
+	private void onItemClick(int position, boolean isLong, int windowX, int windowY) {
 		if (position < 0 || position >= mRows.size()) {
 			return;
 		}
@@ -227,7 +223,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		if ((instantZap && !isLong) || (!instantZap && isLong)) {
 			zapTo(ref);
 		} else {
-			showPopupMenu(v, row);
+			showPopupMenu(windowX, windowY, row);
 		}
 	}
 
@@ -375,57 +371,61 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 		getMultiPaneHandler().showDetails(f, true);
 	}
 
-	public void showPopupMenu(@NonNull View v, @NonNull ServiceNowNext row) {
-		PopupMenu menu = new PopupMenu(getAppCompatActivity(), v);
-		menu.getMenuInflater().inflate(R.menu.popup_servicelist, menu.getMenu());
-		menu.getMenu().findItem(R.id.menu_next_event).setVisible(DreamDroid.featureNowNext() && row.getNext() != null);
+	public void showPopupMenu(int windowX, int windowY, @NonNull ServiceNowNext row) {
+		View root = getView();
+		if (!(root instanceof ViewGroup)) {
+			return;
+		}
+		AnchorPopup.showAtWindow((ViewGroup) root, windowX, windowY, menu -> {
+			menu.getMenuInflater().inflate(R.menu.popup_servicelist, menu.getMenu());
+			menu.getMenu().findItem(R.id.menu_next_event).setVisible(DreamDroid.featureNowNext() && row.getNext() != null);
 
-		menu.setOnMenuItemClickListener(menuItem -> {
-			String ref = row.getServiceReference();
-			String name = row.getServiceName();
-			switch (menuItem.getItemId()) {
-				case R.id.menu_next_event: {
-					Event next = row.getNext();
-					if (next != null) {
-						mCurrentItem = EpgListMapper.toExtendedHashMap(next);
-						EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(next);
-						getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+			menu.setOnMenuItemClickListener(menuItem -> {
+				String ref = row.getServiceReference();
+				String name = row.getServiceName();
+				switch (menuItem.getItemId()) {
+					case R.id.menu_next_event: {
+						Event next = row.getNext();
+						if (next != null) {
+							mCurrentItem = EpgListMapper.toExtendedHashMap(next);
+							EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(next);
+							getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+						}
+						break;
 					}
-					break;
+					case R.id.menu_current_event: {
+						Event now = row.getNow();
+						if (now != null) {
+							mCurrentItem = EpgListMapper.toExtendedHashMap(now);
+							EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(now);
+							getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
+						}
+						break;
+					}
+					case R.id.menu_browse_epg:
+						openEpg(ref, name);
+						break;
+					case R.id.menu_zap:
+						zapTo(ref);
+						break;
+					case R.id.menu_stream:
+						try {
+							startActivity(IntentFactory.getStreamServiceIntent(
+									getAppCompatActivity(),
+									ref,
+									name,
+									mRef,
+									ServiceListMapperKt.serviceNowNextToExtendedHashMap(row)));
+						} catch (ActivityNotFoundException e) {
+							showToast(getText(R.string.missing_stream_player));
+						}
+						break;
+					default:
+						return false;
 				}
-				case R.id.menu_current_event: {
-					Event now = row.getNow();
-					if (now != null) {
-						mCurrentItem = EpgListMapper.toExtendedHashMap(now);
-						EpgDetailBottomSheet epgDialog = EpgDetailBottomSheet.newInstance(now);
-						getMultiPaneHandler().showDialogFragment(epgDialog, "epg_detail_dialog");
-					}
-					break;
-				}
-				case R.id.menu_browse_epg:
-					openEpg(ref, name);
-					break;
-				case R.id.menu_zap:
-					zapTo(ref);
-					break;
-				case R.id.menu_stream:
-					try {
-						startActivity(IntentFactory.getStreamServiceIntent(
-								getAppCompatActivity(),
-								ref,
-								name,
-								mRef,
-								ServiceListMapperKt.serviceNowNextToExtendedHashMap(row)));
-					} catch (ActivityNotFoundException e) {
-						showToast(getText(R.string.missing_stream_player));
-					}
-					break;
-				default:
-					return false;
-			}
-			return true;
+				return true;
+			});
 		});
-		menu.show();
 	}
 
 	@Override

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileEditScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfileEditScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,8 +41,11 @@ fun ProfileEditScreen(
     onSave: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Hosted under simple_layout_with_toolbar which already fits system windows.
+    // Default Scaffold safeDrawing insets would double-pad and lift the FAB (#263).
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             FloatingActionButton(onClick = onSave) {
                 Icon(

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesListState.kt
@@ -17,20 +17,16 @@ class ProfilesListState(initial: List<ProfileListItem> = emptyList()) {
 
 fun ComposeView.bindProfilesScreen(
     state: ProfilesListState,
-    addLabel: String,
     onProfileClick: (ProfileListItem) -> Unit,
     onProfileLongClick: (ProfileListItem) -> Unit,
-    onAddClick: () -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {
             ProfilesScreen(
                 profiles = state.items,
-                addLabel = addLabel,
                 onProfileClick = onProfileClick,
                 onProfileLongClick = onProfileLongClick,
-                onAddClick = onAddClick,
             )
         }
     }

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesScreen.kt
@@ -17,52 +17,31 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import net.reichholf.dreamdroid.R
 
 @Composable
 fun ProfilesScreen(
     profiles: List<ProfileListItem>,
-    addLabel: String,
     onProfileClick: (ProfileListItem) -> Unit,
     onProfileLongClick: (ProfileListItem) -> Unit,
-    onAddClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Scaffold(
-        modifier = modifier.fillMaxSize(),
-        floatingActionButton = {
-            FloatingActionButton(onClick = onAddClick) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_action_fab_add),
-                    contentDescription = addLabel,
-                )
-            }
-        },
-        containerColor = MaterialTheme.colorScheme.background,
-    ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-        ) {
-            items(profiles, key = { it.id }) { profile ->
-                ProfileRow(
-                    profile = profile,
-                    onClick = { onProfileClick(profile) },
-                    onLongClick = { onProfileLongClick(profile) },
-                )
-            }
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+    ) {
+        items(profiles, key = { it.id }) { profile ->
+            ProfileRow(
+                profile = profile,
+                onClick = { onProfileClick(profile) },
+                onLongClick = { onProfileLongClick(profile) },
+            )
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListScreen.kt
@@ -13,19 +13,34 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+typealias MovieListTap = (item: MovieListItem, windowX: Int, windowY: Int) -> Unit
 
 @Composable
 fun MovieListScreen(
     items: List<MovieListItem>,
-    onItemClick: (MovieListItem) -> Unit,
-    onItemLongClick: (MovieListItem) -> Unit,
+    onItemClick: MovieListTap,
+    onItemLongClick: MovieListTap,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 8.dp)) {
         items(items, key = { it.index }) { item ->
-            MovieRow(item, onClick = { onItemClick(item) }, onLongClick = { onItemLongClick(item) })
+            MovieRow(
+                item = item,
+                onClick = { x, y -> onItemClick(item, x, y) },
+                onLongClick = { x, y -> onItemLongClick(item, x, y) },
+            )
         }
     }
 }
@@ -34,14 +49,29 @@ fun MovieListScreen(
 @Composable
 private fun MovieRow(
     item: MovieListItem,
-    onClick: () -> Unit,
-    onLongClick: () -> Unit,
+    onClick: (windowX: Int, windowY: Int) -> Unit,
+    onLongClick: (windowX: Int, windowY: Int) -> Unit,
 ) {
+    var coords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    fun windowTopLeft(): Pair<Int, Int> {
+        val bounds: Rect = coords?.boundsInWindow() ?: return 0 to 0
+        return bounds.left.roundToInt() to bounds.top.roundToInt()
+    }
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+            .onGloballyPositioned { coords = it }
+            .combinedClickable(
+                onClick = {
+                    val (x, y) = windowTopLeft()
+                    onClick(x, y)
+                },
+                onLongClick = {
+                    val (x, y) = windowTopLeft()
+                    onLongClick(x, y)
+                },
+            ),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
         Column(Modifier.padding(12.dp)) {

--- a/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/MovieListState.kt
@@ -21,8 +21,8 @@ fun ComposeView.bindMovieListScreen(
     state: MovieListState,
     refresh: ComposeRefreshState,
     onRefresh: () -> Unit,
-    onItemClick: (MovieListItem) -> Unit,
-    onItemLongClick: (MovieListItem) -> Unit,
+    onItemClick: MovieListTap,
+    onItemLongClick: MovieListTap,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -17,8 +17,16 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -29,20 +37,24 @@ import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.helpers.enigma2.Picon
 import net.reichholf.dreamdroid.helpers.enigma2.Service
+import kotlin.math.roundToInt
+
+/** Window-space top-left of the tapped row — used to anchor View PopupMenus. */
+typealias ServiceListTap = (item: ServiceListItem, windowX: Int, windowY: Int) -> Unit
 
 @Composable
 fun ServiceListScreen(
     items: List<ServiceListItem>,
-    onItemClick: (ServiceListItem) -> Unit,
-    onItemLongClick: (ServiceListItem) -> Unit,
+    onItemClick: ServiceListTap,
+    onItemLongClick: ServiceListTap,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 8.dp)) {
         items(items, key = { "${it.index}:${it.reference}" }) { item ->
             ServiceRow(
                 item = item,
-                onClick = { onItemClick(item) },
-                onLongClick = { onItemLongClick(item) },
+                onClick = { x, y -> onItemClick(item, x, y) },
+                onLongClick = { x, y -> onItemLongClick(item, x, y) },
             )
         }
     }
@@ -52,8 +64,8 @@ fun ServiceListScreen(
 @Composable
 private fun ServiceRow(
     item: ServiceListItem,
-    onClick: () -> Unit,
-    onLongClick: () -> Unit,
+    onClick: (windowX: Int, windowY: Int) -> Unit,
+    onLongClick: (windowX: Int, windowY: Int) -> Unit,
 ) {
     if (item.kind == ServiceRowKind.MARKER) {
         Text(
@@ -64,11 +76,26 @@ private fun ServiceRow(
         )
         return
     }
+    var coords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    fun windowTopLeft(): Pair<Int, Int> {
+        val bounds: Rect = coords?.boundsInWindow() ?: return 0 to 0
+        return bounds.left.roundToInt() to bounds.top.roundToInt()
+    }
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+            .onGloballyPositioned { coords = it }
+            .combinedClickable(
+                onClick = {
+                    val (x, y) = windowTopLeft()
+                    onClick(x, y)
+                },
+                onLongClick = {
+                    val (x, y) = windowTopLeft()
+                    onLongClick(x, y)
+                },
+            ),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
         Column(Modifier.padding(12.dp)) {

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListState.kt
@@ -21,8 +21,8 @@ fun ComposeView.bindServiceListScreen(
     state: ServiceListState,
     refresh: ComposeRefreshState,
     onRefresh: () -> Unit,
-    onItemClick: (ServiceListItem) -> Unit,
-    onItemLongClick: (ServiceListItem) -> Unit,
+    onItemClick: ServiceListTap,
+    onItemLongClick: ServiceListTap,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {

--- a/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -51,8 +52,11 @@ fun TimerEditScreen(
     onPickTags: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Hosted under simple_layout_with_toolbar which already fits system windows.
+    // Default Scaffold safeDrawing insets would double-pad and lift the FAB (#263).
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             FloatingActionButton(onClick = onSave) {
                 Icon(

--- a/app/src/net/reichholf/dreamdroid/widget/AnchorPopup.java
+++ b/app/src/net/reichholf/dreamdroid/widget/AnchorPopup.java
@@ -1,0 +1,60 @@
+package net.reichholf.dreamdroid.widget;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.PopupMenu;
+
+/**
+ * Shows a {@link PopupMenu} at a point inside a {@link ViewGroup}.
+ * Compose list rows have no View anchors; anchoring to the fragment root pins the
+ * menu at the top-left. A 1×1 temporary child at the tap location restores row positioning.
+ */
+public final class AnchorPopup {
+	private AnchorPopup() {
+	}
+
+	public interface Configurer {
+		void configure(@NonNull PopupMenu menu);
+	}
+
+	public static void showAt(
+			@NonNull ViewGroup root,
+			int xInRoot,
+			int yInRoot,
+			@NonNull Configurer configurer
+	) {
+		View anchor = new View(root.getContext());
+		FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(1, 1);
+		lp.leftMargin = Math.max(0, xInRoot);
+		lp.topMargin = Math.max(0, yInRoot);
+		root.addView(anchor, lp);
+		anchor.post(() -> {
+			if (anchor.getParent() == null) {
+				return;
+			}
+			PopupMenu menu = new PopupMenu(anchor.getContext(), anchor);
+			menu.setOnDismissListener(m -> {
+				if (anchor.getParent() instanceof ViewGroup) {
+					((ViewGroup) anchor.getParent()).removeView(anchor);
+				}
+			});
+			configurer.configure(menu);
+			menu.show();
+		});
+	}
+
+	/** Convert window coordinates to offsets inside {@code root}. */
+	public static void showAtWindow(
+			@NonNull ViewGroup root,
+			int windowX,
+			int windowY,
+			@NonNull Configurer configurer
+	) {
+		int[] loc = new int[2];
+		root.getLocationOnScreen(loc);
+		showAt(root, windowX - loc[0], windowY - loc[1], configurer);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Profile Add FAB clipped off-screen; service tap menu (`Aktuelle Sendung` / `Nächste Sendung`) always opened top-left. Overlaps [#263](https://github.com/sreichholf/dreamDroid/pull/263) on FAB alignment.

## Combined fix (supersedes #263)

| Area | Approach |
| --- | --- |
| `fab_main` / `fab_reload` in `dualpane` | `layout_gravity` on Coordinator (no `detail_view` anchor) — same as #263 / #248 |
| Profiles add | Shell XML `fab_main` via `registerFab` (avoids Scaffold-in-`detail_view` entirely; #263 used `WindowInsets(0)` on Scaffold instead) |
| Profile edit / Timer edit save FABs | From #263: `contentWindowInsets = WindowInsets(0)` under `fitsSystemWindows` hosts |
| Service / Movie context menus | Row window coords + `AnchorPopup` (unique to this PR) |

Please close #263 in favor of this PR.

## Proof

```text
bash .cursor/cloud/connected-test.sh \
  DualpaneFabLayoutTest,ProfilesScreenTest,ProfileEditScreenTest,\
TimerEditScreenTest,ServiceListScreenTest
# OK (11 tests)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

