### PR TITLE
fix(ui): TV/Movies hub bottom nav too low

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/widget/DualpaneFabLayoutTest.kt
@@ -3,6 +3,7 @@ package net.reichholf.dreamdroid.widget
 import android.view.ContextThemeWrapper
 import android.view.Gravity
 import android.view.View
+import androidx.compose.ui.platform.ComposeView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -33,5 +34,19 @@ class DualpaneFabLayoutTest {
         assertEquals(View.NO_ID, reloadLp.anchorId)
         assertTrue((reloadLp.gravity and Gravity.TOP) == Gravity.TOP)
         assertTrue((reloadLp.gravity and Gravity.END) == Gravity.END)
+    }
+
+    @Test
+    fun tvMoviesDestinationBarUsesBottomGravityOnCoordinator() {
+        val base = InstrumentationRegistry.getInstrumentation().targetContext
+        val context = ContextThemeWrapper(base, R.style.Theme_DreamDroid_Night)
+        val root = android.view.LayoutInflater.from(context)
+            .inflate(R.layout.dualpane, null, false)
+        val nav = root.findViewById<ComposeView>(R.id.tv_movies_nav)
+        val lp = nav.layoutParams as CoordinatorLayout.LayoutParams
+
+        assertEquals(View.NO_ID, lp.anchorId)
+        assertTrue((lp.gravity and Gravity.BOTTOM) == Gravity.BOTTOM)
+        assertEquals(View.GONE, nav.visibility)
     }
 }

--- a/app/res/layout-sw720dp/dualpane.xml
+++ b/app/res/layout-sw720dp/dualpane.xml
@@ -99,6 +99,16 @@
             app:layout_behavior="net.reichholf.dreamdroid.widget.behaviour.ScrollAwareFABBehavior"
             app:pressedTranslationZ="12dp" />
 
+        <!-- Gravity (not inside detail_view): same ScrollingViewBehavior overflow that clipped
+             FABs also pushed the TV/Movies destination bar off the bottom of the screen. -->
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/tv_movies_nav"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:visibility="gone"
+            android:elevation="8dp" />
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <LinearLayout

--- a/app/res/layout/dualpane.xml
+++ b/app/res/layout/dualpane.xml
@@ -77,6 +77,16 @@
             app:layout_behavior="net.reichholf.dreamdroid.widget.behaviour.ScrollAwareFABBehavior"
             app:pressedTranslationZ="12dp"/>
 
+        <!-- Gravity (not inside detail_view): same ScrollingViewBehavior overflow that clipped
+             FABs also pushed the TV/Movies destination bar off the bottom of the screen. -->
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/tv_movies_nav"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:visibility="gone"
+            android:elevation="8dp"/>
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <LinearLayout

--- a/app/res/layout/service_list_pager.xml
+++ b/app/res/layout/service_list_pager.xml
@@ -15,8 +15,8 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-    <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/tv_movies_nav"
+    <!-- Destination bar lives on the activity Coordinator (tv_movies_nav); reserve its height. -->
+    <Space
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="@dimen/tv_movies_destination_bar_height" />
 </LinearLayout>

--- a/app/res/values/dimens.xml
+++ b/app/res/values/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="keyline2from1">48dip</dimen>
     <dimen name="fab_margin_bottom">16dp</dimen>
     <dimen name="fab_margin_right">16dp</dimen>
+    <!-- Material3 NavigationBar with labels; spacer in service_list_pager matches shell bar. -->
+    <dimen name="tv_movies_destination_bar_height">80dp</dimen>
     <dimen name="recylcerview_content_margin">0dp</dimen>
     <dimen name="navigation_header_height">170dp</dimen>
     <dimen name="navigation_header_padding_top">0dp</dimen>

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -58,6 +58,8 @@ public class ServiceListPager extends BaseHttpFragment {
 	private Job mBouquetLoadJob;
 	@Nullable
 	private Job mLocationsAndTagsJob;
+	@Nullable
+	private ComposeView mDestinationNav;
 
 	@Nullable
 	private Bouquets mBouquets;
@@ -221,17 +223,19 @@ public class ServiceListPager extends BaseHttpFragment {
 		super.onViewCreated(view, savedInstanceState);
 
 		ComposeView header = view.findViewById(R.id.tv_movies_header);
-		ComposeView nav = view.findViewById(R.id.tv_movies_nav);
+		mDestinationNav = requireActivity().findViewById(R.id.tv_movies_nav);
 		TvMoviesHubStateKt.bindTvMoviesHeader(header, mHubState, index -> {
 			if (mPager.getAdapter() != null && index >= 0 && index < mPager.getAdapter().getItemCount())
 				mPager.setCurrentItem(index, false);
 			return kotlin.Unit.INSTANCE;
 		});
-		TvMoviesHubStateKt.bindTvMoviesDestinationBar(nav, mHubState, dest -> {
-			onDestinationSelected(dest);
-			return kotlin.Unit.INSTANCE;
-		});
-
+		if (mDestinationNav != null) {
+			mDestinationNav.setVisibility(View.VISIBLE);
+			TvMoviesHubStateKt.bindTvMoviesDestinationBar(mDestinationNav, mHubState, dest -> {
+				onDestinationSelected(dest);
+				return kotlin.Unit.INSTANCE;
+			});
+		}
 		mPager = view.findViewById(R.id.viewPager);
 		mPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
 			@Override
@@ -303,6 +307,11 @@ public class ServiceListPager extends BaseHttpFragment {
 		if (mLocationsAndTagsJob != null) {
 			mLocationsAndTagsJob.cancel(null);
 			mLocationsAndTagsJob = null;
+		}
+		if (mDestinationNav != null) {
+			mDestinationNav.setVisibility(View.GONE);
+			mDestinationNav.disposeComposition();
+			mDestinationNav = null;
 		}
 		super.onDestroyView();
 	}

--- a/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesScreen.kt
@@ -1,6 +1,7 @@
 package net.reichholf.dreamdroid.ui.services
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -79,7 +80,11 @@ fun TvMoviesDestinationBar(
     onDestinationSelected: (TvMoviesDestination) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    NavigationBar(modifier = modifier.fillMaxWidth()) {
+    // Hosted on MainActivity Coordinator which already fits system windows (#263/#264).
+    NavigationBar(
+        modifier = modifier.fillMaxWidth(),
+        windowInsets = WindowInsets(0, 0, 0, 0),
+    ) {
         TvMoviesDestination.entries.forEach { dest ->
             NavigationBarItem(
                 selected = dest == selected,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The TV / Radio / Movies / Timer destination bar on the services hub sat too far down (same class of bug as the clipped FABs in #263/#264).

`detail_view` uses `AppBarLayout.ScrollingViewBehavior` with `match_parent`, so content is taller than the visible area by ~AppBar height. Bottom chrome inside the fragment was pushed off-screen.

## Fix
- Host `tv_movies_nav` on the activity `CoordinatorLayout` with `layout_gravity="bottom"` (phone + tablet dualpane).
- Reserve bar height in `service_list_pager` so the ViewPager is not covered.
- `ServiceListPager` shows/binds the shell bar and hides + `disposeComposition` on `onDestroyView`.
- Destination `NavigationBar` uses zero window insets (host already fits system windows).
- Instrumented layout test asserts bottom gravity on the shell ComposeView.

## Verification
- `bash .cursor/cloud/connected-test.sh net.reichholf.dreamdroid.widget.DualpaneFabLayoutTest,net.reichholf.dreamdroid.ui.services.TvMoviesScreenTest` — OK (3 tests)
- Manual look: destination labels fully on-screen (bounds bottom ~1815 / 1920); tap TV→Radio→Movies→Timer→TV

[Hub bottom nav fully visible](https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhub-bottom-nav.png)
[hub-bottom-nav-demo.mp4](https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhub-bottom-nav-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d78fcfb-6d8f-495c-aa22-e100c0ec351f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

