### PR TITLE
Phase 2.1e: hub ServiceListPager leaf on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -17,5 +17,6 @@
     <item name="phone_nav_profiles_slot" type="id"/>
     <item name="phone_nav_epg_slot" type="id"/>
     <item name="phone_nav_remote_slot" type="id"/>
+    <item name="phone_nav_hub_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -18,7 +18,7 @@ import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
 
 /**
  * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
- * Migrated drawer leaves include Device Info through Profiles and EPG. Drawer selection uses
+ * Migrated drawer leaves include Device Info through hub (`ServiceListPager`). Drawer selection uses
  * [navigateToRoute] when this host is already shown; [ARG_START_ROUTE] picks the first leaf.
  *
  * [net.reichholf.dreamdroid.activities.abs.BaseActivity] only delivers [onActivityResult] to
@@ -118,6 +118,9 @@ class PhoneNavHostFragment : BaseFragment() {
             PhoneNavRoutes.REMOTE ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_remote_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.REMOTE)
+            PhoneNavRoutes.HUB ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_hub_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.HUB)
             else -> null
         }
     }

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -188,6 +188,8 @@ public class ServiceListPager extends BaseHttpFragment {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		// Nested under PhoneNavHostFragment (non-retained); keep hub non-retained too.
+		mShouldRetainInstance = false;
 		mHasFabReload = false;
 		mBouquets = null;
 		mHubState = new TvMoviesHubState();

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPager.java
@@ -187,9 +187,9 @@ public class ServiceListPager extends BaseHttpFragment {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
 		// Nested under PhoneNavHostFragment (non-retained); keep hub non-retained too.
 		mShouldRetainInstance = false;
+		super.onCreate(savedInstanceState);
 		mHasFabReload = false;
 		mBouquets = null;
 		mHubState = new TvMoviesHubState();

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -20,7 +20,6 @@ import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.MyPreferenceFragment;
-import net.reichholf.dreamdroid.fragment.ServiceListPager;
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment;
 import net.reichholf.dreamdroid.ui.about.AboutComposeDialog;
 import net.reichholf.dreamdroid.fragment.dialogs.PowerStateDialog;
@@ -182,8 +181,7 @@ public class NavigationHelper {
         Intent intent;
         switch (itemId) {
             case R.id.menu_navigation_services:
-                clearBackStack();
-                getMainActivity().showDetails(ServiceListPager.class);
+                navigatePhoneNavRoot(PhoneNavRoutes.HUB);
                 break;
 
             case R.id.menu_navigation_device_info:

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -24,14 +24,15 @@ import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
+import net.reichholf.dreamdroid.fragment.ServiceListPager
 import net.reichholf.dreamdroid.fragment.SignalFragment
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment
 import net.reichholf.dreamdroid.fragment.ZapFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Migrated drawer leaves through EPG and tablet Virtual Remote.
- * Hub (`ServiceListPager`) and phone-only remote activity still use NavigationHelper.
+ * Phone shell [NavHost]. Migrated drawer leaves through hub (`ServiceListPager`)
+ * and tablet Virtual Remote. Phone-only remote still uses a side activity.
  */
 @Composable
 fun PhoneNavHost(
@@ -122,6 +123,14 @@ fun PhoneNavHost(
                 containerId = R.id.phone_nav_remote_slot,
                 routeTag = PhoneNavRoutes.REMOTE,
                 createFragment = { VirtualRemotePagerFragment() },
+            )
+        }
+        composable(PhoneNavRoutes.HUB) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_hub_slot,
+                routeTag = PhoneNavRoutes.HUB,
+                createFragment = { ServiceListPager() },
             )
         }
     }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -14,4 +14,5 @@ object PhoneNavRoutes {
     const val PROFILES = "profiles"
     const val EPG = "epg"
     const val REMOTE = "remote"
+    const val HUB = "hub"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -104,7 +104,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-backup-leaf | [#265](https://github.com/sreichholf/dreamDroid/pull/265) | merged | Phase 2.1e continued: Backup drawer root on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-profiles-leaf | [#266](https://github.com/sreichholf/dreamDroid/pull/266) | merged | Phase 2.1e continued: Profiles drawer root on `PhoneNavHost` (still clears drawer selection). Keep OkHttp 3.14.9. |
 | navhost-epg-leaf | [#267](https://github.com/sreichholf/dreamDroid/pull/267) | merged | Phase 2.1e continued: EPG bouquet drawer root on `PhoneNavHost` with service ref/name extras. Keep OkHttp 3.14.9. |
-| navhost-remote-leaf | this PR | open | Phase 2.1e continued: tablet Virtual Remote on `PhoneNavHost`; phone still side activity. Keep OkHttp 3.14.9. |
+| navhost-remote-leaf | [#269](https://github.com/sreichholf/dreamDroid/pull/269) | merged | Phase 2.1e continued: tablet Virtual Remote on `PhoneNavHost`; phone still side activity. Keep OkHttp 3.14.9. |
+| navhost-hub-leaf | this PR | open | Phase 2.1e continued: hub `ServiceListPager` on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -130,7 +131,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through EPG) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#267](https://github.com/sreichholf/dreamDroid/pull/267); tablet remote leaf **this PR**.
+- Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through tablet remote) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#269](https://github.com/sreichholf/dreamDroid/pull/269); hub leaf **this PR**.
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
 - Phase 2.2c Current Service coroutines **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215).
@@ -168,9 +169,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.3e hash-heavy `@State` **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251).
 - Phase 2.3f Bridge/Evernote drop **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) — Phase 2.3 complete.
 - Phase 2.1b NavHost dive **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254).
-- Phase 2.1c–e through EPG **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#267](https://github.com/sreichholf/dreamDroid/pull/267).
-- **This PR** = tablet Virtual Remote leaf on `PhoneNavHost` (phone keeps side activity).
-- Out of wave still: widgets (2.6); hub `ServiceListPager` / nested routes. See Appendix H.
+- Phase 2.1c–e through tablet remote **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#269](https://github.com/sreichholf/dreamDroid/pull/269).
+- **This PR** = hub `ServiceListPager` leaf on `PhoneNavHost`.
+- Out of wave still: widgets (2.6); nested routes / phone remote. See Appendix H.
 
 ## How to read this
 
@@ -604,7 +605,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through EPG **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#267](https://github.com/sreichholf/dreamDroid/pull/267); **this PR** = tablet remote; then hub / widgets (2.6).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H: NavHost through tablet remote **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#269](https://github.com/sreichholf/dreamDroid/pull/269); **this PR** = hub; then widgets (2.6).
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -683,7 +684,7 @@ One program each, still one PR (or small PR series) at a time:
 | Order | Program | What |
 | --- | --- | --- |
 | 1a | Drawer chrome (Compose) | Replace `NavigationView` menu with Compose `DrawerScreen` in `ComposeView`; keep XML profile header, `DrawerLayout`, fragment `detail_view`, and `NavigationHelper.navigateTo`. `res/menu/navigation.xml` kept for destination ids. **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). |
-| 1b | Drawer Navigation | Through EPG leaf **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#267](https://github.com/sreichholf/dreamDroid/pull/267). Tablet remote **this PR**. |
+| 1b | Drawer Navigation | Through tablet remote **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#269](https://github.com/sreichholf/dreamDroid/pull/269). Hub **this PR**. |
 | 2a | HTTP / async — Device Info | `DeviceInfoFragment` → `lifecycleScope` + suspend `EnigmaClient.getDeviceInfo()`; delete `GetDeviceInfoTask`. **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213). Keep `SimpleHttpClient`/`HttpURLConnection`. |
 | 2b | HTTP / async — Signal | `SignalFragment` poll → `lifecycleScope` + suspend `EnigmaClient.getSignal()`; delete `GetSignalTask`; keep generation guards. **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214). |
 | 2c | HTTP / async — Current Service | `CurrentServiceFragment` → `lifecycleScope` + suspend `EnigmaClient.getCurrent()`; delete `GetCurrentServiceTask`. **merged** [#215](https://github.com/sreichholf/dreamDroid/pull/215). |
@@ -793,7 +794,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.3e | Hash-heavy fragments | **merged** [#251](https://github.com/sreichholf/dreamDroid/pull/251) |
 | 2.3f | MultiChoiceDialog + delete Evernote/Bridge | **merged** [#252](https://github.com/sreichholf/dreamDroid/pull/252) |
 
-### Phase 2.1b — NavHost / Compose Navigation (through EPG [#267](https://github.com/sreichholf/dreamDroid/pull/267); tablet remote this PR)
+### Phase 2.1b — NavHost / Compose Navigation (through tablet remote [#269](https://github.com/sreichholf/dreamDroid/pull/269); hub this PR)
 
 #### Chassis (current)
 
@@ -812,7 +813,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Backup leaf | `PhoneNavRoutes.BACKUP` + nested `BackupFragment` | **merged** [#265](https://github.com/sreichholf/dreamDroid/pull/265) |
 | Profiles leaf | `PhoneNavRoutes.PROFILES` + nested `ProfileListFragment` | **merged** [#266](https://github.com/sreichholf/dreamDroid/pull/266) (still clears drawer selection) |
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
-| Tablet remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | **this PR** (phone still side activity) |
+| Tablet remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269) (phone still side activity) |
+| Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **this PR** |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -820,7 +822,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info through EPG + tablet remote) while `NavigationHelper` still drives hub via Fragments and phone remote via side activity. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info through hub + tablet remote) while `NavigationHelper` still drives phone remote via side activity. Keep `DrawerLayout` + profile header. Keep DialogFragments and side activities initially. Do **not** fold `VideoActivity` into the phone graph.
 
 #### Proposed PR slices
 
@@ -829,17 +831,17 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1b | Docs dive | **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254) |
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
-| 2.1e | More drawer roots (leaves before `ServiceListPager`) | Through EPG **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#267](https://github.com/sreichholf/dreamDroid/pull/267); tablet remote **this PR**; hub later |
+| 2.1e | More drawer roots | Through tablet remote **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#269](https://github.com/sreichholf/dreamDroid/pull/269); hub **this PR** |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
 #### Explicit non-goals of this PR
 
-- No hub / `ServiceListPager` on NavHost
 - No phone remote activity convergence (stays `SimpleNoTitleFragmentActivity`)
 - No VideoActivity / widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
+- No nested typed routes (2.1f)
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -853,7 +855,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through EPG **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#267](https://github.com/sreichholf/dreamDroid/pull/267). **This PR:** tablet Virtual Remote on NavHost. Next Appendix H: hub `ServiceListPager` / widgets (2.6) — one PR at a time.
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through tablet remote **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#269](https://github.com/sreichholf/dreamDroid/pull/269). **This PR:** hub `ServiceListPager` on NavHost. Next Appendix H: widgets (2.6) — one PR at a time.
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `PhoneNavRoutes.HUB` with nested `ServiceListPager` on the phone NavHost graph.
- Drawer Live & Movie uses `navigatePhoneNavRoot(HUB)` (phone and tablet).
- Disable `ServiceListPager` retain under the non-retained NavHost.
- Docs: mark tablet remote [#269](https://github.com/sreichholf/dreamDroid/pull/269) merged; this slice = hub.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Drawer → Live & Movie opens hub in NavHost
- [ ] Switch drawer destinations and return to hub (in-graph navigate)
- [ ] Hub tabs TV/Radio/Movies/Timer still work; rotation keeps mode/bouquet where saved
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

