### PR TITLE
Phase 2.1e: Backup leaf on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -13,5 +13,6 @@
     <item name="phone_nav_screenshot_slot" type="id"/>
     <item name="phone_nav_current_slot" type="id"/>
     <item name="phone_nav_zap_slot" type="id"/>
+    <item name="phone_nav_backup_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -16,7 +16,7 @@ import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
 
 /**
  * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
- * Migrated leaves: Device Info, Signal, Screenshot, Current, Zap. Drawer selection uses [navigateToRoute] when this
+ * Migrated leaves: Device Info, Signal, Screenshot, Current, Zap, Backup. Drawer selection uses [navigateToRoute] when this
  * host is already shown; [ARG_START_ROUTE] picks the first leaf when mounting.
  */
 class PhoneNavHostFragment : BaseFragment() {
@@ -79,6 +79,9 @@ class PhoneNavHostFragment : BaseFragment() {
             PhoneNavRoutes.ZAP ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_zap_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.ZAP)
+            PhoneNavRoutes.BACKUP ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_backup_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.BACKUP)
             else -> null
         }
     }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -18,7 +18,6 @@ import net.reichholf.dreamdroid.activities.SimpleNoTitleFragmentActivity;
 import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
 import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
-import net.reichholf.dreamdroid.fragment.BackupFragment;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.EpgBouquetFragment;
 import net.reichholf.dreamdroid.fragment.MyPreferenceFragment;
@@ -290,8 +289,7 @@ public class NavigationHelper {
                 getMainActivity().showDetails(f);
                 break;
             case R.id.menu_navigation_backup:
-                clearBackStack();
-                getMainActivity().showDetails(BackupFragment.class);
+                navigatePhoneNavRoot(PhoneNavRoutes.BACKUP);
                 break;
         }
         getMainActivity().showContent();

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.fragment.BackupFragment
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
@@ -26,8 +27,8 @@ import net.reichholf.dreamdroid.fragment.ZapFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Migrated drawer leaves: Device Info, Signal, Screenshot, Current, Zap.
- * Other destinations still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
+ * Phone shell [NavHost]. Migrated drawer leaves: Device Info, Signal, Screenshot, Current, Zap,
+ * Backup. Other destinations still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
  */
 @Composable
 fun PhoneNavHost(
@@ -82,6 +83,14 @@ fun PhoneNavHost(
                 containerId = R.id.phone_nav_zap_slot,
                 routeTag = PhoneNavRoutes.ZAP,
                 createFragment = { ZapFragment() },
+            )
+        }
+        composable(PhoneNavRoutes.BACKUP) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_backup_slot,
+                routeTag = PhoneNavRoutes.BACKUP,
+                createFragment = { BackupFragment() },
             )
         }
     }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -10,4 +10,5 @@ object PhoneNavRoutes {
     const val SCREENSHOT = "screenshot"
     const val CURRENT = "current"
     const val ZAP = "zap"
+    const val BACKUP = "backup"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -100,7 +100,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-signal-leaf | [#257](https://github.com/sreichholf/dreamDroid/pull/257) | merged | Phase 2.1e: Signal drawer root on `PhoneNavHost` (sibling of Device Info); `ARG_START_ROUTE` + drawer-style navigate. Keep OkHttp 3.14.9. |
 | navhost-screenshot-leaf | [#258](https://github.com/sreichholf/dreamDroid/pull/258) | merged | Phase 2.1e continued: Screenshot drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-current-leaf | [#260](https://github.com/sreichholf/dreamDroid/pull/260) | merged | Phase 2.1e continued: Current Service drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
-| navhost-zap-leaf | this PR | open | Phase 2.1e continued: Zap drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-zap-leaf | [#262](https://github.com/sreichholf/dreamDroid/pull/262) | merged | Phase 2.1e continued: Zap drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-backup-leaf | this PR | open | Phase 2.1e continued: Backup drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -126,7 +127,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through Current) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#260](https://github.com/sreichholf/dreamDroid/pull/260); Zap leaf **this PR**.
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through Zap) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#262](https://github.com/sreichholf/dreamDroid/pull/262); Backup leaf **this PR**.
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -164,8 +165,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
 - Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
-- Phase 2.1c–e through Current **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#260](https://github.com/sreichholf/dreamDroid/pull/260).
-- **This PR** = Zap leaf on `PhoneNavHost` (2.1e continued).
+- Phase 2.1c–e through Zap **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#262](https://github.com/sreichholf/dreamDroid/pull/262).
+- **This PR** = Backup leaf on `PhoneNavHost` (2.1e continued).
 - Out of wave still: widgets (2.6); more NavHost roots / hub. See Appendix H.
 
 ## How to read this
@@ -600,7 +601,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through Current **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#260](https://github.com/sreichholf/dreamDroid/pull/260); **this PR** = Zap leaf; then more leaves / hub or widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through Zap **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#262](https://github.com/sreichholf/dreamDroid/pull/262); **this PR** = Backup leaf; then more leaves / hub or widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -679,7 +680,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Through Current leaf **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#260](https://github.com/sreichholf/dreamDroid/pull/260). Zap **this PR**. |
+| 1b | Drawer Navigation | Through Zap leaf **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#262](https://github.com/sreichholf/dreamDroid/pull/262). Backup **this PR**. |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -789,7 +790,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation (through Current [#260](https://github.com/sreichholf/dreamDroid/pull/260); Zap this PR)
+### Phase 2.1b — NavHost / Compose Navigation (through Zap [#262](https://github.com/sreichholf/dreamDroid/pull/262); Backup this PR)
 
 #### Chassis (current)
 
@@ -804,7 +805,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Signal leaf | `PhoneNavRoutes.SIGNAL` + nested `SignalFragment` | **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257) |
 | Screenshot leaf | `PhoneNavRoutes.SCREENSHOT` + nested `ScreenShotFragment` | **merged** [#258](https://github.com/sreichholf/dreamDroid/pull/258) |
 | Current leaf | `PhoneNavRoutes.CURRENT` + nested `CurrentServiceFragment` | **merged** [#260](https://github.com/sreichholf/dreamDroid/pull/260) |
-| Zap leaf | `PhoneNavRoutes.ZAP` + nested `ZapFragment` | **this PR** |
+| Zap leaf | `PhoneNavRoutes.ZAP` + nested `ZapFragment` | **merged** [#262](https://github.com/sreichholf/dreamDroid/pull/262) |
+| Backup leaf | `PhoneNavRoutes.BACKUP` + nested `BackupFragment` | **this PR** |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -812,7 +814,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info, Signal, Screenshot, Current, Zap) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Drawer migrated roots call `navigatePhoneNavRoot` / `navigateToRoute` when the host is already visible.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info, Signal, Screenshot, Current, Zap, Backup) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Drawer migrated roots call `navigatePhoneNavRoot` / `navigateToRoute` when the host is already visible.
 
 #### Proposed PR slices
 
@@ -821,7 +823,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
-| 2.1e | More drawer roots (leaves before `ServiceListPager`) | Through Current **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#260](https://github.com/sreichholf/dreamDroid/pull/260); Zap **this PR**; Backup later |
+| 2.1e | More drawer roots (leaves before `ServiceListPager`) | Through Zap **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#262](https://github.com/sreichholf/dreamDroid/pull/262); Backup **this PR**; Profiles/EPG later |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
@@ -829,7 +831,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 #### Explicit non-goals of this PR
 
 - No hub / `ServiceListPager` on NavHost
-- No Backup / Profiles in this PR
+- No Profiles / EPG bouquet in this PR
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -845,7 +847,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through Current **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#260](https://github.com/sreichholf/dreamDroid/pull/260). **This PR:** Zap leaf on NavHost. Next Appendix H: more leaves / hub or widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through Zap **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#262](https://github.com/sreichholf/dreamDroid/pull/262). **This PR:** Backup leaf on NavHost. Next Appendix H: more leaves / hub or widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continue Phase **2.1e** after [#262](https://github.com/sreichholf/dreamDroid/pull/262): Backup as another NavHost drawer leaf.

- `PhoneNavRoutes.BACKUP` + nested `BackupFragment`
- Drawer uses shared `navigatePhoneNavRoot`
- No hub / Profiles / EPG in this PR

## Non-goals
- No `ServiceListPager` on NavHost
- No OkHttp 4; do not merge `master` into `main`

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open Backup; switch among migrated NavHost leaves
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

