### PR TITLE
Phase 2.1h: nested profile edit on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -22,5 +22,6 @@
     <item name="phone_nav_service_epg_slot" type="id"/>
     <item name="phone_nav_epg_search_slot" type="id"/>
     <item name="phone_nav_pick_service_slot" type="id"/>
+    <item name="phone_nav_profile_edit_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -10,7 +10,11 @@ import androidx.activity.OnBackPressedCallback
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavHostController
+import net.reichholf.dreamdroid.Profile
 import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment
+import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
 import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
@@ -32,6 +36,8 @@ class PhoneNavHostFragment : BaseFragment() {
     companion object {
         const val ARG_START_ROUTE = "phone_nav_start_route"
         private const val STATE_PICK_REQUEST_CODE = "phone_nav_pick_request_code"
+        private const val STATE_PROFILE_EDIT_ARGS = "phone_nav_profile_edit_args"
+        private const val STATE_PROFILE_EDIT_TAG = "phone_nav_profile_edit_tag"
 
         @JvmStatic
         fun newInstance(startRoute: String): PhoneNavHostFragment {
@@ -55,6 +61,8 @@ class PhoneNavHostFragment : BaseFragment() {
     private var navController: NavHostController? = null
 
     private var pickRequestCode: Int = -1
+    private var profileEditArgs: Bundle? = null
+    private var profileEditTag: String = PhoneNavRoutes.PROFILE_EDIT
 
     private val backCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
@@ -67,12 +75,16 @@ class PhoneNavHostFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {
             pickRequestCode = savedInstanceState.getInt(STATE_PICK_REQUEST_CODE, -1)
+            profileEditArgs = savedInstanceState.getBundle(STATE_PROFILE_EDIT_ARGS)
+            profileEditTag = savedInstanceState.getString(STATE_PROFILE_EDIT_TAG, PhoneNavRoutes.PROFILE_EDIT)
         }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putInt(STATE_PICK_REQUEST_CODE, pickRequestCode)
+        profileEditArgs?.let { outState.putBundle(STATE_PROFILE_EDIT_ARGS, it) }
+        outState.putString(STATE_PROFILE_EDIT_TAG, profileEditTag)
     }
 
     override fun onCreateView(
@@ -158,6 +170,9 @@ class PhoneNavHostFragment : BaseFragment() {
             route == PhoneNavRoutes.PICK_SERVICE ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_pick_service_slot)
                     ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.PICK_SERVICE)
+            route == PhoneNavRoutes.PROFILE_EDIT ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_profile_edit_slot)
+                    ?: childFragmentManager.findFragmentByTag(profileEditTag)
             else -> null
         }
     }
@@ -279,6 +294,54 @@ class PhoneNavHostFragment : BaseFragment() {
      * Pop the nested picker and forward [onActivityResult] to the prior leaf
      * (Zap / EPG bouquet). Used instead of [Fragment.setTargetFragment] under NavHost.
      */
+
+    fun profileEditRouteTag(): String = profileEditTag
+
+    fun profileEditLeafArguments(): Bundle {
+        return profileEditArgs ?: Bundle()
+    }
+
+    /**
+     * Push nested profile create/edit. Result goes through [deliverPickResult] with
+     * [Statics.REQUEST_EDIT_PROFILE] so [ProfileListFragment] can reload.
+     */
+    fun navigateToProfileEdit(profile: Profile?): Boolean {
+        val controller = navController ?: return false
+        pickRequestCode = Statics.REQUEST_EDIT_PROFILE
+        val data = ExtendedHashMap()
+        data.put("action", Intent.ACTION_EDIT)
+        if (profile != null) {
+            data.put("profile", profile)
+        }
+        profileEditArgs = Bundle().apply {
+            putSerializable(BaseHttpFragment.sData, data)
+        }
+        profileEditTag = if (profile != null) {
+            "profile_edit:${profile.id}"
+        } else {
+            "profile_edit:new"
+        }
+        val existing = childFragmentManager.findFragmentById(R.id.phone_nav_profile_edit_slot)
+            ?: childFragmentManager.findFragmentByTag(profileEditTag)
+        if (existing != null && !childFragmentManager.isStateSaved) {
+            childFragmentManager.beginTransaction().remove(existing).commitNow()
+        }
+        if (controller.currentDestination?.route == PhoneNavRoutes.PROFILE_EDIT) {
+            if (!childFragmentManager.isStateSaved) {
+                childFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.phone_nav_profile_edit_slot,
+                        ProfileEditFragment().apply { arguments = profileEditLeafArguments() },
+                        profileEditTag,
+                    )
+                    .commitNow()
+            }
+            return true
+        }
+        controller.navigate(PhoneNavRoutes.PROFILE_EDIT)
+        return true
+    }
+
     fun deliverPickResult(resultCode: Int, data: Intent?) {
         val controller = navController ?: return
         val code = pickRequestCode

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -349,7 +349,8 @@ class PhoneNavHostFragment : BaseFragment() {
         if (!controller.popBackStack()) return
         view?.post {
             val leaf = getActiveLeaf()
-            if (code >= 0 && leaf != null && data != null) {
+            // Profile edit finishes with a null Intent; bouquet pick sends extras.
+            if (code >= 0 && leaf != null) {
                 leaf.onActivityResult(code, resultCode, data)
             }
         }

--- a/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ProfileListFragment.java
@@ -30,6 +30,8 @@ import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.Profile;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import net.reichholf.dreamdroid.enigma.ProfileDetectLoadKt;
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.IndeterminateProgress;
@@ -356,6 +358,15 @@ public class ProfileListFragment extends BaseFragment {
 	}
 
 	public static void openProfileEditActivity(@NonNull Activity activity, @Nullable Profile profile) {
+		if (activity instanceof FragmentActivity) {
+			Fragment detail = ((FragmentActivity) activity).getSupportFragmentManager()
+					.findFragmentById(R.id.detail_view);
+			if (detail instanceof PhoneNavHostFragment
+					&& ((PhoneNavHostFragment) detail).navigateToProfileEdit(profile)) {
+				return;
+			}
+		}
+
 		ExtendedHashMap data = new ExtendedHashMap();
 		data.put("action", Intent.ACTION_EDIT);
 

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -30,6 +30,7 @@ import net.reichholf.dreamdroid.fragment.EpgSearchFragment
 import net.reichholf.dreamdroid.fragment.MyPreferenceFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.PickServiceFragment
+import net.reichholf.dreamdroid.fragment.ProfileEditFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
 import net.reichholf.dreamdroid.fragment.ServiceEpgListFragment
@@ -213,6 +214,18 @@ fun PhoneNavHost(
                             putSerializable("data", data)
                             putString("action", Statics.INTENT_ACTION_PICK_BOUQUET)
                         }
+                    }
+                },
+            )
+        }
+        composable(PhoneNavRoutes.PROFILE_EDIT) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_profile_edit_slot,
+                routeTag = hostFragment.profileEditRouteTag(),
+                createFragment = {
+                    ProfileEditFragment().apply {
+                        arguments = hostFragment.profileEditLeafArguments()
                     }
                 },
             )

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -29,4 +29,7 @@ object PhoneNavRoutes {
 
     /** Nested bouquet/service picker (Zap / EPG bouquet). */
     const val PICK_SERVICE = "pick_service"
+
+    /** Nested profile create/edit (args via host). */
+    const val PROFILE_EDIT = "profile_edit"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -116,7 +116,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-pick-service | [#276](https://github.com/sreichholf/dreamDroid/pull/276) | merged | Phase 2.1f continued: nested bouquet pick on `PhoneNavHost` (host delivers result; no setTargetFragment). Keep OkHttp 3.14.9. |
 | navhost-phone-remote | [#277](https://github.com/sreichholf/dreamDroid/pull/277) | merged | Phase 2.1h beachhead: phone Virtual Remote on `PhoneNavHost` (same as tablet); drop `SimpleNoTitleFragmentActivity`. Keep OkHttp 3.14.9. |
 | docs-dialog-policy | [#278](https://github.com/sreichholf/dreamDroid/pull/278) | merged | Phase 2.1g: dialog policy decision (keep fragment dialogs; no NavHost promotion). Keep OkHttp 3.14.9. |
-| navhost-settings-leaf | this PR | open | Phase 2.1h continued: Settings drawer root on `PhoneNavHost`; drop side-activity path. Keep OkHttp 3.14.9. |
+| navhost-settings-leaf | [#279](https://github.com/sreichholf/dreamDroid/pull/279) | merged | Phase 2.1h continued: Settings drawer root on `PhoneNavHost`; drop side-activity path. Keep OkHttp 3.14.9. |
+| navhost-profile-edit | this PR | open | Phase 2.1h continued: nested profile create/edit on `PhoneNavHost` (host delivers result). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -185,8 +186,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276).
 - Phase 2.1h beachhead phone Virtual Remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277).
 - Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) (keep fragment dialogs).
-- **This PR** = Phase 2.1h continued: Settings leaf on `PhoneNavHost`.
-- Out of wave still: optional 2.6c Compose config / further 2.1h (profile+timer edit side activities) / Phase 4–5 operator. See Appendix H.
+- Phase 2.1h Settings leaf **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279).
+- **This PR** = Phase 2.1h continued: nested profile edit on `PhoneNavHost`.
+- Out of wave still: optional 2.6c Compose config / further 2.1h (timer edit side activity) / Phase 4–5 operator. See Appendix H.
 
 ## How to read this
 
@@ -883,14 +885,15 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Profiles leaf | `PhoneNavRoutes.PROFILES` + nested `ProfileListFragment` | **merged** [#266](https://github.com/sreichholf/dreamDroid/pull/266) (still clears drawer selection) |
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
 | Remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | Tablet **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269); phone **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277) (2.1h beachhead) |
-| Settings leaf | `PhoneNavRoutes.SETTINGS` + nested `MyPreferenceFragment` | **this PR** (2.1h continued) |
+| Settings leaf | `PhoneNavRoutes.SETTINGS` + nested `MyPreferenceFragment` | **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279) |
+| Profile edit nested | `PhoneNavRoutes.PROFILE_EDIT` | **this PR** (host delivers result) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
 | EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275) |
 | Bouquet pick nested | `PhoneNavRoutes.PICK_SERVICE` | **merged** [#276](https://github.com/sreichholf/dreamDroid/pull/276) (host `deliverPickResult`) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via host / `onActivityResult` |
-| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Profile+timer edit / stream / Share. Settings in-host (**this PR**); remote in-host [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
+| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Timer edit / stream / Share. Settings [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit **this PR**; remote [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
 | Profiles | Profile header XML + first-start | Not in `DrawerScreen` / `navigation.xml`; opens `ProfileListFragment`, clears drawer selection |
 
 #### Agreed approach
@@ -907,12 +910,13 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276) |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) — decision A keep fragment dialogs |
-| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). **This PR:** Settings on NavHost. Further: profile+timer edit still side activity; optional retire switch. No OkHttp 4; no widgets; no Media3 |
+| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277); Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279). **This PR:** nested profile edit. Further: timer edit still side activity; optional retire switch. No OkHttp 4; no widgets; no Media3 |
 
 #### Explicit non-goals after 2.1e ([#270](https://github.com/sreichholf/dreamDroid/pull/270))
 
 - Phone remote side activity retired in 2.1h ([#277](https://github.com/sreichholf/dreamDroid/pull/277))
-- Settings side activity retired in 2.1h (**this PR**)
+- Settings side activity retired in 2.1h ([#279](https://github.com/sreichholf/dreamDroid/pull/279))
+- Profile edit nested in 2.1h (**this PR**)
 - Dialogs stay FragmentDialogs / bottom sheets ([#278](https://github.com/sreichholf/dreamDroid/pull/278))
 - No VideoActivity / Glance widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
@@ -978,7 +982,7 @@ Why:
 #### Explicit non-goals of this PR
 
 - No dialog→route code; no OkHttp 4; no VideoActivity fold; no Glance
-- Optional follow-ons stay under **2.1h** (profile+timer edit side activities) or a separate chassis cleanup
+- Optional follow-ons stay under **2.1h** (timer edit side activity) or a separate chassis cleanup
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -992,7 +996,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** Settings leaf on NavHost. Optional next: further 2.1h (profile+timer edit) / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** nested profile edit on NavHost. Optional next: further 2.1h (timer edit) / Phase 4–5 (operator). Phase 2.1h Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Nested `PROFILE_EDIT` route on `PhoneNavHost` hosting `ProfileEditFragment`.
- `PhoneNavHostFragment.navigateToProfileEdit` stores edit args/tag, remounts on re-edit, and reuses `deliverPickResult` so Profiles reloads after save.
- `ProfileListFragment.openProfileEditActivity` prefers in-host navigation; keeps `SimpleToolbarFragmentActivity` fallback (e.g. if NavHost not shown).
- Docs: mark Settings #279 merged; this PR = nested profile edit.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: Profiles → add/edit opens in-host; save reloads list; system back cancels; connection-error edit still works when host is shown
- [ ] Timer edit still uses side activity (unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

