### PR TITLE
Phase 2.1f: nested bouquet pick on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -20,5 +20,6 @@
     <item name="phone_nav_hub_slot" type="id"/>
     <item name="phone_nav_service_epg_slot" type="id"/>
     <item name="phone_nav_epg_search_slot" type="id"/>
+    <item name="phone_nav_pick_service_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
+import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.datepicker.MaterialDatePicker;
@@ -314,6 +315,14 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 
 	private void pickBouquet() {
 		mWaitingForPicker = true;
+		Fragment parent = getParentFragment();
+		while (parent != null) {
+			if (parent instanceof PhoneNavHostFragment) {
+				((PhoneNavHostFragment) parent).navigateToPickBouquet(Statics.REQUEST_PICK_BOUQUET);
+				return;
+			}
+			parent = parent.getParentFragment();
+		}
 		PickServiceFragment f = new PickServiceFragment();
 		Bundle args = new Bundle();
 

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -53,6 +53,8 @@ class PhoneNavHostFragment : BaseFragment() {
     @Volatile
     private var navController: NavHostController? = null
 
+    private var pickRequestCode: Int = -1
+
     private val backCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
             navController?.popBackStack()
@@ -141,6 +143,9 @@ class PhoneNavHostFragment : BaseFragment() {
             route == PhoneNavRoutes.EPG_SEARCH || route.startsWith("epg_search") ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_epg_search_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.EPG_SEARCH)
+            route == PhoneNavRoutes.PICK_SERVICE ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_pick_service_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.PICK_SERVICE)
             else -> null
         }
     }
@@ -245,6 +250,34 @@ class PhoneNavHostFragment : BaseFragment() {
         }
         controller.navigateToEpgSearch(q)
         return true
+    }
+
+    /**
+     * Push nested bouquet picker onto the NavHost back stack.
+     * Result is delivered via [deliverPickResult] when the picker finishes.
+     */
+    fun navigateToPickBouquet(requestCode: Int): Boolean {
+        val controller = navController ?: return false
+        pickRequestCode = requestCode
+        controller.navigate(PhoneNavRoutes.PICK_SERVICE)
+        return true
+    }
+
+    /**
+     * Pop the nested picker and forward [onActivityResult] to the prior leaf
+     * (Zap / EPG bouquet). Used instead of [Fragment.setTargetFragment] under NavHost.
+     */
+    fun deliverPickResult(resultCode: Int, data: Intent?) {
+        val controller = navController ?: return
+        val code = pickRequestCode
+        pickRequestCode = -1
+        if (!controller.popBackStack()) return
+        view?.post {
+            val leaf = getActiveLeaf()
+            if (code >= 0 && leaf != null && data != null) {
+                leaf.onActivityResult(code, resultCode, data)
+            }
+        }
     }
 
     @Deprecated("Deprecated in Java")

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -31,6 +31,7 @@ class PhoneNavHostFragment : BaseFragment() {
 
     companion object {
         const val ARG_START_ROUTE = "phone_nav_start_route"
+        private const val STATE_PICK_REQUEST_CODE = "phone_nav_pick_request_code"
 
         @JvmStatic
         fun newInstance(startRoute: String): PhoneNavHostFragment {
@@ -64,6 +65,14 @@ class PhoneNavHostFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         mShouldRetainInstance = false
         super.onCreate(savedInstanceState)
+        if (savedInstanceState != null) {
+            pickRequestCode = savedInstanceState.getInt(STATE_PICK_REQUEST_CODE, -1)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_PICK_REQUEST_CODE, pickRequestCode)
     }
 
     override fun onCreateView(

--- a/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
+import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 
 import net.reichholf.dreamdroid.DreamDroid;
@@ -269,6 +270,14 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 
 	private void pickBouquet() {
 		mWaitingForPicker = true;
+		Fragment parent = getParentFragment();
+		while (parent != null) {
+			if (parent instanceof PhoneNavHostFragment) {
+				((PhoneNavHostFragment) parent).navigateToPickBouquet(Statics.REQUEST_PICK_BOUQUET);
+				return;
+			}
+			parent = parent.getParentFragment();
+		}
 		PickServiceFragment f = new PickServiceFragment();
 		Bundle args = new Bundle();
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/FragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/FragmentHelper.java
@@ -19,6 +19,7 @@ import android.view.View;
 
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IBaseFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IMutliPaneContent;
 import net.reichholf.dreamdroid.helpers.Statics;
@@ -98,6 +99,14 @@ public class FragmentHelper {
 	}
 
 	public void finish(int resultCode, @Nullable Intent data) {
+		Fragment walker = mFragment.getParentFragment();
+		while (walker != null) {
+			if (walker instanceof PhoneNavHostFragment) {
+				((PhoneNavHostFragment) walker).deliverPickResult(resultCode, data);
+				return;
+			}
+			walker = walker.getParentFragment();
+		}
 		MultiPaneHandler mph = ((IMutliPaneContent) mFragment).getMultiPaneHandler();
 		if (mph.isMultiPane()) {
 			boolean explicitShow = false;

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -28,6 +28,7 @@ import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
 import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
 import net.reichholf.dreamdroid.fragment.EpgSearchFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
+import net.reichholf.dreamdroid.fragment.PickServiceFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
 import net.reichholf.dreamdroid.fragment.ServiceEpgListFragment
@@ -35,12 +36,15 @@ import net.reichholf.dreamdroid.fragment.ServiceListPager
 import net.reichholf.dreamdroid.fragment.SignalFragment
 import net.reichholf.dreamdroid.fragment.VirtualRemotePagerFragment
 import net.reichholf.dreamdroid.fragment.ZapFragment
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.Event
+import net.reichholf.dreamdroid.helpers.enigma2.Service
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Drawer leaves through hub; nested service EPG and EPG search
- * are the 2.1f beachheads. Phone-only remote still uses a side activity.
+ * Phone shell [NavHost]. Drawer leaves through hub; nested service EPG, EPG search,
+ * and bouquet pick are the 2.1f beachheads. Phone-only remote still uses a side activity.
  */
 @Composable
 fun PhoneNavHost(
@@ -182,6 +186,23 @@ fun PhoneNavHost(
                     EpgSearchFragment().apply {
                         arguments = Bundle().apply {
                             putString(SearchManager.QUERY, query)
+                        }
+                    }
+                },
+            )
+        }
+        composable(PhoneNavRoutes.PICK_SERVICE) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_pick_service_slot,
+                routeTag = PhoneNavRoutes.PICK_SERVICE,
+                createFragment = {
+                    PickServiceFragment().apply {
+                        arguments = Bundle().apply {
+                            val data = ExtendedHashMap()
+                            data.put(Service.KEY_REFERENCE, "default")
+                            putSerializable("data", data)
+                            putString("action", Statics.INTENT_ACTION_PICK_BOUQUET)
                         }
                     }
                 },

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -25,4 +25,7 @@ object PhoneNavRoutes {
     const val ARG_SERVICE_REF = "serviceRef"
     const val ARG_SERVICE_NAME = "serviceName"
     const val ARG_QUERY = "query"
+
+    /** Nested bouquet/service picker (Zap / EPG bouquet). */
+    const val PICK_SERVICE = "pick_service"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -112,7 +112,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | widgets-2-6b-cleanup | [#272](https://github.com/sreichholf/dreamDroid/pull/272) | merged | Phase 2.6b: Kotlin coroutine widget click path (drop JobIntentService); prefs delete `isFull`; remove dead SyncService/`HttpIntentService`. Keep OkHttp 3.14.9. |
 | anchor-popup-kotlin | [#273](https://github.com/sreichholf/dreamDroid/pull/273) | merged | Convert `AnchorPopup` to Kotlin; retab `WidgetRemoteRequest.kt`. Keep OkHttp 3.14.9. |
 | navhost-service-epg | [#274](https://github.com/sreichholf/dreamDroid/pull/274) | merged | Phase 2.1f beachhead: nested service EPG typed route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
-| navhost-epg-search | this PR | open | Phase 2.1f continued: nested EPG search typed query route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-epg-search | [#275](https://github.com/sreichholf/dreamDroid/pull/275) | merged | Phase 2.1f continued: nested EPG search typed query route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
+| navhost-pick-service | this PR | open | Phase 2.1f continued: nested bouquet pick on `PhoneNavHost` (host delivers result; no setTargetFragment). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -878,7 +879,8 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Tablet remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269) (phone still side activity) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
-| EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **this PR** |
+| EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275) |
+| Bouquet pick nested | `PhoneNavRoutes.PICK_SERVICE` | **this PR** (host `deliverPickResult`) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via `targetFragment` / `onActivityResult` |
 | Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Phone remote → `SimpleNoTitleFragmentActivity`; **tablet** remote stays in-host via `showDetails` |
@@ -896,7 +898,7 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1c | Beachhead: `navigation-compose` + Device Info leaf | **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255) |
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
-| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Service EPG **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274). **This PR:** EPG search. Pick-service later. |
+| 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | Service EPG **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274); EPG search **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275). **This PR:** bouquet pick. |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
 | 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | No OkHttp 4; no widgets; no Media3 |
 
@@ -919,7 +921,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Service EPG nested **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274). **This PR:** nested EPG search. Optional next: pick-service / 2.1g–h / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Nested service EPG / EPG search **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)/[#275](https://github.com/sreichholf/dreamDroid/pull/275). **This PR:** nested bouquet pick. Optional next: 2.1g–h / Phase 4–5 (operator).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.1f continued:** nested `PICK_SERVICE` route for bouquet pick (Zap / EPG bouquet).
- Host stores request code (persisted across config change); `FragmentHelper.finish` under NavHost calls `deliverPickResult` (pop + `onActivityResult` to prior leaf).
- Fallback `setTargetFragment` + `showDetails` when host is missing.

## Non-goals
- Timer service pick activity path
- Phone remote (2.1h) / dialog policy (2.1g)

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Zap → pick bouquet → select → Zap reloads; back without select returns to Zap
- [ ] Drawer EPG → pick bouquet same flow
- [ ] Rotate on picker, then select — result still delivered
- [ ] Fallback showDetails path still works without host
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

