### PR TITLE
Phase 2.1h: nested timer service pick on PhoneNavHost

### DIFF
--- a/app/res/values/ids.xml
+++ b/app/res/values/ids.xml
@@ -24,5 +24,6 @@
     <item name="phone_nav_pick_service_slot" type="id"/>
     <item name="phone_nav_profile_edit_slot" type="id"/>
     <item name="phone_nav_timer_edit_slot" type="id"/>
+    <item name="phone_nav_timer_service_pick_slot" type="id"/>
 
 </resources>

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -10,6 +10,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavHostController
+import java.util.ArrayDeque
 import net.reichholf.dreamdroid.Profile
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment
@@ -37,7 +38,7 @@ class PhoneNavHostFragment : BaseFragment() {
 
     companion object {
         const val ARG_START_ROUTE = "phone_nav_start_route"
-        private const val STATE_PICK_REQUEST_CODE = "phone_nav_pick_request_code"
+        private const val STATE_PICK_REQUEST_CODES = "phone_nav_pick_request_codes"
         private const val STATE_PROFILE_EDIT_ARGS = "phone_nav_profile_edit_args"
         private const val STATE_PROFILE_EDIT_TAG = "phone_nav_profile_edit_tag"
         private const val STATE_TIMER_EDIT_ARGS = "phone_nav_timer_edit_args"
@@ -64,7 +65,8 @@ class PhoneNavHostFragment : BaseFragment() {
     @Volatile
     private var navController: NavHostController? = null
 
-    private var pickRequestCode: Int = -1
+    /** Stack of pending onActivityResult request codes (nested edit → service pick). */
+    private val resultRequestCodes: ArrayDeque<Int> = ArrayDeque()
     private var profileEditArgs: Bundle? = null
     private var profileEditTag: String = PhoneNavRoutes.PROFILE_EDIT
     private var timerEditArgs: Bundle? = null
@@ -80,7 +82,8 @@ class PhoneNavHostFragment : BaseFragment() {
         mShouldRetainInstance = false
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {
-            pickRequestCode = savedInstanceState.getInt(STATE_PICK_REQUEST_CODE, -1)
+            resultRequestCodes.clear()
+            savedInstanceState.getIntArray(STATE_PICK_REQUEST_CODES)?.forEach { resultRequestCodes.addLast(it) }
             profileEditArgs = savedInstanceState.getBundle(STATE_PROFILE_EDIT_ARGS)
             profileEditTag = savedInstanceState.getString(STATE_PROFILE_EDIT_TAG, PhoneNavRoutes.PROFILE_EDIT)
             timerEditArgs = savedInstanceState.getBundle(STATE_TIMER_EDIT_ARGS)
@@ -90,7 +93,7 @@ class PhoneNavHostFragment : BaseFragment() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putInt(STATE_PICK_REQUEST_CODE, pickRequestCode)
+        outState.putIntArray(STATE_PICK_REQUEST_CODES, resultRequestCodes.toIntArray())
         profileEditArgs?.let { outState.putBundle(STATE_PROFILE_EDIT_ARGS, it) }
         outState.putString(STATE_PROFILE_EDIT_TAG, profileEditTag)
         timerEditArgs?.let { outState.putBundle(STATE_TIMER_EDIT_ARGS, it) }
@@ -186,6 +189,9 @@ class PhoneNavHostFragment : BaseFragment() {
             route == PhoneNavRoutes.TIMER_EDIT ->
                 childFragmentManager.findFragmentById(R.id.phone_nav_timer_edit_slot)
                     ?: childFragmentManager.findFragmentByTag(timerEditTag)
+            route == PhoneNavRoutes.TIMER_SERVICE_PICK ->
+                childFragmentManager.findFragmentById(R.id.phone_nav_timer_service_pick_slot)
+                    ?: childFragmentManager.findFragmentByTag(PhoneNavRoutes.TIMER_SERVICE_PICK)
             else -> null
         }
     }
@@ -298,7 +304,7 @@ class PhoneNavHostFragment : BaseFragment() {
      */
     fun navigateToPickBouquet(requestCode: Int): Boolean {
         val controller = navController ?: return false
-        pickRequestCode = requestCode
+        pushResultRequestCode(requestCode)
         controller.navigate(PhoneNavRoutes.PICK_SERVICE)
         return true
     }
@@ -320,7 +326,7 @@ class PhoneNavHostFragment : BaseFragment() {
      */
     fun navigateToProfileEdit(profile: Profile?): Boolean {
         val controller = navController ?: return false
-        pickRequestCode = Statics.REQUEST_EDIT_PROFILE
+        pushResultRequestCode(Statics.REQUEST_EDIT_PROFILE)
         val data = ExtendedHashMap()
         data.put("action", Intent.ACTION_EDIT)
         if (profile != null) {
@@ -361,12 +367,12 @@ class PhoneNavHostFragment : BaseFragment() {
     fun timerEditLeafArguments(): Bundle = timerEditArgs ?: Bundle()
 
     /**
-     * Push nested timer create/edit. Service pick stays on [SimpleToolbarFragmentActivity].
+     * Push nested timer create/edit. Service pick uses [navigateToTimerServicePick].
      * Result goes through [deliverPickResult] with [Statics.REQUEST_EDIT_TIMER].
      */
     fun navigateToTimerEdit(timer: ExtendedHashMap, create: Boolean): Boolean {
         val controller = navController ?: return false
-        pickRequestCode = Statics.REQUEST_EDIT_TIMER
+        pushResultRequestCode(Statics.REQUEST_EDIT_TIMER)
         val data = ExtendedHashMap()
         data.put("timer", timer)
         data.put("action", if (create) DreamDroid.ACTION_CREATE else Intent.ACTION_EDIT)
@@ -401,14 +407,28 @@ class PhoneNavHostFragment : BaseFragment() {
         return true
     }
 
+    private fun pushResultRequestCode(code: Int) {
+        resultRequestCodes.addLast(code)
+    }
+
+    /**
+     * Push nested timer service pick onto the NavHost back stack (from [TimerEditFragment]).
+     * Pushes [Statics.REQUEST_PICK_SERVICE] without clearing the pending edit request code.
+     */
+    fun navigateToTimerServicePick(): Boolean {
+        val controller = navController ?: return false
+        pushResultRequestCode(Statics.REQUEST_PICK_SERVICE)
+        controller.navigate(PhoneNavRoutes.TIMER_SERVICE_PICK)
+        return true
+    }
+
     fun deliverPickResult(resultCode: Int, data: Intent?) {
         val controller = navController ?: return
-        val code = pickRequestCode
-        pickRequestCode = -1
+        val code = if (resultRequestCodes.isEmpty()) -1 else resultRequestCodes.removeLast()
         if (!controller.popBackStack()) return
         view?.post {
             val leaf = getActiveLeaf()
-            // Profile edit finishes with a null Intent; bouquet pick sends extras.
+            // Profile/timer edit finish with a null Intent; service/bouquet pick send extras.
             if (code >= 0 && leaf != null) {
                 leaf.onActivityResult(code, resultCode, data)
             }

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -74,6 +74,7 @@ class PhoneNavHostFragment : BaseFragment() {
 
     private val backCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
+            discardResultRequestCodeForCurrentRoute()
             navController?.popBackStack()
         }
     }
@@ -220,6 +221,7 @@ class PhoneNavHostFragment : BaseFragment() {
      */
     fun navigateToRoute(route: String): Boolean {
         val controller = navController ?: return false
+        resultRequestCodes.clear()
         controller.navigateDrawerRoot(route)
         return true
     }
@@ -231,6 +233,10 @@ class PhoneNavHostFragment : BaseFragment() {
      */
     fun navigateToEpg(serviceReference: String?, serviceName: String?): Boolean {
         val controller = navController ?: return false
+        // Drawer-style EPG open drops any nested edit/pick back stack entries.
+        if (controller.currentDestination?.route != PhoneNavRoutes.EPG) {
+            resultRequestCodes.clear()
+        }
         val args = arguments ?: Bundle().also { arguments = it }
         args.putString(Event.KEY_SERVICE_REFERENCE, serviceReference)
         args.putString(Event.KEY_SERVICE_NAME, serviceName)
@@ -409,6 +415,27 @@ class PhoneNavHostFragment : BaseFragment() {
 
     private fun pushResultRequestCode(code: Int) {
         resultRequestCodes.addLast(code)
+    }
+
+    /** True when this route pushed a pending [resultRequestCodes] entry. */
+    private fun isResultDestination(route: String?): Boolean {
+        if (route == null) return false
+        return route == PhoneNavRoutes.PICK_SERVICE
+            || route == PhoneNavRoutes.PROFILE_EDIT
+            || route == PhoneNavRoutes.TIMER_EDIT
+            || route == PhoneNavRoutes.TIMER_SERVICE_PICK
+    }
+
+    /**
+     * System/gesture back pops the NavHost without [deliverPickResult]; drop the
+     * matching pending request code so a later finish still sees the outer code
+     * (e.g. timer edit after canceling service pick).
+     */
+    private fun discardResultRequestCodeForCurrentRoute() {
+        val route = navController?.currentDestination?.route
+        if (isResultDestination(route) && resultRequestCodes.isNotEmpty()) {
+            resultRequestCodes.removeLast()
+        }
     }
 
     /**

--- a/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/TimerEditFragment.java
@@ -20,6 +20,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import androidx.annotation.Nullable;
 import androidx.compose.ui.platform.ComposeView;
 
@@ -29,6 +30,7 @@ import com.google.android.material.timepicker.TimeFormat;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
+import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.activities.SimpleToolbarFragmentActivity;
 import net.reichholf.dreamdroid.enigma.LocationsAndTagsLoadKt;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment;
@@ -325,6 +327,15 @@ public class TimerEditFragment extends BaseHttpFragment implements MultiChoiceDi
 	}
 
 	private void pickService() {
+		Fragment walker = getParentFragment();
+		while (walker != null) {
+			if (walker instanceof PhoneNavHostFragment
+					&& ((PhoneNavHostFragment) walker).navigateToTimerServicePick()) {
+				return;
+			}
+			walker = walker.getParentFragment();
+		}
+
 		ExtendedHashMap data = new ExtendedHashMap();
 		data.put(Service.KEY_REFERENCE, "default");
 

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -1,6 +1,7 @@
 package net.reichholf.dreamdroid.ui.nav
 
 import android.app.SearchManager
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.ViewGroup
@@ -23,6 +24,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.BackupFragment
+import net.reichholf.dreamdroid.fragment.abs.BaseHttpFragment
 import net.reichholf.dreamdroid.fragment.CurrentServiceFragment
 import net.reichholf.dreamdroid.fragment.DeviceInfoFragment
 import net.reichholf.dreamdroid.fragment.EpgBouquetFragment
@@ -32,6 +34,7 @@ import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.fragment.PickServiceFragment
 import net.reichholf.dreamdroid.fragment.ProfileEditFragment
 import net.reichholf.dreamdroid.fragment.TimerEditFragment
+import net.reichholf.dreamdroid.fragment.TimerServicePickFragment
 import net.reichholf.dreamdroid.fragment.ProfileListFragment
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment
 import net.reichholf.dreamdroid.fragment.ServiceEpgListFragment
@@ -239,6 +242,23 @@ fun PhoneNavHost(
                 createFragment = {
                     TimerEditFragment().apply {
                         arguments = hostFragment.timerEditLeafArguments()
+                    }
+                },
+            )
+        }
+        composable(PhoneNavRoutes.TIMER_SERVICE_PICK) {
+            NestedFragmentDestination(
+                hostFragment = hostFragment,
+                containerId = R.id.phone_nav_timer_service_pick_slot,
+                routeTag = PhoneNavRoutes.TIMER_SERVICE_PICK,
+                createFragment = {
+                    TimerServicePickFragment().apply {
+                        arguments = Bundle().apply {
+                            val data = ExtendedHashMap()
+                            data.put(Service.KEY_REFERENCE, "default")
+                            putSerializable(BaseHttpFragment.sData, data)
+                            putString("action", Intent.ACTION_PICK)
+                        }
                     }
                 },
             )

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -33,6 +33,9 @@ object PhoneNavRoutes {
     /** Nested profile create/edit (args via host). */
     const val PROFILE_EDIT = "profile_edit"
 
-    /** Nested timer create/edit (args via host). Service pick stays side activity. */
+    /** Nested timer create/edit (args via host). */
     const val TIMER_EDIT = "timer_edit"
+
+    /** Nested timer service pick (from timer edit). */
+    const val TIMER_SERVICE_PICK = "timer_service_pick"
 }

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -118,7 +118,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | docs-dialog-policy | [#278](https://github.com/sreichholf/dreamDroid/pull/278) | merged | Phase 2.1g: dialog policy decision (keep fragment dialogs; no NavHost promotion). Keep OkHttp 3.14.9. |
 | navhost-settings-leaf | [#279](https://github.com/sreichholf/dreamDroid/pull/279) | merged | Phase 2.1h continued: Settings drawer root on `PhoneNavHost`; drop side-activity path. Keep OkHttp 3.14.9. |
 | navhost-profile-edit | [#280](https://github.com/sreichholf/dreamDroid/pull/280) | merged | Phase 2.1h continued: nested profile create/edit on `PhoneNavHost` (host delivers result). Keep OkHttp 3.14.9. |
-| navhost-timer-edit | this PR | open | Phase 2.1h continued: nested timer create/edit on `PhoneNavHost`; service pick stays side activity. Keep OkHttp 3.14.9. |
+| navhost-timer-edit | [#281](https://github.com/sreichholf/dreamDroid/pull/281) | merged | Phase 2.1h continued: nested timer create/edit on `PhoneNavHost`; service pick stayed side activity. Keep OkHttp 3.14.9. |
+| navhost-timer-service-pick | this PR | open | Phase 2.1h continued: nested timer service pick on `PhoneNavHost` (request-code stack). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -189,8 +190,9 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) (keep fragment dialogs).
 - Phase 2.1h Settings leaf **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279).
 - Phase 2.1h nested profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280).
-- **This PR** = Phase 2.1h continued: nested timer edit on `PhoneNavHost`.
-- Out of wave still: optional 2.6c Compose config / further 2.1h (timer service pick) / Phase 4–5 operator. See Appendix H.
+- Phase 2.1h nested timer edit **merged** [#281](https://github.com/sreichholf/dreamDroid/pull/281).
+- **This PR** = Phase 2.1h continued: nested timer service pick (request-code stack).
+- Out of wave still: optional 2.6c Compose config / further 2.1h (retire NavigationHelper switch) / Phase 4–5 operator. See Appendix H.
 
 ## How to read this
 
@@ -889,14 +891,15 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | Remote leaf | `PhoneNavRoutes.REMOTE` + nested `VirtualRemotePagerFragment` | Tablet **merged** [#269](https://github.com/sreichholf/dreamDroid/pull/269); phone **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277) (2.1h beachhead) |
 | Settings leaf | `PhoneNavRoutes.SETTINGS` + nested `MyPreferenceFragment` | **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279) |
 | Profile edit nested | `PhoneNavRoutes.PROFILE_EDIT` | **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280) |
-| Timer edit nested | `PhoneNavRoutes.TIMER_EDIT` | **this PR** (service pick still side activity) |
+| Timer edit nested | `PhoneNavRoutes.TIMER_EDIT` | **merged** [#281](https://github.com/sreichholf/dreamDroid/pull/281) |
+| Timer service pick nested | `PhoneNavRoutes.TIMER_SERVICE_PICK` | **this PR** (request-code stack) |
 | Hub leaf | `PhoneNavRoutes.HUB` + nested `ServiceListPager` | **merged** [#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | Service EPG nested | `PhoneNavRoutes.SERVICE_EPG` typed ref/name | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274) (2.1f beachhead) |
 | EPG search nested | `PhoneNavRoutes.EPG_SEARCH` typed query | **merged** [#275](https://github.com/sreichholf/dreamDroid/pull/275) |
 | Bouquet pick nested | `PhoneNavRoutes.PICK_SERVICE` | **merged** [#276](https://github.com/sreichholf/dreamDroid/pull/276) (host `deliverPickResult`) |
 | Host API | `MultiPaneHandler` | `isMultiPane()` always true on `MainActivity` (in-host detail, not master–detail columns) |
 | Nested | `FragmentHelper`, `HttpFragmentHelper` | FM back stack; pickers via host / `onActivityResult` |
-| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Timer service pick / stream / Share. Settings [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit [#280](https://github.com/sreichholf/dreamDroid/pull/280); timer edit **this PR**; remote [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
+| Side hosts | `Simple*FragmentActivity`, `VideoActivity`, `ShareActivity` | Stream / Share (+ fallbacks). Settings [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile [#280](https://github.com/sreichholf/dreamDroid/pull/280); timer edit [#281](https://github.com/sreichholf/dreamDroid/pull/281); timer service pick **this PR**; remote [#277](https://github.com/sreichholf/dreamDroid/pull/277). |
 | Profiles | Profile header XML + first-start | Not in `DrawerScreen` / `navigation.xml`; opens `ProfileListFragment`, clears drawer selection |
 
 #### Agreed approach
@@ -913,14 +916,15 @@ None remaining. Last consumer was `MultiChoiceDialog` (`boolean[]` via Bundle [#
 | 2.1e | More drawer roots | Through hub **merged** [#257](https://github.com/sreichholf/dreamDroid/pull/257)–[#270](https://github.com/sreichholf/dreamDroid/pull/270) |
 | 2.1f | Nested stack (EPG search / service EPG / pick-service) typed routes | **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276) |
 | 2.1g | Dialog policy (keep fragment dialogs or promote a few) | **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278) — decision A keep fragment dialogs |
-| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277); Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280). **This PR:** nested timer edit (service pick still side activity). Further: optional timer service pick / retire switch. No OkHttp 4; no widgets; no Media3 |
+| 2.1h | Optional side-activity convergence; retire `NavigationHelper` switch | Phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277); Settings **merged** [#279](https://github.com/sreichholf/dreamDroid/pull/279); profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280); timer edit **merged** [#281](https://github.com/sreichholf/dreamDroid/pull/281). **This PR:** nested timer service pick + request-code stack. Further: optional retire `NavigationHelper` switch. No OkHttp 4; no widgets; no Media3 |
 
 #### Explicit non-goals after 2.1e ([#270](https://github.com/sreichholf/dreamDroid/pull/270))
 
 - Phone remote side activity retired in 2.1h ([#277](https://github.com/sreichholf/dreamDroid/pull/277))
 - Settings side activity retired in 2.1h ([#279](https://github.com/sreichholf/dreamDroid/pull/279))
 - Profile edit nested in 2.1h ([#280](https://github.com/sreichholf/dreamDroid/pull/280))
-- Timer edit nested in 2.1h (**this PR**; service pick still side activity)
+- Timer edit nested in 2.1h ([#281](https://github.com/sreichholf/dreamDroid/pull/281))
+- Timer service pick nested in 2.1h (**this PR**)
 - Dialogs stay FragmentDialogs / bottom sheets ([#278](https://github.com/sreichholf/dreamDroid/pull/278))
 - No VideoActivity / Glance widgets / TV Leanback / Media3
 - No OkHttp 4; do not merge master into main
@@ -986,7 +990,7 @@ Why:
 #### Explicit non-goals of this PR
 
 - No dialog→route code; no OkHttp 4; no VideoActivity fold; no Glance
-- Optional follow-ons stay under **2.1h** (timer service pick) or a separate chassis cleanup
+- Optional follow-ons stay under **2.1h** (retire NavigationHelper switch) or a separate chassis cleanup
 
 ### Phase 3 — Leanback TV (after Phase 0 dive)
 
@@ -1000,7 +1004,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** nested timer edit on NavHost (service pick still side activity). Optional next: further 2.1h (timer service pick) / Phase 4–5 (operator). Profile edit **merged** [#280](https://github.com/sreichholf/dreamDroid/pull/280).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277). Phase 2.1g dialog policy **merged** [#278](https://github.com/sreichholf/dreamDroid/pull/278). **This PR:** nested timer service pick on NavHost (request-code stack). Optional next: further 2.1h (retire NavigationHelper switch) / Phase 4–5 (operator). Timer edit **merged** [#281](https://github.com/sreichholf/dreamDroid/pull/281).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Nest `TimerServicePickFragment` on `PhoneNavHost` via `TIMER_SERVICE_PICK`.
- Replace the single pending result request code with a **stack** so timer edit → service pick → edit keeps `REQUEST_EDIT_TIMER` under the pick’s `REQUEST_PICK_SERVICE`.
- `TimerEditFragment.pickService` prefers in-host navigation; side-activity fallback remains.
- Docs: mark #281 merged; this PR = nested timer service pick.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: open timer edit in-host → pick service → select → returns to edit with service filled → save returns to list
- [ ] Bouquet pick (Zap/EPG) still works (same stack)
- [ ] Profile edit still reloads list after save

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

