### PR TITLE
Phase 2.1f: nested EPG search typed route on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -19,5 +19,6 @@
     <item name="phone_nav_remote_slot" type="id"/>
     <item name="phone_nav_hub_slot" type="id"/>
     <item name="phone_nav_service_epg_slot" type="id"/>
+    <item name="phone_nav_epg_search_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -786,6 +786,11 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 	 */
 	@Override
 	public boolean onQueryTextSubmit(String query) {
+		Fragment detail = getCurrentDetailFragment();
+		if (detail instanceof PhoneNavHostFragment
+				&& ((PhoneNavHostFragment) detail).navigateToEpgSearch(query)) {
+			return true;
+		}
 		Bundle args = new Bundle();
 		args.putString(SearchManager.QUERY, query);
 		Fragment f = new EpgSearchFragment();

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -217,11 +217,32 @@ class PhoneNavHostFragment : BaseFragment() {
     /**
      * Push nested EPG search onto the NavHost back stack.
      * Typed query string; back pops to the previous leaf.
+     * Resubmitting the same query remounts the leaf so results reload.
      */
     fun navigateToEpgSearch(query: String?): Boolean {
         val controller = navController ?: return false
         val q = query.orEmpty()
         if (q.isEmpty()) return false
+        val existing = childFragmentManager.findFragmentById(R.id.phone_nav_epg_search_slot)
+            ?: childFragmentManager.findFragmentByTag("epg_search:$q")
+        val onSearch = controller.currentDestination?.route == PhoneNavRoutes.EPG_SEARCH
+            || controller.currentDestination?.route?.startsWith("epg_search") == true
+        if (existing != null && !childFragmentManager.isStateSaved) {
+            childFragmentManager.beginTransaction().remove(existing).commitNow()
+        }
+        if (onSearch && !childFragmentManager.isStateSaved) {
+            childFragmentManager.beginTransaction()
+                .replace(
+                    R.id.phone_nav_epg_search_slot,
+                    EpgSearchFragment().apply {
+                        arguments = Bundle().apply {
+                            putString(android.app.SearchManager.QUERY, q)
+                        }
+                    },
+                    "epg_search:$q",
+                )
+                .commitNow()
+        }
         controller.navigateToEpgSearch(q)
         return true
     }

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -16,6 +16,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
+import net.reichholf.dreamdroid.ui.nav.navigateToEpgSearch
 import net.reichholf.dreamdroid.ui.nav.navigateToServiceEpg
 
 /**
@@ -137,6 +138,9 @@ class PhoneNavHostFragment : BaseFragment() {
             route == PhoneNavRoutes.SERVICE_EPG || route.startsWith("service_epg") ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_service_epg_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.SERVICE_EPG)
+            route == PhoneNavRoutes.EPG_SEARCH || route.startsWith("epg_search") ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_epg_search_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG_SEARCH)
             else -> null
         }
     }
@@ -207,6 +211,18 @@ class PhoneNavHostFragment : BaseFragment() {
     fun navigateToServiceEpg(serviceReference: String?, serviceName: String?): Boolean {
         val controller = navController ?: return false
         controller.navigateToServiceEpg(serviceReference.orEmpty(), serviceName)
+        return true
+    }
+
+    /**
+     * Push nested EPG search onto the NavHost back stack.
+     * Typed query string; back pops to the previous leaf.
+     */
+    fun navigateToEpgSearch(query: String?): Boolean {
+        val controller = navController ?: return false
+        val q = query.orEmpty()
+        if (q.isEmpty()) return false
+        controller.navigateToEpgSearch(q)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -29,6 +29,7 @@ import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
 import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IHttpBase;
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap;
@@ -260,9 +261,18 @@ public class HttpFragmentHelper {
     }
 
     public void findSimilarEvents(@NonNull ExtendedHashMap event) {
+        String query = event.getString(Event.KEY_EVENT_TITLE);
+        Fragment walker = mFragment;
+        while (walker != null) {
+            if (walker instanceof PhoneNavHostFragment
+                    && ((PhoneNavHostFragment) walker).navigateToEpgSearch(query)) {
+                return;
+            }
+            walker = walker.getParentFragment();
+        }
         EpgSearchFragment f = new EpgSearchFragment();
         Bundle args = new Bundle();
-        args.putString(SearchManager.QUERY, event.getString(Event.KEY_EVENT_TITLE));
+        args.putString(SearchManager.QUERY, query);
         f.setArguments(args);
 
         MultiPaneHandler m = (MultiPaneHandler) getAppCompatActivity();

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -272,9 +272,11 @@ fun NavHostController.navigateToServiceEpg(serviceRef: String, serviceName: Stri
     navigate(route)
 }
 
-/** Nested EPG search: push onto the NavHost back stack. */
+/** Nested EPG search: push onto the NavHost back stack (singleTop avoids duplicate same query). */
 fun NavHostController.navigateToEpgSearch(query: String) {
-    navigate("epg_search/${Uri.encode(query)}")
+    navigate("epg_search/${Uri.encode(query)}") {
+        launchSingleTop = true
+    }
 }
 
 fun ComposeView.bindPhoneNavHost(hostFragment: PhoneNavHostFragment) {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -1,5 +1,6 @@
 package net.reichholf.dreamdroid.ui.nav
 
+import android.app.SearchManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.ViewGroup
@@ -25,6 +26,7 @@ import net.reichholf.dreamdroid.fragment.BackupFragment
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
 import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
+import net.reichholf.dreamdroid.fragment.EpgSearchFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
@@ -37,8 +39,8 @@ import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Drawer leaves through hub; nested service EPG is the 2.1f beachhead.
- * Phone-only remote still uses a side activity.
+ * Phone shell [NavHost]. Drawer leaves through hub; nested service EPG and EPG search
+ * are the 2.1f beachheads. Phone-only remote still uses a side activity.
  */
 @Composable
 fun PhoneNavHost(
@@ -165,6 +167,26 @@ fun PhoneNavHost(
                 },
             )
         }
+        composable(
+            route = PhoneNavRoutes.EPG_SEARCH,
+            arguments = listOf(
+                navArgument(PhoneNavRoutes.ARG_QUERY) { type = NavType.StringType },
+            ),
+        ) { entry ->
+            val query = entry.arguments?.getString(PhoneNavRoutes.ARG_QUERY).orEmpty()
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_epg_search_slot,
+                routeTag = "epg_search:$query",
+                createFragment = {
+                    EpgSearchFragment().apply {
+                        arguments = Bundle().apply {
+                            putString(SearchManager.QUERY, query)
+                        }
+                    }
+                },
+            )
+        }
     }
 }
 
@@ -248,6 +270,11 @@ fun NavHostController.navigateToServiceEpg(serviceRef: String, serviceName: Stri
     val route = "service_epg/${Uri.encode(serviceRef)}" +
         "?serviceName=${Uri.encode(serviceName.orEmpty())}"
     navigate(route)
+}
+
+/** Nested EPG search: push onto the NavHost back stack. */
+fun NavHostController.navigateToEpgSearch(query: String) {
+    navigate("epg_search/${Uri.encode(query)}")
 }
 
 fun ComposeView.bindPhoneNavHost(hostFragment: PhoneNavHostFragment) {

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -19,6 +19,10 @@ object PhoneNavRoutes {
     /** Nested service EPG (typed string args). */
     const val SERVICE_EPG = "service_epg/{serviceRef}?serviceName={serviceName}"
 
+    /** Nested EPG search (typed query string). */
+    const val EPG_SEARCH = "epg_search/{query}"
+
     const val ARG_SERVICE_REF = "serviceRef"
     const val ARG_SERVICE_NAME = "serviceName"
+    const val ARG_QUERY = "query"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -111,7 +111,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | widgets-2-6-dive | [#271](https://github.com/sreichholf/dreamDroid/pull/271) | merged | Phase 2.6: widgets product decision (keep XML RemoteViews; no Glance rewrite this program). Keep OkHttp 3.14.9. |
 | widgets-2-6b-cleanup | [#272](https://github.com/sreichholf/dreamDroid/pull/272) | merged | Phase 2.6b: Kotlin coroutine widget click path (drop JobIntentService); prefs delete `isFull`; remove dead SyncService/`HttpIntentService`. Keep OkHttp 3.14.9. |
 | anchor-popup-kotlin | [#273](https://github.com/sreichholf/dreamDroid/pull/273) | merged | Convert `AnchorPopup` to Kotlin; retab `WidgetRemoteRequest.kt`. Keep OkHttp 3.14.9. |
-| navhost-service-epg | this PR | open | Phase 2.1f beachhead: nested service EPG typed route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-service-epg | [#274](https://github.com/sreichholf/dreamDroid/pull/274) | merged | Phase 2.1f beachhead: nested service EPG typed route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-epg-search | this PR | open | Phase 2.1f continued: nested EPG search typed query route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -876,7 +877,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
 | Tablet remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269) (phone still side activity) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
-| Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **this PR** (2.1f beachhead) |
+| Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
+| EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **this PR** |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -894,7 +896,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
-| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **This PR:** service EPG beachhead. Search / pick later. Prefer typed args over hash Bundles |
+| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Service EPG **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274). **This PR:** EPG search. Pick-service later. |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
@@ -917,7 +919,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). **This PR:** 2.1f service-EPG nested typed route. Optional next: EPG search / pick-service / 2.1g–h / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Service EPG nested **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274). **This PR:** nested EPG search. Optional next: pick-service / 2.1g–h / Phase 4–5 (operator).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.1f continued:** nested `EPG_SEARCH` route with typed `query` arg.
- Toolbar search (`MainActivity.onQueryTextSubmit`) and `findSimilarEvents` use NavHost when present; fallback `showDetails` kept.
- Remount on query change via `routeTag = epg_search:$query`.

## Non-goals
- Pick-service nested route (later)
- Phone remote (2.1h)

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Toolbar EPG search opens in NavHost; back returns to prior leaf
- [ ] Find-similar from hub/event detail uses NavHost when hosted
- [ ] Fallback `showDetails` still works without host
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

