### PR TITLE
Slim the drawer and nest About/Changelog/Backup under Settings

### DIFF
--- a/.cursor/skills/verify-dreamdroid/SKILL.md
+++ b/.cursor/skills/verify-dreamdroid/SKILL.md
@@ -55,7 +55,7 @@ Pass only when an adb device is in `device` state, `net.reichholf.dreamdroid.deb
 
 ## Drive (optional look)
 
-Prefer resource ids and visible text over coordinates. `tap --text About` matches **Settings & About** first; scroll the drawer and match text exactly `About`.
+Prefer resource ids and visible text over coordinates. About lives at the bottom of Settings, not in the drawer.
 
 | User control | Handle |
 | --- | --- |
@@ -64,7 +64,7 @@ Prefer resource ids and visible text over coordinates. `tap --text About` matche
 | Profile name / status | `...:id/drawer_profile_name`, `...:id/drawer_profile_status` |
 | TV & Movies | text `TV & Movies` |
 | EPG / Virtual Remote / Zap / Current event | text `EPG`, `Virtual Remote`, `Zap`, `Current event` |
-| About | text `About` (opens a dialog) |
+| About | Settings, then text `About` (opens a dialog) |
 | Add Profile FAB | `...:id/fab_main` content-desc from `R.string.profile_add` (shell XML FAB) || Autodiscovery | text `Dreambox Autodiscovery` |
 | TV/Radio/Movies/Timer tabs | text `TV`, `Radio`, `Movies`, `Timer` |
 

--- a/.cursor/skills/verify-dreamdroid/features/README.md
+++ b/.cursor/skills/verify-dreamdroid/features/README.md
@@ -42,7 +42,7 @@ Keep implementation details out of the map. Name only user paths, stable handles
 ## Features
 
 - [Profiles](./profiles.md) covers first-start Profiles, the Demo row, Add Profile, and the drawer profile header.
-- [About](./about.md) covers the About dialog from the drawer (no receiver required).
+- [About](./about.md) covers the About dialog from Settings (no receiver required).
 - [TV and Movies](./tv-and-movies.md) covers drawer TV & Movies and the TV/Radio/Movies/Timer bar.
 - [Zap](./zap.md) covers the Zap screen and changing channel.
 - [Virtual Remote](./virtual-remote.md) covers opening the on-screen remote.

--- a/.cursor/skills/verify-dreamdroid/features/about.md
+++ b/.cursor/skills/verify-dreamdroid/features/about.md
@@ -4,12 +4,12 @@ About shows the installed version, the GPL notice, and the source link in a dial
 
 ## Sub-features
 
-- `about-open` opens the About dialog from the drawer.
+- `about-open` opens the About dialog from Settings.
 - `about-identity` shows a version string and `About` as the dialog title.
 
 ## How to get to it (user POV)
 
-- Open the navigation drawer and choose `About`.
+- Open the navigation drawer, choose `Settings`, then `About` at the bottom of the list.
 
 ## Driving it with verify-dreamdroid
 
@@ -19,10 +19,10 @@ Preconditions:
 - No Enigma2 box is required.
 
 - **Proof.** Run `./gradlew.bat :app:connectedGoogleDebugAndroidTest`. `AboutScreenTest` and `AboutDialogHostTest` must pass. Night `LocalContentColor` is asserted equal to `onSurface` (light) inside `DreamDroidTheme`, including when hosted in a Material night `AlertDialog`.
-- **Look (optional).** `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch`, open the drawer, tap text exactly `About` (not `Settings & About`), then `screenshot --path .cursor/skills/verify-dreamdroid/artifacts/about/screen.png`.
+- **Look (optional).** `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch`, open the drawer, tap `Settings`, scroll to `About`, then `screenshot --path .cursor/skills/verify-dreamdroid/artifacts/about/screen.png`.
 
 ## Gotchas
 
 - Instrumented tests are the pass criteria. A screenshot is not a substitute.
-- `tap --text About` matches **Settings & About** first. Scroll the drawer and match `About` exactly.
+- About is a Settings footer row, not a drawer destination.
 - Licenses is a separate button inside the dialog and is not this feature's pass criteria.

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
@@ -57,13 +57,10 @@ class DrawerScreenTest {
         var clicked = 0
         composeRule.setContent {
             DreamDroidTheme {
-                DrawerScreen(
-                    state = state,
-                    onItemClick = { id ->
-                        clicked = id
-                        state.select(id)
-                    },
-                )
+                DrawerScreen(state = state, onItemClick = { id ->
+                    clicked = id
+                    state.select(id)
+                })
             }
         }
 
@@ -79,12 +76,7 @@ class DrawerScreenTest {
         var clicked = 0
         composeRule.setContent {
             DreamDroidTheme {
-                DrawerScreen(
-                    state = state,
-                    onItemClick = { id ->
-                        clicked = id
-                    },
-                )
+                DrawerScreen(state = state, onItemClick = { clicked = it })
             }
         }
 
@@ -103,13 +95,10 @@ class DrawerScreenTest {
         var clicked = 0
         composeRule.setContent {
             DreamDroidTheme {
-                DrawerScreen(
-                    state = state,
-                    onItemClick = { id ->
-                        clicked = id
-                        state.select(id)
-                    },
-                )
+                DrawerScreen(state = state, onItemClick = { id ->
+                    clicked = id
+                    state.select(id)
+                })
             }
         }
 

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/drawer/DrawerScreenTest.kt
@@ -1,6 +1,7 @@
 package net.reichholf.dreamdroid.ui.drawer
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -28,7 +29,7 @@ class DrawerScreenTest {
     }
 
     @Test
-    fun showsSectionsAndItems() {
+    fun showsSectionsAndPinnedSettings() {
         val state = DrawerListState()
         composeRule.setContent {
             DreamDroidTheme {
@@ -36,12 +37,18 @@ class DrawerScreenTest {
             }
         }
 
+        composeRule.onNodeWithText("Power Control").assertIsDisplayed()
+        composeRule.onNodeWithText("Sleep Timer").assertIsDisplayed()
+        composeRule.onNodeWithText("Send Message").assertIsDisplayed()
         composeRule.onNodeWithText("Control").assertIsDisplayed()
         composeRule.onNodeWithText("Tools").assertIsDisplayed()
-        composeRule.onNodeWithText("Settings & About").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("TV & Movies").assertIsDisplayed()
         composeRule.onNodeWithText("Signal Meter").performScrollTo().assertIsDisplayed()
-        composeRule.onNodeWithText("Backup").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeRule.onNodeWithText("Settings & About").assertDoesNotExist()
+        composeRule.onNodeWithText("About").assertDoesNotExist()
+        composeRule.onNodeWithText("Backup").assertDoesNotExist()
+        composeRule.onNodeWithText("Changelog").assertDoesNotExist()
     }
 
     @Test
@@ -67,6 +74,52 @@ class DrawerScreenTest {
     }
 
     @Test
+    fun boxActionClickDoesNotStaySelected() {
+        val state = DrawerListState()
+        var clicked = 0
+        composeRule.setContent {
+            DreamDroidTheme {
+                DrawerScreen(
+                    state = state,
+                    onItemClick = { id ->
+                        clicked = id
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Power Control").performClick()
+        composeRule.waitForIdle()
+        assertEquals(R.id.menu_navigation_power, clicked)
+        composeRule.runOnIdle {
+            assertEquals(R.id.menu_none, state.selectedItemId)
+        }
+        composeRule.onNodeWithText("TV & Movies").assertIsNotSelected()
+    }
+
+    @Test
+    fun settingsRowSelects() {
+        val state = DrawerListState()
+        var clicked = 0
+        composeRule.setContent {
+            DreamDroidTheme {
+                DrawerScreen(
+                    state = state,
+                    onItemClick = { id ->
+                        clicked = id
+                        state.select(id)
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Settings").performClick()
+        composeRule.waitForIdle()
+        assertEquals(R.id.menu_navigation_settings, clicked)
+        composeRule.onNodeWithText("Settings").assertIsSelected()
+    }
+
+    @Test
     fun clearSelectionRemovesHighlight() {
         val state = DrawerListState()
         state.select(R.id.menu_navigation_services)
@@ -80,7 +133,6 @@ class DrawerScreenTest {
         composeRule.runOnIdle { state.clearSelection() }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("TV & Movies").assertIsDisplayed()
-        // After clear, no drawer destination should stay selected.
         composeRule.runOnIdle {
             assertEquals(R.id.menu_none, state.selectedItemId)
         }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/settings/SettingsScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/settings/SettingsScreenTest.kt
@@ -3,11 +3,13 @@ package net.reichholf.dreamdroid.ui.settings
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,5 +47,38 @@ class SettingsScreenTest {
         composeRule.onNodeWithText("Day/Night Theme choices").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Picons").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Use Picons").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("About").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Changelog").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Backup").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun footerRowsInvokeCallbacks() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val state = SettingsState.create(context)
+        var about = false
+        var changelog = false
+        var backup = false
+        composeRule.setContent {
+            DreamDroidTheme {
+                SettingsScreen(
+                    state = state,
+                    onThemeChanged = {},
+                    onDynamicColorsChanged = {},
+                    onSyncPicons = {},
+                    onAbout = { about = true },
+                    onChangelog = { changelog = true },
+                    onBackup = { backup = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("About").performScrollTo().performClick()
+        composeRule.onNodeWithText("Changelog").performScrollTo().performClick()
+        composeRule.onNodeWithText("Backup").performScrollTo().performClick()
+        composeRule.waitForIdle()
+        assertTrue(about)
+        assertTrue(changelog)
+        assertTrue(backup)
     }
 }

--- a/app/res/menu/navigation.xml
+++ b/app/res/menu/navigation.xml
@@ -31,20 +31,10 @@
                         android:icon="?attr/ic_menu_current"
                         android:title="@string/current_event"/>
                     <item
-                        android:id="@+id/menu_navigation_power"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_power_off"
-                        android:title="@string/powercontrol"/>
-                    <item
                         android:id="@+id/menu_navigation_zap"
                         android:checked="false"
                         android:icon="?attr/ic_menu_zap"
                         android:title="@string/zap"/>
-                    <item
-                        android:id="@+id/menu_navigation_sleeptimer"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_sleeptimer"
-                        android:title="@string/sleeptimer"/>
                 </group>
             </menu>
         </item>
@@ -64,11 +54,6 @@
                         android:icon="?attr/ic_menu_device"
                         android:title="@string/device_info"/>
                     <item
-                        android:id="@+id/menu_navigation_message"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_mail"
-                        android:title="@string/send_message"/>
-                    <item
                         android:id="@+id/menu_navigation_signal"
                         android:checked="false"
                         android:icon="?attr/ic_menu_signal"
@@ -77,32 +62,42 @@
             </menu>
         </item>
         <item
-            android:id="@+id/settings_about_header"
-            android:title="@string/settings_and_about">
-            <menu>
-                <group android:checkableBehavior="single">
-                    <item
-                        android:id="@+id/menu_navigation_settings"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_settings"
-                        android:title="@string/settings"/>
-                    <item
-                        android:id="@+id/menu_navigation_about"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_about"
-                        android:title="@string/about"/>
-                    <item
-                        android:id="@+id/menu_navigation_backup"
-                        android:checked="false"
-                        android:icon="?attr/ic_import_export"
-                        android:title="@string/backup"/>
-                    <item
-                        android:id="@+id/menu_navigation_changelog"
-                        android:checked="false"
-                        android:icon="?attr/ic_menu_changelog"
-                        android:title="@string/changelog"/>
-                </group>
-            </menu>
-        </item>
+            android:id="@+id/menu_navigation_settings"
+            android:checked="false"
+            android:icon="?attr/ic_menu_settings"
+            android:title="@string/settings"/>
+    </group>
+    <!-- Action ids used by the drawer box strip and Settings footer; not destinations. -->
+    <group android:checkableBehavior="none">
+        <item
+            android:id="@+id/menu_navigation_power"
+            android:icon="?attr/ic_menu_power_off"
+            android:title="@string/powercontrol"
+            android:visible="false"/>
+        <item
+            android:id="@+id/menu_navigation_sleeptimer"
+            android:icon="?attr/ic_menu_sleeptimer"
+            android:title="@string/sleeptimer"
+            android:visible="false"/>
+        <item
+            android:id="@+id/menu_navigation_message"
+            android:icon="?attr/ic_menu_mail"
+            android:title="@string/send_message"
+            android:visible="false"/>
+        <item
+            android:id="@+id/menu_navigation_about"
+            android:icon="?attr/ic_menu_about"
+            android:title="@string/about"
+            android:visible="false"/>
+        <item
+            android:id="@+id/menu_navigation_backup"
+            android:icon="?attr/ic_import_export"
+            android:title="@string/backup"
+            android:visible="false"/>
+        <item
+            android:id="@+id/menu_navigation_changelog"
+            android:icon="?attr/ic_menu_changelog"
+            android:title="@string/changelog"
+            android:visible="false"/>
     </group>
 </menu>

--- a/app/res/menu/navigation.xml
+++ b/app/res/menu/navigation.xml
@@ -67,37 +67,4 @@
             android:icon="?attr/ic_menu_settings"
             android:title="@string/settings"/>
     </group>
-    <!-- Action ids used by the drawer box strip and Settings footer; not destinations. -->
-    <group android:checkableBehavior="none">
-        <item
-            android:id="@+id/menu_navigation_power"
-            android:icon="?attr/ic_menu_power_off"
-            android:title="@string/powercontrol"
-            android:visible="false"/>
-        <item
-            android:id="@+id/menu_navigation_sleeptimer"
-            android:icon="?attr/ic_menu_sleeptimer"
-            android:title="@string/sleeptimer"
-            android:visible="false"/>
-        <item
-            android:id="@+id/menu_navigation_message"
-            android:icon="?attr/ic_menu_mail"
-            android:title="@string/send_message"
-            android:visible="false"/>
-        <item
-            android:id="@+id/menu_navigation_about"
-            android:icon="?attr/ic_menu_about"
-            android:title="@string/about"
-            android:visible="false"/>
-        <item
-            android:id="@+id/menu_navigation_backup"
-            android:icon="?attr/ic_import_export"
-            android:title="@string/backup"
-            android:visible="false"/>
-        <item
-            android:id="@+id/menu_navigation_changelog"
-            android:icon="?attr/ic_menu_changelog"
-            android:title="@string/changelog"
-            android:visible="false"/>
-    </group>
 </menu>

--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -6,6 +6,12 @@
     <item name="recyclerview_item_selection_support" type="id"/>
     <item name="fab_scrolling_view_behavior_enabled" type="id"/>
     <item name="menu_navigation_profiles" type="id"/>
+    <item name="menu_navigation_power" type="id"/>
+    <item name="menu_navigation_sleeptimer" type="id"/>
+    <item name="menu_navigation_message" type="id"/>
+    <item name="menu_navigation_about" type="id"/>
+    <item name="menu_navigation_backup" type="id"/>
+    <item name="menu_navigation_changelog" type="id"/>
     <item name="menu_cancel" type="id"/>
     <item name="menu_check_connectivity" type="id"/>
     <item name="phone_nav_device_info_slot" type="id"/>

--- a/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
@@ -18,14 +18,17 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.compose.ui.platform.ComposeView;
+import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.color.DynamicColors;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.activities.MainActivity;
 import net.reichholf.dreamdroid.activities.abs.BaseActivity;
 import net.reichholf.dreamdroid.fragment.abs.BaseFragment;
+import net.reichholf.dreamdroid.ui.about.AboutComposeDialog;
 import net.reichholf.dreamdroid.ui.settings.SettingsScreenKt;
 import net.reichholf.dreamdroid.ui.settings.SettingsState;
 
@@ -73,6 +76,21 @@ public class MyPreferenceFragment extends BaseFragment {
 			},
 			() -> {
 				startPiconSync();
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				getMultiPaneHandler().showDialogFragment(AboutComposeDialog.newInstance(), "about_dialog");
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				((MainActivity) getAppCompatActivity()).showChangeLog(false);
+				return kotlin.Unit.INSTANCE;
+			},
+			() -> {
+				Fragment parent = getParentFragment();
+				if (parent instanceof PhoneNavHostFragment) {
+					((PhoneNavHostFragment) parent).navigateToBackup();
+				}
 				return kotlin.Unit.INSTANCE;
 			}
 		);

--- a/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/MyPreferenceFragment.java
@@ -15,7 +15,6 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.compose.ui.platform.ComposeView;
 import androidx.fragment.app.Fragment;

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -237,10 +237,7 @@ class PhoneNavHostFragment : BaseFragment() {
         return true
     }
 
-    /**
-     * Push nested Backup onto the NavHost back stack (Settings → Backup).
-     * Back pops to Settings. Drawer selection stays on Settings.
-     */
+    /** Push nested Backup (Settings → Backup). Back returns to Settings. */
     fun navigateToBackup(): Boolean {
         val controller = navController ?: return false
         controller.navigateToBackup()

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -23,6 +23,8 @@ import net.reichholf.dreamdroid.helpers.enigma2.Event
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
+import net.reichholf.dreamdroid.ui.nav.navigateDrawerSettings
+import net.reichholf.dreamdroid.ui.nav.navigateToBackup
 import net.reichholf.dreamdroid.ui.nav.navigateToEpgSearch
 import net.reichholf.dreamdroid.ui.nav.navigateToServiceEpg
 
@@ -227,7 +229,21 @@ class PhoneNavHostFragment : BaseFragment() {
     fun navigateToRoute(route: String): Boolean {
         val controller = navController ?: return false
         resultRequestCodes.clear()
+        if (route == PhoneNavRoutes.SETTINGS) {
+            controller.navigateDrawerSettings()
+            return true
+        }
         controller.navigateDrawerRoot(route)
+        return true
+    }
+
+    /**
+     * Push nested Backup onto the NavHost back stack (Settings → Backup).
+     * Back pops to Settings. Drawer selection stays on Settings.
+     */
+    fun navigateToBackup(): Boolean {
+        val controller = navController ?: return false
+        controller.navigateToBackup()
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -64,7 +64,6 @@ public class NavigationHelper {
 		sNavRootRoutes.put(R.id.menu_navigation_profiles, PhoneNavRoutes.PROFILES);
 		sNavRootRoutes.put(R.id.menu_navigation_signal, PhoneNavRoutes.SIGNAL);
 		sNavRootRoutes.put(R.id.menu_navigation_zap, PhoneNavRoutes.ZAP);
-		sNavRootRoutes.put(R.id.menu_navigation_backup, PhoneNavRoutes.BACKUP);
 	}
 
     MainActivity mActivity;
@@ -248,6 +247,17 @@ public class NavigationHelper {
             case R.id.menu_navigation_epg:
                 navigateToEpg();
                 break;
+
+            case R.id.menu_navigation_backup: {
+                Fragment backupHost = getMainActivity().getSupportFragmentManager()
+                        .findFragmentById(R.id.detail_view);
+                if (backupHost instanceof PhoneNavHostFragment
+                        && ((PhoneNavHostFragment) backupHost).navigateToBackup()) {
+                    break;
+                }
+                navigatePhoneNavRoot(PhoneNavRoutes.BACKUP);
+                break;
+            }
         }
         getMainActivity().showContent();
         return !isDialogItem(itemId);

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java
@@ -252,9 +252,8 @@ public class NavigationHelper {
                 Fragment backupHost = getMainActivity().getSupportFragmentManager()
                         .findFragmentById(R.id.detail_view);
                 if (backupHost instanceof PhoneNavHostFragment
-                        && ((PhoneNavHostFragment) backupHost).navigateToBackup()) {
+                        && ((PhoneNavHostFragment) backupHost).navigateToBackup())
                     break;
-                }
                 navigatePhoneNavRoot(PhoneNavRoutes.BACKUP);
                 break;
             }

--- a/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
@@ -50,16 +50,15 @@ data class DrawerSection(
 )
 
 object DrawerDestinations {
-    val boxActions: List<DrawerMenuItem> = listOf(
+    val boxActions = listOf(
         DrawerMenuItem(R.id.menu_navigation_power, R.string.powercontrol, R.attr.ic_menu_power_off),
         DrawerMenuItem(R.id.menu_navigation_sleeptimer, R.string.sleeptimer, R.attr.ic_menu_sleeptimer),
         DrawerMenuItem(R.id.menu_navigation_message, R.string.send_message, R.attr.ic_menu_mail),
     )
-
-    val sections: List<DrawerSection> = listOf(
+    val sections = listOf(
         DrawerSection(
-            titleRes = R.string.control,
-            items = listOf(
+            R.string.control,
+            listOf(
                 DrawerMenuItem(R.id.menu_navigation_services, R.string.live_movie, R.attr.ic_menu_services),
                 DrawerMenuItem(R.id.menu_navigation_epg, R.string.epg, R.attr.ic_menu_epg),
                 DrawerMenuItem(R.id.menu_navigation_remote, R.string.virtual_remote, R.attr.ic_menu_remote),
@@ -68,19 +67,16 @@ object DrawerDestinations {
             ),
         ),
         DrawerSection(
-            titleRes = R.string.tools,
-            items = listOf(
+            R.string.tools,
+            listOf(
                 DrawerMenuItem(R.id.menu_navigation_screenshot, R.string.screenshot, R.attr.ic_menu_picture),
                 DrawerMenuItem(R.id.menu_navigation_device_info, R.string.device_info, R.attr.ic_menu_device),
                 DrawerMenuItem(R.id.menu_navigation_signal, R.string.signal_meter, R.attr.ic_menu_signal),
             ),
         ),
     )
-
-    val settings: DrawerMenuItem = DrawerMenuItem(
-        R.id.menu_navigation_settings,
-        R.string.settings,
-        R.attr.ic_menu_settings,
+    val settings = DrawerMenuItem(
+        R.id.menu_navigation_settings, R.string.settings, R.attr.ic_menu_settings,
     )
 }
 
@@ -106,19 +102,13 @@ private fun resolveThemeDrawable(@AttrRes attr: Int): Int {
 }
 
 @Composable
-private fun DrawerBoxActions(
-    onItemClick: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-) {
+private fun DrawerBoxActions(onItemClick: (Int) -> Unit, modifier: Modifier = Modifier) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+        modifier = modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
     ) {
         DrawerDestinations.boxActions.forEach { item ->
             val iconRes = resolveThemeDrawable(item.iconAttr)
-            val label = stringResource(item.titleRes)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
@@ -135,7 +125,7 @@ private fun DrawerBoxActions(
                     )
                 }
                 Text(
-                    text = label,
+                    text = stringResource(item.titleRes),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
@@ -153,6 +143,7 @@ private fun DrawerDestinationItem(
     item: DrawerMenuItem,
     selected: Boolean,
     onItemClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val iconRes = resolveThemeDrawable(item.iconAttr)
     NavigationDrawerItem(
@@ -161,10 +152,7 @@ private fun DrawerDestinationItem(
         onClick = { onItemClick(item.id) },
         icon = {
             if (iconRes != 0) {
-                Icon(
-                    painter = painterResource(iconRes),
-                    contentDescription = null,
-                )
+                Icon(painter = painterResource(iconRes), contentDescription = null)
             }
         },
         colors = NavigationDrawerItemDefaults.colors(
@@ -174,7 +162,7 @@ private fun DrawerDestinationItem(
             unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
             unselectedTextColor = MaterialTheme.colorScheme.onSurface,
         ),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     )
 }
 
@@ -198,9 +186,7 @@ fun DrawerScreen(
                     text = stringResource(section.titleRes),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
+                    modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
                 )
                 section.items.forEach { item ->
                     DrawerDestinationItem(
@@ -212,20 +198,16 @@ fun DrawerScreen(
             }
         }
         HorizontalDivider()
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-            DrawerDestinationItem(
-                item = DrawerDestinations.settings,
-                selected = state.selectedItemId == DrawerDestinations.settings.id,
-                onItemClick = onItemClick,
-            )
-        }
+        DrawerDestinationItem(
+            item = DrawerDestinations.settings,
+            selected = state.selectedItemId == DrawerDestinations.settings.id,
+            onItemClick = onItemClick,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+        )
     }
 }
 
-fun ComposeView.bindDrawerScreen(
-    state: DrawerListState,
-    onItemClick: (Int) -> Unit,
-) {
+fun ComposeView.bindDrawerScreen(state: DrawerListState, onItemClick: (Int) -> Unit) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
         DreamDroidTheme {

--- a/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/drawer/DrawerScreen.kt
@@ -3,12 +3,16 @@ package net.reichholf.dreamdroid.ui.drawer
 import android.util.TypedValue
 import androidx.annotation.AttrRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationDrawerItem
@@ -18,12 +22,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
@@ -40,6 +50,12 @@ data class DrawerSection(
 )
 
 object DrawerDestinations {
+    val boxActions: List<DrawerMenuItem> = listOf(
+        DrawerMenuItem(R.id.menu_navigation_power, R.string.powercontrol, R.attr.ic_menu_power_off),
+        DrawerMenuItem(R.id.menu_navigation_sleeptimer, R.string.sleeptimer, R.attr.ic_menu_sleeptimer),
+        DrawerMenuItem(R.id.menu_navigation_message, R.string.send_message, R.attr.ic_menu_mail),
+    )
+
     val sections: List<DrawerSection> = listOf(
         DrawerSection(
             titleRes = R.string.control,
@@ -48,9 +64,7 @@ object DrawerDestinations {
                 DrawerMenuItem(R.id.menu_navigation_epg, R.string.epg, R.attr.ic_menu_epg),
                 DrawerMenuItem(R.id.menu_navigation_remote, R.string.virtual_remote, R.attr.ic_menu_remote),
                 DrawerMenuItem(R.id.menu_navigation_current, R.string.current_event, R.attr.ic_menu_current),
-                DrawerMenuItem(R.id.menu_navigation_power, R.string.powercontrol, R.attr.ic_menu_power_off),
                 DrawerMenuItem(R.id.menu_navigation_zap, R.string.zap, R.attr.ic_menu_zap),
-                DrawerMenuItem(R.id.menu_navigation_sleeptimer, R.string.sleeptimer, R.attr.ic_menu_sleeptimer),
             ),
         ),
         DrawerSection(
@@ -58,19 +72,15 @@ object DrawerDestinations {
             items = listOf(
                 DrawerMenuItem(R.id.menu_navigation_screenshot, R.string.screenshot, R.attr.ic_menu_picture),
                 DrawerMenuItem(R.id.menu_navigation_device_info, R.string.device_info, R.attr.ic_menu_device),
-                DrawerMenuItem(R.id.menu_navigation_message, R.string.send_message, R.attr.ic_menu_mail),
                 DrawerMenuItem(R.id.menu_navigation_signal, R.string.signal_meter, R.attr.ic_menu_signal),
             ),
         ),
-        DrawerSection(
-            titleRes = R.string.settings_and_about,
-            items = listOf(
-                DrawerMenuItem(R.id.menu_navigation_settings, R.string.settings, R.attr.ic_menu_settings),
-                DrawerMenuItem(R.id.menu_navigation_about, R.string.about, R.attr.ic_menu_about),
-                DrawerMenuItem(R.id.menu_navigation_backup, R.string.backup, R.attr.ic_import_export),
-                DrawerMenuItem(R.id.menu_navigation_changelog, R.string.changelog, R.attr.ic_menu_changelog),
-            ),
-        ),
+    )
+
+    val settings: DrawerMenuItem = DrawerMenuItem(
+        R.id.menu_navigation_settings,
+        R.string.settings,
+        R.attr.ic_menu_settings,
     )
 }
 
@@ -96,51 +106,118 @@ private fun resolveThemeDrawable(@AttrRes attr: Int): Int {
 }
 
 @Composable
+private fun DrawerBoxActions(
+    onItemClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        DrawerDestinations.boxActions.forEach { item ->
+            val iconRes = resolveThemeDrawable(item.iconAttr)
+            val label = stringResource(item.titleRes)
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { role = Role.Button }
+                    .clickable { onItemClick(item.id) }
+                    .padding(horizontal = 4.dp, vertical = 8.dp),
+            ) {
+                if (iconRes != 0) {
+                    Icon(
+                        painter = painterResource(iconRes),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrawerDestinationItem(
+    item: DrawerMenuItem,
+    selected: Boolean,
+    onItemClick: (Int) -> Unit,
+) {
+    val iconRes = resolveThemeDrawable(item.iconAttr)
+    NavigationDrawerItem(
+        label = { Text(stringResource(item.titleRes)) },
+        selected = selected,
+        onClick = { onItemClick(item.id) },
+        icon = {
+            if (iconRes != 0) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = null,
+                )
+            }
+        },
+        colors = NavigationDrawerItemDefaults.colors(
+            selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+            selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            unselectedTextColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
 fun DrawerScreen(
     state: DrawerListState,
     onItemClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-    ) {
-        DrawerDestinations.sections.forEach { section ->
-            Text(
-                text = stringResource(section.titleRes),
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
-            )
-            section.items.forEach { item ->
-                val selected = state.selectedItemId == item.id
-                val iconRes = resolveThemeDrawable(item.iconAttr)
-                NavigationDrawerItem(
-                    label = { Text(stringResource(item.titleRes)) },
-                    selected = selected,
-                    onClick = { onItemClick(item.id) },
-                    icon = {
-                        if (iconRes != 0) {
-                            Icon(
-                                painter = painterResource(iconRes),
-                                contentDescription = null,
-                            )
-                        }
-                    },
-                    colors = NavigationDrawerItemDefaults.colors(
-                        selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        unselectedTextColor = MaterialTheme.colorScheme.onSurface,
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
+    Column(modifier = modifier.fillMaxSize()) {
+        DrawerBoxActions(onItemClick = onItemClick)
+        HorizontalDivider()
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            DrawerDestinations.sections.forEach { section ->
+                Text(
+                    text = stringResource(section.titleRes),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, top = 12.dp, bottom = 4.dp),
                 )
+                section.items.forEach { item ->
+                    DrawerDestinationItem(
+                        item = item,
+                        selected = state.selectedItemId == item.id,
+                        onItemClick = onItemClick,
+                    )
+                }
             }
+        }
+        HorizontalDivider()
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            DrawerDestinationItem(
+                item = DrawerDestinations.settings,
+                selected = state.selectedItemId == DrawerDestinations.settings.id,
+                onItemClick = onItemClick,
+            )
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -49,8 +49,8 @@ import net.reichholf.dreamdroid.helpers.enigma2.Service
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Phone shell [NavHost]. Drawer leaves through hub + settings; nested service EPG, EPG search,
- * and bouquet pick are the 2.1f beachheads.
+ * Phone shell [NavHost]. Drawer leaves through hub + settings; Backup is nested from Settings.
+ * Nested service EPG, EPG search, and bouquet pick are the 2.1f beachheads.
  */
 @Composable
 fun PhoneNavHost(
@@ -352,6 +352,25 @@ fun NavHostController.navigateToServiceEpg(serviceRef: String, serviceName: Stri
 fun NavHostController.navigateToEpgSearch(query: String) {
     navigate("epg_search/${Uri.encode(query)}") {
         launchSingleTop = true
+    }
+}
+
+/** Nested Backup from Settings: push onto the back stack (back returns to Settings). */
+fun NavHostController.navigateToBackup() {
+    if (currentDestination?.route == PhoneNavRoutes.BACKUP) return
+    navigate(PhoneNavRoutes.BACKUP) {
+        launchSingleTop = true
+    }
+}
+
+/** Drawer Settings: land on the Settings leaf, not a nested Backup restored on top. */
+fun NavHostController.navigateDrawerSettings() {
+    if (currentDestination?.route == PhoneNavRoutes.BACKUP) {
+        if (popBackStack(PhoneNavRoutes.SETTINGS, false)) return
+    }
+    navigateDrawerRoot(PhoneNavRoutes.SETTINGS)
+    if (currentDestination?.route == PhoneNavRoutes.BACKUP) {
+        popBackStack(PhoneNavRoutes.SETTINGS, false)
     }
 }
 

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -355,15 +355,13 @@ fun NavHostController.navigateToEpgSearch(query: String) {
     }
 }
 
-/** Nested Backup from Settings: push onto the back stack (back returns to Settings). */
+/** Nested Backup from Settings. Back returns to Settings. */
 fun NavHostController.navigateToBackup() {
     if (currentDestination?.route == PhoneNavRoutes.BACKUP) return
-    navigate(PhoneNavRoutes.BACKUP) {
-        launchSingleTop = true
-    }
+    navigate(PhoneNavRoutes.BACKUP) { launchSingleTop = true }
 }
 
-/** Drawer Settings: land on the Settings leaf, not a nested Backup restored on top. */
+/** Drawer Settings: land on Settings, not a nested Backup restored on top. */
 fun NavHostController.navigateDrawerSettings() {
     if (currentDestination?.route == PhoneNavRoutes.BACKUP) {
         if (popBackStack(PhoneNavRoutes.SETTINGS, false)) return

--- a/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
@@ -271,21 +271,9 @@ fun SettingsScreen(
         )
 
         HorizontalDivider(modifier = Modifier.padding(top = 16.dp, bottom = 4.dp))
-        ActionPreferenceRow(
-            title = stringResource(R.string.about),
-            summary = DreamDroid.VERSION_STRING,
-            onClick = onAbout,
-        )
-        ActionPreferenceRow(
-            title = stringResource(R.string.changelog),
-            summary = null,
-            onClick = onChangelog,
-        )
-        ActionPreferenceRow(
-            title = stringResource(R.string.backup),
-            summary = null,
-            onClick = onBackup,
-        )
+        ActionPreferenceRow(stringResource(R.string.about), DreamDroid.VERSION_STRING, onAbout)
+        ActionPreferenceRow(stringResource(R.string.changelog), null, onChangelog)
+        ActionPreferenceRow(stringResource(R.string.backup), null, onBackup)
     }
 
     listDialog?.let { dialog ->

--- a/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -41,6 +42,9 @@ fun SettingsScreen(
     onThemeChanged: () -> Unit,
     onDynamicColorsChanged: () -> Unit,
     onSyncPicons: () -> Unit,
+    onAbout: () -> Unit = {},
+    onChangelog: () -> Unit = {},
+    onBackup: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var listDialog by remember { mutableStateOf<ListDialogSpec?>(null) }
@@ -265,6 +269,23 @@ fun SettingsScreen(
                 state.setBoolean(DreamDroid.PREFS_KEY_AUTO_SWITCH_PROFILE_WIFI_BASED, it)
             },
         )
+
+        HorizontalDivider(modifier = Modifier.padding(top = 16.dp, bottom = 4.dp))
+        ActionPreferenceRow(
+            title = stringResource(R.string.about),
+            summary = DreamDroid.VERSION_STRING,
+            onClick = onAbout,
+        )
+        ActionPreferenceRow(
+            title = stringResource(R.string.changelog),
+            summary = null,
+            onClick = onChangelog,
+        )
+        ActionPreferenceRow(
+            title = stringResource(R.string.backup),
+            summary = null,
+            onClick = onBackup,
+        )
     }
 
     listDialog?.let { dialog ->
@@ -374,7 +395,7 @@ internal fun ListPreferenceRow(
 @Composable
 internal fun ActionPreferenceRow(
     title: String,
-    summary: String,
+    summary: String?,
     onClick: () -> Unit,
     enabled: Boolean = true,
 ) {
@@ -390,12 +411,14 @@ internal fun ActionPreferenceRow(
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
         )
-        Spacer(modifier = Modifier.height(2.dp))
-        Text(
-            text = summary,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
-        )
+        if (!summary.isNullOrEmpty()) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+            )
+        }
     }
 }
 
@@ -480,6 +503,9 @@ fun ComposeView.bindSettingsScreen(
     onThemeChanged: () -> Unit,
     onDynamicColorsChanged: () -> Unit,
     onSyncPicons: () -> Unit,
+    onAbout: () -> Unit,
+    onChangelog: () -> Unit,
+    onBackup: () -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
@@ -489,6 +515,9 @@ fun ComposeView.bindSettingsScreen(
                 onThemeChanged = onThemeChanged,
                 onDynamicColorsChanged = onDynamicColorsChanged,
                 onSyncPicons = onSyncPicons,
+                onAbout = onAbout,
+                onChangelog = onChangelog,
+                onBackup = onBackup,
             )
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Slim the phone drawer to destinations + pinned Settings. Move About, Changelog, and Backup into the Settings footer (Backup nested on `PhoneNavHost`).

## Rebase
Rebased onto `main` after [#286](https://github.com/sreichholf/dreamDroid/pull/286) (nested `PhoneNavHost` leaf resume crash). Local unit tests + assemble green.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [ ] CI green
- [ ] Drawer: destinations + Settings; About/Changelog/Backup from Settings footer
- [ ] Nested Backup back → Settings; hub/profile edit no crash (#286)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-798a7540-1355-4c62-b052-9bcd7238fdc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-798a7540-1355-4c62-b052-9bcd7238fdc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

