### PR TITLE
Phase 2.1e: EPG leaf on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -15,5 +15,6 @@
     <item name="phone_nav_zap_slot" type="id"/>
     <item name="phone_nav_backup_slot" type="id"/>
     <item name="phone_nav_profiles_slot" type="id"/>
+    <item name="phone_nav_epg_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -144,7 +144,8 @@ class PhoneNavHostFragment : BaseFragment() {
 
     /**
      * Open EPG with bouquet args. Remounts the nested leaf when args change so
-     * [EpgBouquetFragment] reads a fresh Bundle.
+     * [EpgBouquetFragment] reads a fresh Bundle. When already on the EPG route,
+     * `launchSingleTop` would no-op — replace the child fragment directly.
      */
     fun navigateToEpg(serviceReference: String?, serviceName: String?): Boolean {
         val controller = navController ?: return false
@@ -155,6 +156,18 @@ class PhoneNavHostFragment : BaseFragment() {
             ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG)
         if (existing != null && !childFragmentManager.isStateSaved) {
             childFragmentManager.beginTransaction().remove(existing).commitNow()
+        }
+        if (controller.currentDestination?.route == PhoneNavRoutes.EPG) {
+            if (!childFragmentManager.isStateSaved) {
+                childFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.phone_nav_epg_slot,
+                        EpgBouquetFragment().apply { arguments = epgLeafArguments() },
+                        PhoneNavRoutes.EPG,
+                    )
+                    .commitNow()
+            }
+            return true
         }
         controller.navigateDrawerRoot(PhoneNavRoutes.EPG)
         return true

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -11,17 +11,18 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavHostController
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
+import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
 
 /**
  * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
- * Migrated leaves: Device Info, Signal, Screenshot, Current, Zap, Backup, Profiles. Drawer selection uses [navigateToRoute] when this
- * host is already shown; [ARG_START_ROUTE] picks the first leaf when mounting.
+ * Migrated drawer leaves include Device Info through Profiles and EPG. Drawer selection uses
+ * [navigateToRoute] when this host is already shown; [ARG_START_ROUTE] picks the first leaf.
  *
  * [net.reichholf.dreamdroid.activities.abs.BaseActivity] only delivers [onActivityResult] to
- * top-level fragments; forward to the active leaf so Profiles edit/add still reloads the list.
+ * top-level fragments; forward to the active leaf (Profiles edit, EPG bouquet picker, Zap).
  */
 class PhoneNavHostFragment : BaseFragment() {
 
@@ -30,9 +31,17 @@ class PhoneNavHostFragment : BaseFragment() {
 
         @JvmStatic
         fun newInstance(startRoute: String): PhoneNavHostFragment {
+            return newInstance(startRoute, null)
+        }
+
+        @JvmStatic
+        fun newInstance(startRoute: String, leafExtras: Bundle?): PhoneNavHostFragment {
             return PhoneNavHostFragment().apply {
                 arguments = Bundle().apply {
                     putString(ARG_START_ROUTE, startRoute)
+                    if (leafExtras != null) {
+                        putAll(leafExtras)
+                    }
                 }
             }
         }
@@ -64,6 +73,20 @@ class PhoneNavHostFragment : BaseFragment() {
         return arguments?.getString(ARG_START_ROUTE) ?: PhoneNavRoutes.DEVICE_INFO
     }
 
+    /** Args for nested [EpgBouquetFragment] (default TV bouquet from drawer). */
+    fun epgLeafArguments(): Bundle {
+        return Bundle().apply {
+            putString(
+                Event.KEY_SERVICE_REFERENCE,
+                arguments?.getString(Event.KEY_SERVICE_REFERENCE),
+            )
+            putString(
+                Event.KEY_SERVICE_NAME,
+                arguments?.getString(Event.KEY_SERVICE_NAME),
+            )
+        }
+    }
+
     /** Nested destination fragment for the current NavHost route (if any). */
     fun getActiveLeaf(): Fragment? {
         val route = navController?.currentDestination?.route ?: startRoute()
@@ -89,6 +112,9 @@ class PhoneNavHostFragment : BaseFragment() {
             PhoneNavRoutes.PROFILES ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_profiles_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.PROFILES)
+            PhoneNavRoutes.EPG ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_epg_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG)
             else -> null
         }
     }
@@ -113,6 +139,24 @@ class PhoneNavHostFragment : BaseFragment() {
     fun navigateToRoute(route: String): Boolean {
         val controller = navController ?: return false
         controller.navigateDrawerRoot(route)
+        return true
+    }
+
+    /**
+     * Open EPG with bouquet args. Remounts the nested leaf when args change so
+     * [EpgBouquetFragment] reads a fresh Bundle.
+     */
+    fun navigateToEpg(serviceReference: String?, serviceName: String?): Boolean {
+        val controller = navController ?: return false
+        val args = arguments ?: Bundle().also { arguments = it }
+        args.putString(Event.KEY_SERVICE_REFERENCE, serviceReference)
+        args.putString(Event.KEY_SERVICE_NAME, serviceName)
+        val existing = childFragmentManager.findFragmentById(R.id.phone_nav_epg_slot)
+            ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG)
+        if (existing != null && !childFragmentManager.isStateSaved) {
+            childFragmentManager.beginTransaction().remove(existing).commitNow()
+        }
+        controller.navigateDrawerRoot(PhoneNavRoutes.EPG)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -19,7 +19,6 @@ import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
 import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
-import net.reichholf.dreamdroid.fragment.EpgBouquetFragment;
 import net.reichholf.dreamdroid.fragment.MyPreferenceFragment;
 import net.reichholf.dreamdroid.fragment.ServiceListPager;
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment;
@@ -273,20 +272,24 @@ public class NavigationHelper {
                 break;
             case Statics.ITEM_RELOAD:
                 return false;
-            case R.id.menu_navigation_epg:
-                clearBackStack();
-                Bundle args = new Bundle();
-
+            case R.id.menu_navigation_epg: {
+                Bundle epgArgs = new Bundle();
                 String ref = DreamDroid.getCurrentProfile().getDefaultBouquetTv();
-                args.putString(Event.KEY_SERVICE_REFERENCE, ref);
-
+                epgArgs.putString(Event.KEY_SERVICE_REFERENCE, ref);
                 String name = DreamDroid.getCurrentProfile().getDefaultBouquetTvName();
-                args.putString(Event.KEY_SERVICE_NAME, name);
+                epgArgs.putString(Event.KEY_SERVICE_NAME, name);
 
-                EpgBouquetFragment f = new EpgBouquetFragment();
-                f.setArguments(args);
-                getMainActivity().showDetails(f);
+                Fragment detail = getMainActivity().getSupportFragmentManager()
+                        .findFragmentById(R.id.detail_view);
+                if (detail instanceof PhoneNavHostFragment
+                        && ((PhoneNavHostFragment) detail).navigateToEpg(ref, name)) {
+                    break;
+                }
+                clearBackStack();
+                getMainActivity().showDetails(
+                        PhoneNavHostFragment.newInstance(PhoneNavRoutes.EPG, epgArgs));
                 break;
+            }
             case R.id.menu_navigation_backup:
                 navigatePhoneNavRoot(PhoneNavRoutes.BACKUP);
                 break;

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -20,6 +20,7 @@ import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.BackupFragment
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
+import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
@@ -28,8 +29,8 @@ import net.reichholf.dreamdroid.fragment.ZapFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Migrated drawer leaves: Device Info, Signal, Screenshot, Current, Zap,
- * Backup, Profiles. Other destinations still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
+ * Phone shell [NavHost]. Migrated drawer leaves through Profiles and EPG. Other destinations
+ * (hub, tablet remote) still go through [net.reichholf.dreamdroid.fragment.helper.NavigationHelper].
  */
 @Composable
 fun PhoneNavHost(
@@ -100,6 +101,18 @@ fun PhoneNavHost(
                 containerId = R.id.phone_nav_profiles_slot,
                 routeTag = PhoneNavRoutes.PROFILES,
                 createFragment = { ProfileListFragment() },
+            )
+        }
+        composable(PhoneNavRoutes.EPG) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_epg_slot,
+                routeTag = PhoneNavRoutes.EPG,
+                createFragment = {
+                    EpgBouquetFragment().apply {
+                        arguments = hostFragment.epgLeafArguments()
+                    }
+                },
             )
         }
     }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -12,4 +12,5 @@ object PhoneNavRoutes {
     const val ZAP = "zap"
     const val BACKUP = "backup"
     const val PROFILES = "profiles"
+    const val EPG = "epg"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -102,7 +102,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-current-leaf | [#260](https://github.com/sreichholf/dreamDroid/pull/260) | merged | Phase 2.1e continued: Current Service drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-zap-leaf | [#262](https://github.com/sreichholf/dreamDroid/pull/262) | merged | Phase 2.1e continued: Zap drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-backup-leaf | [#265](https://github.com/sreichholf/dreamDroid/pull/265) | merged | Phase 2.1e continued: Backup drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
-| navhost-profiles-leaf | this PR | open | Phase 2.1e continued: Profiles drawer root on `PhoneNavHost` (still clears drawer selection). Keep OkHttp 3.14.9. |
+| navhost-profiles-leaf | [#266](https://github.com/sreichholf/dreamDroid/pull/266) | merged | Phase 2.1e continued: Profiles drawer root on `PhoneNavHost` (still clears drawer selection). Keep OkHttp 3.14.9. |
+| navhost-epg-leaf | this PR | open | Phase 2.1e continued: EPG bouquet drawer root on `PhoneNavHost` with service ref/name extras. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -128,7 +129,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through Backup) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#265](https://github.com/sreichholf/dreamDroid/pull/265); Profiles leaf **this PR**.
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through Profiles) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#266](https://github.com/sreichholf/dreamDroid/pull/266); EPG leaf **this PR**.
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -166,9 +167,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
 - Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
-- Phase 2.1c–e through Backup **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#265](https://github.com/sreichholf/dreamDroid/pull/265).
-- **This PR** = Profiles leaf on `PhoneNavHost` (2.1e continued; drawer selection still cleared).
-- Out of wave still: widgets (2.6); hub / EPG / nested routes. See Appendix H.
+- Phase 2.1c–e through Profiles **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#266](https://github.com/sreichholf/dreamDroid/pull/266).
+- **This PR** = EPG bouquet leaf on `PhoneNavHost` (default TV bouquet args).
+- Out of wave still: widgets (2.6); hub / tablet remote / nested routes. See Appendix H.
 
 ## How to read this
 
@@ -602,7 +603,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through Backup **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#265](https://github.com/sreichholf/dreamDroid/pull/265); **this PR** = Profiles leaf; then hub / EPG / widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through Profiles **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#266](https://github.com/sreichholf/dreamDroid/pull/266); **this PR** = EPG leaf; then hub / tablet remote / widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -681,7 +682,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Through Backup leaf **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#265](https://github.com/sreichholf/dreamDroid/pull/265). Profiles **this PR**. |
+| 1b | Drawer Navigation | Through Profiles leaf **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#266](https://github.com/sreichholf/dreamDroid/pull/266). EPG **this PR**. |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -791,7 +792,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation (through Backup [#265](https://github.com/sreichholf/dreamDroid/pull/265); Profiles this PR)
+### Phase 2.1b — NavHost / Compose Navigation (through Profiles [#266](https://github.com/sreichholf/dreamDroid/pull/266); EPG this PR)
 
 #### Chassis (current)
 
@@ -808,7 +809,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Current leaf | `PhoneNavRoutes.CURRENT` + nested `CurrentServiceFragment` | **merged** [#260](https://github.com/sreichholf/dreamDroid/pull/260) |
 | Zap leaf | `PhoneNavRoutes.ZAP` + nested `ZapFragment` | **merged** [#262](https://github.com/sreichholf/dreamDroid/pull/262) |
 | Backup leaf | `PhoneNavRoutes.BACKUP` + nested `BackupFragment` | **merged** [#265](https://github.com/sreichholf/dreamDroid/pull/265) |
-| Profiles leaf | `PhoneNavRoutes.PROFILES` + nested `ProfileListFragment` | **this PR** (still clears drawer selection) |
+| Profiles leaf | `PhoneNavRoutes.PROFILES` + nested `ProfileListFragment` | **merged** [#266](https://github.com/sreichholf/dreamDroid/pull/266) (still clears drawer selection) |
+| EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **this PR** (default bouquet ref/name extras) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -816,7 +818,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info, Signal, Screenshot, Current, Zap, Backup, Profiles) while `NavigationHelper` still drives others via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Drawer migrated roots call `navigatePhoneNavRoot` / `navigateToRoute` when the host is already visible.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info through Profiles + EPG) while `NavigationHelper` still drives hub / tablet remote via Fragments. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph. Drawer migrated roots call `navigatePhoneNavRoot` / `navigateToRoute` when the host is already visible.
 
 #### Proposed PR slices
 
@@ -825,7 +827,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
-| 2.1e | More drawer roots (leaves before `ServiceListPager`) | Through Backup **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#265](https://github.com/sreichholf/dreamDroid/pull/265); Profiles **this PR**; EPG/hub later |
+| 2.1e | More drawer roots (leaves before `ServiceListPager`) | Through Profiles **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#266](https://github.com/sreichholf/dreamDroid/pull/266); EPG **this PR**; hub / tablet remote later |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
@@ -833,7 +835,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 #### Explicit non-goals of this PR
 
 - No hub / `ServiceListPager` on NavHost
-- No EPG bouquet / tablet remote in this PR
+- No tablet virtual remote in this PR
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 
@@ -849,7 +851,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through Backup **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#265](https://github.com/sreichholf/dreamDroid/pull/265). **This PR:** Profiles leaf on NavHost. Next Appendix H: hub / EPG / widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through Profiles **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#266](https://github.com/sreichholf/dreamDroid/pull/266). **This PR:** EPG leaf on NavHost. Next Appendix H: hub / tablet remote / widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continue Phase **2.1e** after [#266](https://github.com/sreichholf/dreamDroid/pull/266): EPG bouquet on `PhoneNavHost`.

- `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment`
- Host carries default TV bouquet ref/name; `navigateToEpg` remounts the leaf when args change (including when already on EPG — `launchSingleTop` would no-op)
- Remaining non-NavHost drawer roots: hub `ServiceListPager`, tablet virtual remote

## Non-goals
- No hub / tablet remote / nested typed routes (2.1f)
- No OkHttp 4; do not merge `master` into `main`

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open EPG from drawer; re-open EPG while already there; bouquet picker still works; switch to/from other NavHost leaves
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

