### PR TITLE
Phase 2.1g: keep fragment dialogs (docs decision)

### DIFF
--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -114,7 +114,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-service-epg | [#274](https://github.com/sreichholf/dreamDroid/pull/274) | merged | Phase 2.1f beachhead: nested service EPG typed route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-epg-search | [#275](https://github.com/sreichholf/dreamDroid/pull/275) | merged | Phase 2.1f continued: nested EPG search typed query route on `PhoneNavHost`. Keep OkHttp 3.14.9. |
 | navhost-pick-service | [#276](https://github.com/sreichholf/dreamDroid/pull/276) | merged | Phase 2.1f continued: nested bouquet pick on `PhoneNavHost` (host delivers result; no setTargetFragment). Keep OkHttp 3.14.9. |
-| navhost-phone-remote | this PR | open | Phase 2.1h beachhead: phone Virtual Remote on `PhoneNavHost` (same as tablet); drop `SimpleNoTitleFragmentActivity`. Keep OkHttp 3.14.9. |
+| navhost-phone-remote | [#277](https://github.com/sreichholf/dreamDroid/pull/277) | merged | Phase 2.1h beachhead: phone Virtual Remote on `PhoneNavHost` (same as tablet); drop `SimpleNoTitleFragmentActivity`. Keep OkHttp 3.14.9. |
+| docs-dialog-policy | this PR | open | Phase 2.1g: dialog policy decision (keep fragment dialogs; no NavHost promotion). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -181,8 +182,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.1c–e through hub **merged** [#255](https://github.com/sreichholf/dreamDroid/pull/255)–[#270](https://github.com/sreichholf/dreamDroid/pull/270).
 - Phase 2.6a widgets decision **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271); 2.6b **merged** [#272](https://github.com/sreichholf/dreamDroid/pull/272).
 - Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276).
-- **This PR** = Phase 2.1h beachhead: phone Virtual Remote on `PhoneNavHost`.
-- Out of wave still: optional 2.6c Compose config / 2.1g / further 2.1h / Phase 4–5 operator. See Appendix H.
+- Phase 2.1h beachhead phone Virtual Remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277).
+- **This PR** = Phase 2.1g dialog policy decision (keep fragment dialogs).
+- Out of wave still: optional 2.6c Compose config / further 2.1h (settings / edit side activities) / Phase 4–5 operator. See Appendix H.
 
 ## How to read this
 
@@ -878,19 +880,19 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Backup leaf | `PhoneNavRoutes.BACKUP` + nested `BackupFragment` | **merged** [#265](https://github.com/sreichholf/dreamDroid/pull/265) |
 | Profiles leaf | `PhoneNavRoutes.PROFILES` + nested `ProfileListFragment` | **merged** [#266](https://github.com/sreichholf/dreamDroid/pull/266) (still clears drawer selection) |
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
-| Remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | Tablet **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269); phone **this PR** (2.1h beachhead) |
+| Remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | Tablet **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269); phone **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277) (2.1h beachhead) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
 | EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275) |
 | Bouquet pick nested | `PhoneNavRoutes.PICK_SERVICE` | **merged** [#276](https://github.com/sreichholf/dreamDroid/pull/276) (host `deliverPickResult`) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via host / `onActivityResult` |
-| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Remote is in-host on phone + tablet (**this PR**). |
+| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Settings / profile+timer edit / stream / Share. Remote in-host phone + tablet [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
 | Profiles | Profile header XML + first-start | Not in `DrawerScreen` / `navigation.xml`; opens `ProfileListFragment`, clears drawer selection |
 
 #### Agreed approach
 
-**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info through hub + remote on phone and tablet). Keep `DrawerLayout` + profile header. Keep DialogFragments and remaining side activities initially. Do **not** fold `VideoActivity` into the phone graph.
+**A → hybrid beachhead:** add `navigation-compose`; host `NavHost` inside existing `MainActivity` / `detail_view` via `PhoneNavHostFragment`; migrate leaves (Device Info through hub + remote on phone and tablet). Keep `DrawerLayout` + profile header. Keep DialogFragments (**2.1g decision**) and remaining side activities initially. Do **not** fold `VideoActivity` into the phone graph.
 
 #### Proposed PR slices
 
@@ -901,15 +903,78 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1d | Drawer → `NavController` for migrated roots; stop `clearBackStack`+`showDetails` for those | **merged** [#256](https://github.com/sreichholf/dreamDroid/pull/256) |
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276) |
-| 2.1g | Dialog policy (keep fragment dialogs or promote a few) | |
-| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | **This PR:** phone remote on NavHost; drop `SimpleNoTitleFragmentActivity`. Further: settings/dialogs still side activity; optional retire switch. No OkHttp 4; no widgets; no Media3 |
+| 2.1g | Dialog policy (keep fragment dialogs or promote a few) | **This PR:** decision A — keep fragment dialogs |
+| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Further: settings / profile+timer edit still side activity; optional retire switch. No OkHttp 4; no widgets; no Media3 |
 
 #### Explicit non-goals after 2.1e ([#270](https://github.com/sreichholf/dreamDroid/pull/270))
 
-- Phone remote side activity retired in 2.1h (**this PR**)
+- Phone remote side activity retired in 2.1h ([#277](https://github.com/sreichholf/dreamDroid/pull/277))
+- Dialogs stay FragmentDialogs / bottom sheets (2.1g **this PR**)
 - No VideoActivity / Glance widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
 - Nested typed routes done in 2.1f
+
+### Phase 2.1g — Dialog policy (this PR; docs only)
+
+**No dialog→NavHost code in this PR.** Implementation follow-ons are not required for this decision.
+
+#### Chassis (current)
+
+| Class | Path | Role |
+| --- | --- | --- |
+| `AbstractDialog` | `fragment/dialogs/AbstractDialog.java` | `DialogFragment`; retain-instance + destroy-view dismiss workaround |
+| `ActionDialog` | `fragment/dialogs/ActionDialog.java` | Extends `AbstractDialog`; `finishDialog` → activity `DialogActionListener` |
+| `AbstractBottomSheetDialog` / `BottomSheetActionDialog` | `fragment/dialogs/` | Bottom-sheet equivalents |
+| `MultiChoiceDialog` | `fragment/dialogs/MultiChoiceDialog.java` | Standalone `DialogFragment`; Bundle `boolean[]` (Phase 2.3f) |
+
+Host: `MainActivity` / `MultiPaneHandler.showDialogFragment`. Drawer tags in `MainActivity.NAVIGATION_DIALOG_TAGS` (`about_dialog`, `powerstate_dialog`, `sendmessage_dialog`, `sleeptimer_dialog`, `sleeptimer_progress_dialog`) route callbacks to `NavigationHelper`.
+
+#### Inventory — drawer / shell
+
+| Dialog | UI | Host |
+| --- | --- | --- |
+| `AboutComposeDialog` | Compose alert (`ui/about/AboutScreen.kt`) | Drawer About |
+| `SendMessageDialog` / `PowerStateDialog` / `SleepTimerDialog` | Compose | Drawer message / power / sleep |
+| `ChangelogDialog` | Compose + Markwon | Drawer changelog / `MainActivity.showChangeLog` |
+| `ConnectionErrorDialog` | Compose | Profile-check fail |
+| `PositiveNegativeDialog` | Material alert | Leave-confirm; also contextual deletes |
+
+#### Inventory — contextual
+
+| Dialog | UI | Typical hosts |
+| --- | --- | --- |
+| `EpgDetailBottomSheet` / `MovieDetailBottomSheet` | Compose sheets | Hub / EPG / movies / phone `VideoOverlayFragment` |
+| `MultiChoiceDialog` | Material multi-choice | Movies tags; timer edit |
+| `SimpleChoiceDialog` | Material list | Video overlay track pick |
+| `IndeterminateProgress` | Material progress | Profile device search |
+| Material date/time pickers | Material lib | EPG bouquet; timer edit |
+| Settings in-composition alerts | Compose | Settings side activity |
+
+#### Product options
+
+| Option | Idea | Pros | Cons |
+| --- | --- | --- | --- |
+| **A. Keep fragment dialogs** | Leave FM dialogs + Compose bodies | Zero UX/back-stack risk; matches Wave 3 Compose dialogs; small surface | `retainInstance` / listener chassis remains |
+| **B. Promote several to NavHost** | About / power / sleep / sheets as routes | Uniform navigation API | Fights modal semantics; rewires `ActionDialog` + overlay; large churn |
+| **C. Hybrid** | Promote “big” sheets only | Partial consistency | Two systems forever; unclear win |
+| **D. Defer indefinitely** | No decision | — | Leaves Appendix H open |
+
+#### Decision (Phase 2.1g — this PR)
+
+**Decision: option A** — keep fragment dialogs / bottom sheets. Do **not** promote drawer or contextual dialogs to `PhoneNavHost` routes (**B**/**C**) without a new operator ask.
+
+Why:
+
+- These are **modals**, not destinations; NavHost routes would fight dimming, back stack, and `ActionDialog` → `MainActivity` / `NavigationHelper` routing that already works.
+- Bodies are already Compose (Wave 3 / drawer-dialogs / detail sheets); remaining cost is chassis, not XML UI.
+- Phase 2.1 budget went to real leaves and side-activity retirement (through [#277](https://github.com/sreichholf/dreamDroid/pull/277)); dialog promotion is low leverage.
+
+**Revisit B/C later** only if a dialog becomes a full screen with deep links, or the `ActionDialog` / `retainInstance` chassis is retired as its own cleanup (not a NavHost migration).
+
+#### Explicit non-goals of this PR
+
+- No dialog→route code; no OkHttp 4; no VideoActivity fold; no Glance
+- Optional follow-ons stay under **2.1h** (settings / profile+timer edit side activities) or a separate chassis cleanup
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -923,7 +988,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). **This PR:** 2.1h beachhead phone remote on NavHost. Optional next: 2.1g / further 2.1h / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). **This PR:** 2.1g dialog policy (keep fragment dialogs). Optional next: further 2.1h (settings / edit side activities) / Phase 4–5 (operator).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.1g** dialog policy: **option A — keep fragment dialogs / bottom sheets**.
- Inventory of drawer + contextual dialog chassis (`AbstractDialog` / `ActionDialog` / sheets).
- Explicit non-goal: do not promote dialogs to `PhoneNavHost` routes.
- Docs: mark #277 phone remote merged; next optional work is further 2.1h (settings / edit side activities).

Docs only — no app code.

## Test plan
- [x] Docs-only change
- [ ] CI green (should be trivial)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

