### PR TITLE
Phase 2.1h: nested timer edit on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -23,5 +23,6 @@
     <item name="phone_nav_epg_search_slot" type="id"/>
     <item name="phone_nav_pick_service_slot" type="id"/>
     <item name="phone_nav_profile_edit_slot" type="id"/>
+    <item name="phone_nav_timer_edit_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -15,6 +15,8 @@ import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Statics
+import net.reichholf.dreamdroid.helpers.enigma2.Timer
+import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment
 import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
@@ -38,6 +40,8 @@ class PhoneNavHostFragment : BaseFragment() {
         private const val STATE_PICK_REQUEST_CODE = "phone_nav_pick_request_code"
         private const val STATE_PROFILE_EDIT_ARGS = "phone_nav_profile_edit_args"
         private const val STATE_PROFILE_EDIT_TAG = "phone_nav_profile_edit_tag"
+        private const val STATE_TIMER_EDIT_ARGS = "phone_nav_timer_edit_args"
+        private const val STATE_TIMER_EDIT_TAG = "phone_nav_timer_edit_tag"
 
         @JvmStatic
         fun newInstance(startRoute: String): PhoneNavHostFragment {
@@ -63,6 +67,8 @@ class PhoneNavHostFragment : BaseFragment() {
     private var pickRequestCode: Int = -1
     private var profileEditArgs: Bundle? = null
     private var profileEditTag: String = PhoneNavRoutes.PROFILE_EDIT
+    private var timerEditArgs: Bundle? = null
+    private var timerEditTag: String = PhoneNavRoutes.TIMER_EDIT
 
     private val backCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
@@ -77,6 +83,8 @@ class PhoneNavHostFragment : BaseFragment() {
             pickRequestCode = savedInstanceState.getInt(STATE_PICK_REQUEST_CODE, -1)
             profileEditArgs = savedInstanceState.getBundle(STATE_PROFILE_EDIT_ARGS)
             profileEditTag = savedInstanceState.getString(STATE_PROFILE_EDIT_TAG, PhoneNavRoutes.PROFILE_EDIT)
+            timerEditArgs = savedInstanceState.getBundle(STATE_TIMER_EDIT_ARGS)
+            timerEditTag = savedInstanceState.getString(STATE_TIMER_EDIT_TAG, PhoneNavRoutes.TIMER_EDIT)
         }
     }
 
@@ -85,6 +93,8 @@ class PhoneNavHostFragment : BaseFragment() {
         outState.putInt(STATE_PICK_REQUEST_CODE, pickRequestCode)
         profileEditArgs?.let { outState.putBundle(STATE_PROFILE_EDIT_ARGS, it) }
         outState.putString(STATE_PROFILE_EDIT_TAG, profileEditTag)
+        timerEditArgs?.let { outState.putBundle(STATE_TIMER_EDIT_ARGS, it) }
+        outState.putString(STATE_TIMER_EDIT_TAG, timerEditTag)
     }
 
     override fun onCreateView(
@@ -173,6 +183,9 @@ class PhoneNavHostFragment : BaseFragment() {
             route == PhoneNavRoutes.PROFILE_EDIT ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_profile_edit_slot)
                     ?: childFragmentManager.findFragmentByTag(profileEditTag)
+            route == PhoneNavRoutes.TIMER_EDIT ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_timer_edit_slot)
+                    ?: childFragmentManager.findFragmentByTag(timerEditTag)
             else -> null
         }
     }
@@ -339,6 +352,52 @@ class PhoneNavHostFragment : BaseFragment() {
             return true
         }
         controller.navigate(PhoneNavRoutes.PROFILE_EDIT)
+        return true
+    }
+
+
+    fun timerEditRouteTag(): String = timerEditTag
+
+    fun timerEditLeafArguments(): Bundle = timerEditArgs ?: Bundle()
+
+    /**
+     * Push nested timer create/edit. Service pick stays on [SimpleToolbarFragmentActivity].
+     * Result goes through [deliverPickResult] with [Statics.REQUEST_EDIT_TIMER].
+     */
+    fun navigateToTimerEdit(timer: ExtendedHashMap, create: Boolean): Boolean {
+        val controller = navController ?: return false
+        pickRequestCode = Statics.REQUEST_EDIT_TIMER
+        val data = ExtendedHashMap()
+        data.put("timer", timer)
+        data.put("action", if (create) DreamDroid.ACTION_CREATE else Intent.ACTION_EDIT)
+        timerEditArgs = Bundle().apply {
+            putSerializable(BaseHttpFragment.sData, data)
+        }
+        val ref = timer.getString(Timer.KEY_REFERENCE).orEmpty()
+        val begin = timer.getString(Timer.KEY_BEGIN).orEmpty()
+        timerEditTag = if (create) {
+            "timer_edit:new:$begin"
+        } else {
+            "timer_edit:$ref:$begin"
+        }
+        val existing = childFragmentManager.findFragmentById(R.id.phone_nav_timer_edit_slot)
+            ?: childFragmentManager.findFragmentByTag(timerEditTag)
+        if (existing != null && !childFragmentManager.isStateSaved) {
+            childFragmentManager.beginTransaction().remove(existing).commitNow()
+        }
+        if (controller.currentDestination?.route == PhoneNavRoutes.TIMER_EDIT) {
+            if (!childFragmentManager.isStateSaved) {
+                childFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.phone_nav_timer_edit_slot,
+                        TimerEditFragment().apply { arguments = timerEditLeafArguments() },
+                        timerEditTag,
+                    )
+                    .commitNow()
+            }
+            return true
+        }
+        controller.navigate(PhoneNavRoutes.TIMER_EDIT)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/Timer.java
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/Timer.java
@@ -16,6 +16,7 @@ import androidx.fragment.app.Fragment;
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.fragment.TimerEditFragment;
 import net.reichholf.dreamdroid.helpers.DateTime;
@@ -246,6 +247,15 @@ public class Timer {
 	 * @param create - set to true if a new timer should be created instead of editing an existing one
 	 */
 	public static void edit(MultiPaneHandler mph, ExtendedHashMap timer, @NonNull Fragment target, boolean create) {
+		Fragment walker = target.getParentFragment();
+		while (walker != null) {
+			if (walker instanceof PhoneNavHostFragment
+					&& ((PhoneNavHostFragment) walker).navigateToTimerEdit(timer, create)) {
+				return;
+			}
+			walker = walker.getParentFragment();
+		}
+
 		ExtendedHashMap data = new ExtendedHashMap();
 		data.put("timer", timer);
 		data.put("action", create ? DreamDroid.ACTION_CREATE : Intent.ACTION_EDIT);

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -31,6 +31,7 @@ import net.reichholf.dreamdroid.fragment.MyPreferenceFragment
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.PickServiceFragment
 import net.reichholf.dreamdroid.fragment.ProfileEditFragment
+import net.reichholf.dreamdroid.fragment.TimerEditFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
 import net.reichholf.dreamdroid.fragment.ServiceEpgListFragment
@@ -226,6 +227,18 @@ fun PhoneNavHost(
                 createFragment = {
                     ProfileEditFragment().apply {
                         arguments = hostFragment.profileEditLeafArguments()
+                    }
+                },
+            )
+        }
+        composable(PhoneNavRoutes.TIMER_EDIT) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_timer_edit_slot,
+                routeTag = hostFragment.timerEditRouteTag(),
+                createFragment = {
+                    TimerEditFragment().apply {
+                        arguments = hostFragment.timerEditLeafArguments()
                     }
                 },
             )

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -32,4 +32,7 @@ object PhoneNavRoutes {
 
     /** Nested profile create/edit (args via host). */
     const val PROFILE_EDIT = "profile_edit"
+
+    /** Nested timer create/edit (args via host). Service pick stays side activity. */
+    const val TIMER_EDIT = "timer_edit"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -117,7 +117,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-phone-remote | [#277](https://github.com/sreichholf/dreamDroid/pull/277) | merged | Phase 2.1h beachhead: phone Virtual Remote on `PhoneNavHost` (same as tablet); drop `SimpleNoTitleFragmentActivity`. Keep OkHttp 3.14.9. |
 | docs-dialog-policy | [#278](https://github.com/sreichholf/dreamDroid/pull/278) | merged | Phase 2.1g: dialog policy decision (keep fragment dialogs; no NavHost promotion). Keep OkHttp 3.14.9. |
 | navhost-settings-leaf | [#279](https://github.com/sreichholf/dreamDroid/pull/279) | merged | Phase 2.1h continued: Settings drawer root on `PhoneNavHost`; drop side-activity path. Keep OkHttp 3.14.9. |
-| navhost-profile-edit | this PR | open | Phase 2.1h continued: nested profile create/edit on `PhoneNavHost` (host delivers result). Keep OkHttp 3.14.9. |
+| navhost-profile-edit | [#280](https://github.com/sreichholf/dreamDroid/pull/280) | merged | Phase 2.1h continued: nested profile create/edit on `PhoneNavHost` (host delivers result). Keep OkHttp 3.14.9. |
+| navhost-timer-edit | this PR | open | Phase 2.1h continued: nested timer create/edit on `PhoneNavHost`; service pick stays side activity. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -187,8 +188,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.1h beachhead phone Virtual Remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277).
 - Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) (keep fragment dialogs).
 - Phase 2.1h Settings leaf **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279).
-- **This PR** = Phase 2.1h continued: nested profile edit on `PhoneNavHost`.
-- Out of wave still: optional 2.6c Compose config / further 2.1h (timer edit side activity) / Phase 4–5 operator. See Appendix H.
+- Phase 2.1h nested profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280).
+- **This PR** = Phase 2.1h continued: nested timer edit on `PhoneNavHost`.
+- Out of wave still: optional 2.6c Compose config / further 2.1h (timer service pick) / Phase 4–5 operator. See Appendix H.
 
 ## How to read this
 
@@ -886,14 +888,15 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | EPG leaf | `PhoneNavRoutes.EPG` + nested `EpgBouquetFragment` | **merged** [#267](https://github.com/sreichholf/dreamDroid/pull/267) (default bouquet ref/name extras) |
 | Remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | Tablet **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269); phone **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277) (2.1h beachhead) |
 | Settings leaf | `PhoneNavRoutes.SETTINGS` + nested `MyPreferenceFragment` | **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279) |
-| Profile edit nested | `PhoneNavRoutes.PROFILE_EDIT` | **this PR** (host delivers result) |
+| Profile edit nested | `PhoneNavRoutes.PROFILE_EDIT` | **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280) |
+| Timer edit nested | `PhoneNavRoutes.TIMER_EDIT` | **this PR** (service pick still side activity) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
 | EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275) |
 | Bouquet pick nested | `PhoneNavRoutes.PICK_SERVICE` | **merged** [#276](https://github.com/sreichholf/dreamDroid/pull/276) (host `deliverPickResult`) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via host / `onActivityResult` |
-| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Timer edit / stream / Share. Settings [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit **this PR**; remote [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
+| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Timer service pick / stream / Share. Settings [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit [#280](https://github.com/sreichholf/dreamDroid/pull/280); timer edit **this PR**; remote [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
 | Profiles | Profile header XML + first-start | Not in `DrawerScreen` / `navigation.xml`; opens `ProfileListFragment`, clears drawer selection |
 
 #### Agreed approach
@@ -910,13 +913,14 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276) |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) — decision A keep fragment dialogs |
-| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277); Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279). **This PR:** nested profile edit. Further: timer edit still side activity; optional retire switch. No OkHttp 4; no widgets; no Media3 |
+| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277); Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280). **This PR:** nested timer edit (service pick still side activity). Further: optional timer service pick / retire switch. No OkHttp 4; no widgets; no Media3 |
 
 #### Explicit non-goals after 2.1e ([#270](https://github.com/sreichholf/dreamDroid/pull/270))
 
 - Phone remote side activity retired in 2.1h ([#277](https://github.com/sreichholf/dreamDroid/pull/277))
 - Settings side activity retired in 2.1h ([#279](https://github.com/sreichholf/dreamDroid/pull/279))
-- Profile edit nested in 2.1h (**this PR**)
+- Profile edit nested in 2.1h ([#280](https://github.com/sreichholf/dreamDroid/pull/280))
+- Timer edit nested in 2.1h (**this PR**; service pick still side activity)
 - Dialogs stay FragmentDialogs / bottom sheets ([#278](https://github.com/sreichholf/dreamDroid/pull/278))
 - No VideoActivity / Glance widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
@@ -982,7 +986,7 @@ Why:
 #### Explicit non-goals of this PR
 
 - No dialog→route code; no OkHttp 4; no VideoActivity fold; no Glance
-- Optional follow-ons stay under **2.1h** (timer edit side activity) or a separate chassis cleanup
+- Optional follow-ons stay under **2.1h** (timer service pick) or a separate chassis cleanup
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -996,7 +1000,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** nested profile edit on NavHost. Optional next: further 2.1h (timer edit) / Phase 4–5 (operator). Phase 2.1h Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** nested timer edit on NavHost (service pick still side activity). Optional next: further 2.1h (timer service pick) / Phase 4–5 (operator). Profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Nest `TimerEditFragment` on `PhoneNavHost` via `TIMER_EDIT`.
- `Timer.edit` prefers in-host navigation when a parent `PhoneNavHostFragment` is present; keeps `SimpleToolbarFragmentActivity` fallback.
- **Out of scope:** `TimerServicePickFragment` stays on the side activity (avoids clobbering `pickRequestCode`).
- Docs: mark #280 merged; this PR = nested timer edit.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: Timers / EPG / Current → edit or new timer opens in-host; save/cancel pops; service pick still opens side activity and returns into the edit leaf
- [ ] Profile edit / settings / remote unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

