### PR TITLE
Fix crash: nested PhoneNavHost leaves must not call showDetails

### DIFF
--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -656,6 +656,13 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 	@Override
 	public void onFragmentResume(@NonNull Fragment fragment) {
+		// Nested leaves live under PhoneNavHostFragment's child FragmentManager.
+		// showDetails()/hide() only work on the activity FM — calling them for a
+		// nested ServiceListPager / ProfileEditFragment crashes with
+		// "Cannot hide Fragment attached to a different FragmentManager".
+		if (isNestedInPhoneNavHost(fragment)) {
+			return;
+		}
 		if (!fragment.equals(mDetailFragment)) {
 			mDetailFragment = fragment;
 			showDetails(fragment);
@@ -664,7 +671,23 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 
 	@Override
 	public void onFragmentPause(Fragment fragment) {
-		mDetailFragment = null;
+		if (isNestedInPhoneNavHost(fragment)) {
+			return;
+		}
+		if (fragment.equals(mDetailFragment)) {
+			mDetailFragment = null;
+		}
+	}
+
+	private static boolean isNestedInPhoneNavHost(@NonNull Fragment fragment) {
+		Fragment parent = fragment.getParentFragment();
+		while (parent != null) {
+			if (parent instanceof PhoneNavHostFragment) {
+				return true;
+			}
+			parent = parent.getParentFragment();
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Nested leaves under `PhoneNavHostFragment` (`ServiceListPager`, `ProfileEditFragment`, …) call `FragmentHelper.onResume` → `MainActivity.onFragmentResume` → `showDetails`. That runs `hide()`/`show()` on the **activity** `FragmentManager`, but those fragments are attached to the host’s **child** FM →

`IllegalStateException: Cannot hide Fragment attached to a different FragmentManager`

## Fix
Skip `onFragmentResume` / `onFragmentPause` detail handling when the fragment is nested under `PhoneNavHostFragment`. Only the host itself is an activity-level detail.

## Note
Seen while testing [#282](https://github.com/sreichholf/dreamDroid/pull/282) (drawer IA), but the bug is on `main` whenever a nested leaf resumes — not introduced by the drawer slim.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [ ] CI green
- [ ] Manual: open hub / profile edit under PhoneNavHost without crash (operator)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

