### PR TITLE
Fix hub bottom bar stuck after leaving TV & Movies

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/nav/NestedFragmentTeardownTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/nav/NestedFragmentTeardownTest.kt
@@ -1,0 +1,58 @@
+package net.reichholf.dreamdroid.ui.nav
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.testsupport.FragmentHostActivity
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Nested NavHost leaves must be removed when their Compose route leaves composition;
+ * otherwise [net.reichholf.dreamdroid.fragment.ServiceListPager] keeps the activity
+ * TV/Movies bottom bar visible and drawer Settings appears broken.
+ */
+@RunWith(AndroidJUnit4::class)
+class NestedFragmentTeardownTest {
+    class HostFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?,
+        ): View {
+            return FragmentContainerView(requireContext()).apply {
+                id = R.id.phone_nav_hub_slot
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun removeNestedFragmentDetachesLeaf() {
+        ActivityScenario.launch(FragmentHostActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val host = HostFragment()
+                activity.supportFragmentManager.beginTransaction()
+                    .replace(android.R.id.content, host, "host")
+                    .commitNow()
+                ensureNestedFragment(host, R.id.phone_nav_hub_slot, PhoneNavRoutes.HUB) {
+                    Fragment()
+                }
+                assertNotNull(host.childFragmentManager.findFragmentByTag(PhoneNavRoutes.HUB))
+                removeNestedFragment(host, R.id.phone_nav_hub_slot, PhoneNavRoutes.HUB)
+                assertNull(host.childFragmentManager.findFragmentByTag(PhoneNavRoutes.HUB))
+            }
+        }
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="net.reichholf.dreamdroid.testsupport.FragmentHostActivity"
+            android:exported="false"
+            android:theme="@style/Theme.DreamDroid.Night" />
+    </application>
+</manifest>

--- a/app/src/debug/java/net/reichholf/dreamdroid/testsupport/FragmentHostActivity.kt
+++ b/app/src/debug/java/net/reichholf/dreamdroid/testsupport/FragmentHostActivity.kt
@@ -1,0 +1,22 @@
+package net.reichholf.dreamdroid.testsupport
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentContainerView
+import net.reichholf.dreamdroid.R
+
+/**
+ * Debug-only host for instrumented fragment helper tests (avoids fragment-testing's
+ * EmptyFragmentActivity, which must live in the app APK).
+ */
+class FragmentHostActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(R.style.Theme_DreamDroid_Night)
+        super.onCreate(savedInstanceState)
+        setContentView(
+            FragmentContainerView(this).apply {
+                id = android.R.id.content
+            },
+        )
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -273,6 +273,15 @@ private fun NestedFragmentDestination(
     routeTag: String,
     createFragment: () -> Fragment,
 ) {
+    // Tear down the child Fragment when this route leaves composition. Without
+    // this, AndroidView drops the FragmentContainerView but leaves the leaf
+    // RESUMED under PhoneNavHostFragment — ServiceListPager's activity-scoped
+    // TV/Movies bottom bar then stays visible and blocks drawer Settings.
+    DisposableEffect(hostFragment, containerId, routeTag) {
+        onDispose {
+            removeNestedFragment(hostFragment, containerId, routeTag)
+        }
+    }
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = { context ->
@@ -328,6 +337,26 @@ private fun commitNestedFragment(
     fm.beginTransaction()
         .replace(containerId, createFragment(), routeTag)
         .commitNow()
+}
+
+/**
+ * Remove a nested leaf when its Compose route leaves composition so
+ * [Fragment.onDestroyView] runs (e.g. hub clears [R.id.tv_movies_nav]).
+ */
+internal fun removeNestedFragment(
+    hostFragment: Fragment,
+    containerId: Int,
+    routeTag: String,
+) {
+    if (!hostFragment.isAdded) return
+    val fm = hostFragment.childFragmentManager
+    val existing = fm.findFragmentById(containerId) ?: return
+    if (existing.tag != routeTag) return
+    if (fm.isStateSaved) {
+        fm.beginTransaction().remove(existing).commitAllowingStateLoss()
+        return
+    }
+    fm.beginTransaction().remove(existing).commitNow()
 }
 
 /** Drawer-style top-level navigate: single-top + save/restore under the start destination. */

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -121,7 +121,10 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | navhost-timer-edit | [#281](https://github.com/sreichholf/dreamDroid/pull/281) | merged | Phase 2.1h continued: nested timer create/edit on `PhoneNavHost`; service pick stayed side activity. Keep OkHttp 3.14.9. |
 | navhost-timer-service-pick | [#283](https://github.com/sreichholf/dreamDroid/pull/283) | merged | Phase 2.1h continued: nested timer service pick on `PhoneNavHost` (request-code stack). Keep OkHttp 3.14.9. |
 | drop-side-edit-fallbacks | [#284](https://github.com/sreichholf/dreamDroid/pull/284) | merged | Phase 2.1h continued: drop `SimpleToolbarFragmentActivity` fallbacks for profile/timer edit + service pick. Keep OkHttp 3.14.9. |
-| navhelper-map-routes | this PR | open | Phase 2.1h continued: map drawer menu ids → `PhoneNavHost` roots; keep dialog/action arms. Keep OkHttp 3.14.9. |
+| navhelper-map-routes | [#285](https://github.com/sreichholf/dreamDroid/pull/285) | merged | Phase 2.1h continued: map drawer menu ids → `PhoneNavHost` roots; keep dialog/action arms. Keep OkHttp 3.14.9. |
+| fix-nested-fragment-resume | [#286](https://github.com/sreichholf/dreamDroid/pull/286) | merged | Fix crash: nested `PhoneNavHost` leaves must not call `showDetails`. Keep OkHttp 3.14.9. |
+| drawer-ia-settings | [#282](https://github.com/sreichholf/dreamDroid/pull/282) | merged | Slim drawer; nest About/Changelog/Backup under Settings. Keep OkHttp 3.14.9. |
+| fix-hub-nested-teardown | this PR | open | Fix hub TV/Movies bottom bar stuck after leaving hub (remove nested leaf on NavHost route dispose). Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -195,7 +198,10 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.1h nested timer edit **merged** [#281](https://github.com/sreichholf/dreamDroid/pull/281).
 - Phase 2.1h nested timer service pick **merged** [#283](https://github.com/sreichholf/dreamDroid/pull/283).
 - Phase 2.1h drop side-edit fallbacks **merged** [#284](https://github.com/sreichholf/dreamDroid/pull/284).
-- **This PR** = Phase 2.1h continued: map drawer NavHost roots in `NavigationHelper` (dialogs/actions stay).
+- Phase 2.1h map drawer NavHost roots **merged** [#285](https://github.com/sreichholf/dreamDroid/pull/285).
+- Nested leaf `showDetails` crash fix **merged** [#286](https://github.com/sreichholf/dreamDroid/pull/286).
+- Drawer IA (About/Changelog/Backup under Settings) **merged** [#282](https://github.com/sreichholf/dreamDroid/pull/282).
+- **This PR** = remove nested NavHost leaves when their Compose route leaves composition (hub bottom bar / Settings).
 - Out of wave still: optional 2.6c Compose config / Phase 4–5 operator. See Appendix H.
 
 ## How to read this
@@ -1010,7 +1016,7 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote through side-edit fallbacks **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277)–[#284](https://github.com/sreichholf/dreamDroid/pull/284) (incl. dialog policy [#278](https://github.com/sreichholf/dreamDroid/pull/278)). **This PR:** map drawer `NavigationHelper` roots → `PhoneNavHost`. Optional next: 2.6c Compose widget config / Phase 4–5 (operator).
+**Phase 3 Leanback code path complete for this program** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub stays Leanback shell). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote through drawer root map **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277)–[#285](https://github.com/sreichholf/dreamDroid/pull/285) (dialog policy [#278](https://github.com/sreichholf/dreamDroid/pull/278); nested resume crash [#286](https://github.com/sreichholf/dreamDroid/pull/286); drawer IA [#282](https://github.com/sreichholf/dreamDroid/pull/282)). **This PR:** tear down nested NavHost leaves on route dispose (hub bottom bar). Optional next: 2.6c Compose widget config / Phase 4–5 (operator).
 
 ### Phase 4 — Operator usertests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Nested `PhoneNavHost` leaves mounted via `AndroidView` were never removed when their Compose route left composition. `ServiceListPager` stayed **RESUMED**, so its activity-scoped TV/Movies bottom bar (`R.id.tv_movies_nav`) never went `GONE`. Drawer Settings still navigated, but the leftover hub chrome made it look broken / untappable.

## Fix
- `DisposableEffect` teardown in `NestedFragmentDestination` → `removeNestedFragment(...)` so `onDestroyView` runs
- Instrumented helper test for mount/remove
- Docs status for #282/#285/#286 + this fix

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [x] `adb shell am instrument -w -e class net.reichholf.dreamdroid.ui.nav.NestedFragmentTeardownTest ...`
- [ ] CI green
- [ ] Manual: TV & Movies → Settings — bottom bar gone, Settings usable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

