### PR TITLE
Phase 2.1f: nested service EPG typed route on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -18,5 +18,6 @@
     <item name="phone_nav_epg_slot" type="id"/>
     <item name="phone_nav_remote_slot" type="id"/>
     <item name="phone_nav_hub_slot" type="id"/>
+    <item name="phone_nav_service_epg_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -6,6 +6,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavHostController
@@ -15,6 +16,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
+import net.reichholf.dreamdroid.ui.nav.navigateToServiceEpg
 
 /**
  * Hosts Compose [androidx.navigation.compose.NavHost] in the phone detail pane.
@@ -50,6 +52,12 @@ class PhoneNavHostFragment : BaseFragment() {
     @Volatile
     private var navController: NavHostController? = null
 
+    private val backCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            navController?.popBackStack()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         mShouldRetainInstance = false
         super.onCreate(savedInstanceState)
@@ -67,6 +75,11 @@ class PhoneNavHostFragment : BaseFragment() {
             )
             bindPhoneNavHost(this@PhoneNavHostFragment)
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
     }
 
     fun startRoute(): String {
@@ -90,48 +103,56 @@ class PhoneNavHostFragment : BaseFragment() {
     /** Nested destination fragment for the current NavHost route (if any). */
     fun getActiveLeaf(): Fragment? {
         val route = navController?.currentDestination?.route ?: startRoute()
-        return when (route) {
-            PhoneNavRoutes.DEVICE_INFO ->
+        return when {
+            route == PhoneNavRoutes.DEVICE_INFO ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_device_info_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.DEVICE_INFO)
-            PhoneNavRoutes.SIGNAL ->
+            route == PhoneNavRoutes.SIGNAL ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_signal_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.SIGNAL)
-            PhoneNavRoutes.SCREENSHOT ->
+            route == PhoneNavRoutes.SCREENSHOT ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_screenshot_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.SCREENSHOT)
-            PhoneNavRoutes.CURRENT ->
+            route == PhoneNavRoutes.CURRENT ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_current_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.CURRENT)
-            PhoneNavRoutes.ZAP ->
+            route == PhoneNavRoutes.ZAP ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_zap_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.ZAP)
-            PhoneNavRoutes.BACKUP ->
+            route == PhoneNavRoutes.BACKUP ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_backup_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.BACKUP)
-            PhoneNavRoutes.PROFILES ->
+            route == PhoneNavRoutes.PROFILES ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_profiles_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.PROFILES)
-            PhoneNavRoutes.EPG ->
+            route == PhoneNavRoutes.EPG ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_epg_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG)
-            PhoneNavRoutes.REMOTE ->
+            route == PhoneNavRoutes.REMOTE ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_remote_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.REMOTE)
-            PhoneNavRoutes.HUB ->
+            route == PhoneNavRoutes.HUB ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_hub_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.HUB)
+            route == PhoneNavRoutes.SERVICE_EPG || route.startsWith("service_epg") ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_service_epg_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.SERVICE_EPG)
             else -> null
         }
     }
 
     fun attachNavController(controller: NavHostController) {
         navController = controller
+        controller.addOnDestinationChangedListener { _, _, _ ->
+            backCallback.isEnabled = controller.previousBackStackEntry != null
+        }
+        backCallback.isEnabled = controller.previousBackStackEntry != null
     }
 
     fun detachNavController(controller: NavHostController) {
         if (navController === controller) {
             navController = null
+            backCallback.isEnabled = false
         }
     }
 
@@ -176,6 +197,16 @@ class PhoneNavHostFragment : BaseFragment() {
             return true
         }
         controller.navigateDrawerRoot(PhoneNavRoutes.EPG)
+        return true
+    }
+
+    /**
+     * Push nested service EPG onto the NavHost back stack (hub → service EPG).
+     * Typed string args; back pops to the previous drawer leaf.
+     */
+    fun navigateToServiceEpg(serviceReference: String?, serviceName: String?): Boolean {
+        val controller = navController ?: return false
+        controller.navigateToServiceEpg(serviceReference.orEmpty(), serviceName)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceEpgListFragment.java
@@ -52,8 +52,17 @@ public class ServiceEpgListFragment extends BaseHttpRecyclerEventFragment {
 		mRefreshState = new ComposeRefreshState();
 		initTitle(getString(R.string.epg));
 
-		mReference = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE);
-		mName = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME);
+		Bundle args = getArguments();
+		if (args != null) {
+			mReference = args.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE);
+			mName = args.getString(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME);
+		}
+		if (mReference == null) {
+			mReference = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE);
+		}
+		if (mName == null) {
+			mName = getDataForKey(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME);
+		}
 	}
 
 	@Nullable

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -19,6 +19,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
+import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 
 import net.reichholf.dreamdroid.DreamDroid;
@@ -361,6 +362,14 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 	 * @param nam The name of the Service for the reference
 	 */
 	public void openEpg(String ref, String nam) {
+		Fragment parent = getParentFragment();
+		while (parent != null) {
+			if (parent instanceof PhoneNavHostFragment) {
+				((PhoneNavHostFragment) parent).navigateToServiceEpg(ref, nam);
+				return;
+			}
+			parent = parent.getParentFragment();
+		}
 		ServiceEpgListFragment f = new ServiceEpgListFragment();
 		ExtendedHashMap map = new ExtendedHashMap();
 		map.put(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE, ref);

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -154,7 +154,7 @@ fun PhoneNavHost(
             NestedFragmentDestination(
                 hostFragment = hostFragment,
                 containerId = R.id.phone_nav_service_epg_slot,
-                routeTag = PhoneNavRoutes.SERVICE_EPG,
+                routeTag = "service_epg:$serviceRef",
                 createFragment = {
                     ServiceEpgListFragment().apply {
                         arguments = Bundle().apply {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -193,9 +193,9 @@ private fun NestedFragmentDestination(
 }
 
 /**
- * Mount [createFragment] under the host when missing. Never uses
- * `commitNowAllowingStateLoss`; if the child FM has already saved state, defer via
- * [android.view.View.post] until a safe window (e.g. after rotation restore).
+ * Mount [createFragment] under the host when missing or when [routeTag] changed
+ * (parameterized nested destinations). Never uses `commitNowAllowingStateLoss`;
+ * if the child FM has already saved state, defer via [android.view.View.post].
  */
 internal fun ensureNestedFragment(
     hostFragment: Fragment,
@@ -205,7 +205,8 @@ internal fun ensureNestedFragment(
 ) {
     if (!hostFragment.isAdded) return
     val fm = hostFragment.childFragmentManager
-    if (fm.findFragmentById(containerId) != null) return
+    val existing = fm.findFragmentById(containerId)
+    if (existing != null && existing.tag == routeTag) return
     if (!fm.isStateSaved) {
         commitNestedFragment(fm, containerId, routeTag, createFragment)
         return
@@ -213,7 +214,9 @@ internal fun ensureNestedFragment(
     hostFragment.view?.post {
         if (!hostFragment.isAdded) return@post
         val childFm = hostFragment.childFragmentManager
-        if (childFm.findFragmentById(containerId) != null || childFm.isStateSaved) return@post
+        if (childFm.isStateSaved) return@post
+        val still = childFm.findFragmentById(containerId)
+        if (still != null && still.tag == routeTag) return@post
         commitNestedFragment(childFm, containerId, routeTag, createFragment)
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -1,5 +1,7 @@
 package net.reichholf.dreamdroid.ui.nav
 
+import android.net.Uri
+import android.os.Bundle
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -13,9 +15,11 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.BackupFragment
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment
@@ -24,15 +28,17 @@ import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
+import net.reichholf.dreamdroid.fragment.ServiceEpgListFragment
 import net.reichholf.dreamdroid.fragment.ServiceListPager
 import net.reichholf.dreamdroid.fragment.SignalFragment
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment
 import net.reichholf.dreamdroid.fragment.ZapFragment
+import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Migrated drawer leaves through hub (`ServiceListPager`)
- * and tablet Virtual Remote. Phone-only remote still uses a side activity.
+ * Phone shell [NavHost]. Drawer leaves through hub; nested service EPG is the 2.1f beachhead.
+ * Phone-only remote still uses a side activity.
  */
 @Composable
 fun PhoneNavHost(
@@ -133,6 +139,32 @@ fun PhoneNavHost(
                 createFragment = { ServiceListPager() },
             )
         }
+        composable(
+            route = PhoneNavRoutes.SERVICE_EPG,
+            arguments = listOf(
+                navArgument(PhoneNavRoutes.ARG_SERVICE_REF) { type = NavType.StringType },
+                navArgument(PhoneNavRoutes.ARG_SERVICE_NAME) {
+                    type = NavType.StringType
+                    defaultValue = ""
+                },
+            ),
+        ) { entry ->
+            val serviceRef = entry.arguments?.getString(PhoneNavRoutes.ARG_SERVICE_REF).orEmpty()
+            val serviceName = entry.arguments?.getString(PhoneNavRoutes.ARG_SERVICE_NAME).orEmpty()
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_service_epg_slot,
+                routeTag = PhoneNavRoutes.SERVICE_EPG,
+                createFragment = {
+                    ServiceEpgListFragment().apply {
+                        arguments = Bundle().apply {
+                            putString(Event.KEY_SERVICE_REFERENCE, serviceRef)
+                            putString(Event.KEY_SERVICE_NAME, serviceName)
+                        }
+                    }
+                },
+            )
+        }
     }
 }
 
@@ -206,6 +238,13 @@ fun NavHostController.navigateDrawerRoot(route: String) {
         launchSingleTop = true
         restoreState = true
     }
+}
+
+/** Nested service EPG: push onto the NavHost back stack (back returns to hub). */
+fun NavHostController.navigateToServiceEpg(serviceRef: String, serviceName: String?) {
+    val route = "service_epg/${Uri.encode(serviceRef)}" +
+        "?serviceName=${Uri.encode(serviceName.orEmpty())}"
+    navigate(route)
 }
 
 fun ComposeView.bindPhoneNavHost(hostFragment: PhoneNavHostFragment) {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -15,4 +15,10 @@ object PhoneNavRoutes {
     const val EPG = "epg"
     const val REMOTE = "remote"
     const val HUB = "hub"
+
+    /** Nested service EPG (typed string args). */
+    const val SERVICE_EPG = "service_epg/{serviceRef}?serviceName={serviceName}"
+
+    const val ARG_SERVICE_REF = "serviceRef"
+    const val ARG_SERVICE_NAME = "serviceName"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -110,7 +110,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-hub-leaf | [#270](https://github.com/sreichholf/dreamDroid/pull/270) | merged | Phase 2.1e continued: hub `ServiceListPager` on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | widgets-2-6-dive | [#271](https://github.com/sreichholf/dreamDroid/pull/271) | merged | Phase 2.6: widgets product decision (keep XML RemoteViews; no Glance rewrite this program). Keep OkHttp 3.14.9. |
 | widgets-2-6b-cleanup | [#272](https://github.com/sreichholf/dreamDroid/pull/272) | merged | Phase 2.6b: Kotlin coroutine widget click path (drop JobIntentService); prefs delete `isFull`; remove dead SyncService/`HttpIntentService`. Keep OkHttp 3.14.9. |
-| anchor-popup-kotlin | this PR | open | Convert `AnchorPopup` to Kotlin; retab `WidgetRemoteRequest.kt` to match appwidget tabs. Keep OkHttp 3.14.9. |
+| anchor-popup-kotlin | [#273](https://github.com/sreichholf/dreamDroid/pull/273) | merged | Convert `AnchorPopup` to Kotlin; retab `WidgetRemoteRequest.kt`. Keep OkHttp 3.14.9. |
+| navhost-service-epg | this PR | open | Phase 2.1f beachhead: nested service EPG typed route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -875,6 +876,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
 | Tablet remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269) (phone still side activity) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
+| Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **this PR** (2.1f beachhead) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -892,7 +894,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
-| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Prefer typed args over hash Bundles |
+| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **This PR:** service EPG beachhead. Search / pick later. Prefer typed args over hash Bundles |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
@@ -915,7 +917,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). **This PR:** `AnchorPopup` → Kotlin. Optional next: 2.6c / 2.1f–h / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). **This PR:** 2.1f service-EPG nested typed route. Optional next: EPG search / pick-service / 2.1g–h / Phase 4–5 (operator).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.1f beachhead:** nested `SERVICE_EPG` route with typed `serviceRef` / `serviceName` args.
- Hub `openEpg` navigates inside `PhoneNavHost` (back pops to hub); falls back to `showDetails` if host missing.
- `ServiceEpgListFragment` reads plain Bundle strings first, then legacy hash `sData`.
- Host `OnBackPressedCallback` pops NavController when nested.

## Non-goals
- EPG search / pick-service nested routes (later 2.1f slices)
- Phone remote activity (2.1h)

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Hub → service EPG opens in NavHost; system back returns to hub
- [ ] Drawer switch while on service EPG still works
- [ ] Legacy `showDetails` path still works if host not present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

