### PR TITLE
Drop dead bare showDetails leaf fallbacks under PhoneNavHost

### DIFF
--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.java
@@ -46,8 +46,8 @@ import net.reichholf.dreamdroid.activities.abs.BaseActivity;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.enigma.ProfileDetectLoadKt;
 import net.reichholf.dreamdroid.fragment.ActivityCallbackHandler;
-import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
+import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes;
 import net.reichholf.dreamdroid.fragment.ProfileEditFragment;
 import net.reichholf.dreamdroid.fragment.ProfileListFragment;
 import net.reichholf.dreamdroid.fragment.dialogs.ActionDialog;
@@ -558,23 +558,6 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 	 * (non-Javadoc)
 	 *
 	 * @see
-	 * net.reichholf.dreamdroid.abstivities.MultiPaneHandler#showDetails(java
-	 * .lang.Class, java.lang.Class)
-	 */
-	@Override
-	public void showDetails(@NonNull Class<? extends Fragment> fragmentClass) {
-		try {
-			showDetails(fragmentClass.newInstance());
-		} catch (@NonNull InstantiationException | IllegalAccessException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
 	 * net.reichholf.dreamdroid.abstivities.MultiPaneHandler#showDetails(android
 	 * .support.v4.app.Fragment)
 	 */
@@ -827,16 +810,17 @@ public class MainActivity extends BaseActivity implements MultiPaneHandler, Prof
 	 */
 	@Override
 	public boolean onQueryTextSubmit(String query) {
+		if (query == null || query.isEmpty()) {
+			return true;
+		}
 		Fragment detail = getCurrentDetailFragment();
 		if (detail instanceof PhoneNavHostFragment
 				&& ((PhoneNavHostFragment) detail).navigateToEpgSearch(query)) {
 			return true;
 		}
-		Bundle args = new Bundle();
-		args.putString(SearchManager.QUERY, query);
-		Fragment f = new EpgSearchFragment();
-		f.setArguments(args);
-		showDetails(f, true);
+		PhoneNavHostFragment host = PhoneNavHostFragment.newInstance(PhoneNavRoutes.HUB);
+		host.queueEpgSearch(query);
+		showDetails(host);
 		return true;
 	}
 

--- a/app/src/net/reichholf/dreamdroid/activities/abs/MultiPaneHandler.java
+++ b/app/src/net/reichholf/dreamdroid/activities/abs/MultiPaneHandler.java
@@ -19,8 +19,6 @@ public interface MultiPaneHandler {
 
 	void showDetails(Fragment fragment, boolean addToBackStack);
 
-	void showDetails(Class<? extends Fragment> fragmentClass);
-
 	void onFragmentResume(Fragment fragment);
 
 	void onFragmentPause(Fragment fragment);

--- a/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/EpgBouquetFragment.java
@@ -323,18 +323,7 @@ public class EpgBouquetFragment extends BaseHttpRecyclerEventFragment {
 			}
 			parent = parent.getParentFragment();
 		}
-		PickServiceFragment f = new PickServiceFragment();
-		Bundle args = new Bundle();
-
-		ExtendedHashMap data = new ExtendedHashMap();
-		data.put(Service.KEY_REFERENCE, "default");
-
-		args.putSerializable(sData, data);
-		args.putString("action", Statics.INTENT_ACTION_PICK_BOUQUET);
-
-		f.setArguments(args);
-		f.setTargetFragment(this, Statics.REQUEST_PICK_BOUQUET);
-		((MultiPaneHandler) getAppCompatActivity()).showDetails(f, true);
+		throw new IllegalStateException("EPG bouquet pick requires PhoneNavHostFragment");
 	}
 
 	@NonNull

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -77,6 +77,7 @@ class PhoneNavHostFragment : BaseFragment() {
     private var pendingProfileEdit: Profile? = null
     private var pendingTimerEdit: ExtendedHashMap? = null
     private var pendingTimerCreate: Boolean = false
+    private var pendingEpgSearchQuery: String? = null
 
     private val backCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
@@ -353,6 +354,12 @@ class PhoneNavHostFragment : BaseFragment() {
         flushPendingNavigations()
     }
 
+    /** Queue EPG search until [attachNavController] (cold SEARCH / empty detail pane). */
+    fun queueEpgSearch(query: String) {
+        pendingEpgSearchQuery = query
+        flushPendingNavigations()
+    }
+
     private fun flushPendingNavigations() {
         if (navController == null) return
         if (pendingProfileEditRequested) {
@@ -367,6 +374,11 @@ class PhoneNavHostFragment : BaseFragment() {
             val create = pendingTimerCreate
             pendingTimerCreate = false
             navigateToTimerEdit(timer, create)
+        }
+        val searchQuery = pendingEpgSearchQuery
+        if (searchQuery != null) {
+            pendingEpgSearchQuery = null
+            navigateToEpgSearch(searchQuery)
         }
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ServiceListPageFragment.java
@@ -370,14 +370,7 @@ public class ServiceListPageFragment extends BaseHttpRecyclerEventFragment {
 			}
 			parent = parent.getParentFragment();
 		}
-		ServiceEpgListFragment f = new ServiceEpgListFragment();
-		ExtendedHashMap map = new ExtendedHashMap();
-		map.put(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_REFERENCE, ref);
-		map.put(net.reichholf.dreamdroid.helpers.enigma2.Event.KEY_SERVICE_NAME, nam);
-		Bundle args = new Bundle();
-		args.putSerializable(sData, map);
-		f.setArguments(args);
-		getMultiPaneHandler().showDetails(f, true);
+		throw new IllegalStateException("Service EPG requires PhoneNavHostFragment");
 	}
 
 	public void showPopupMenu(int windowX, int windowY, @NonNull ServiceNowNext row) {

--- a/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/ZapFragment.java
@@ -18,7 +18,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import net.reichholf.dreamdroid.DreamDroid;
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.enigma.ServiceListLoadKt;
 import net.reichholf.dreamdroid.fragment.abs.BaseHttpRecyclerFragment;
@@ -278,17 +277,6 @@ public class ZapFragment extends BaseHttpRecyclerFragment {
 			}
 			parent = parent.getParentFragment();
 		}
-		PickServiceFragment f = new PickServiceFragment();
-		Bundle args = new Bundle();
-
-		ExtendedHashMap data = new ExtendedHashMap();
-		data.put(net.reichholf.dreamdroid.helpers.enigma2.Service.KEY_REFERENCE, "default");
-
-		args.putSerializable(sData, data);
-		args.putString("action", Statics.INTENT_ACTION_PICK_BOUQUET);
-
-		f.setArguments(args);
-		f.setTargetFragment(this, Statics.REQUEST_PICK_BOUQUET);
-		((MultiPaneHandler) getAppCompatActivity()).showDetails(f, true);
+		throw new IllegalStateException("Zap bouquet pick requires PhoneNavHostFragment");
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/FragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/FragmentHelper.java
@@ -12,8 +12,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
@@ -21,8 +19,6 @@ import net.reichholf.dreamdroid.R;
 import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IBaseFragment;
-import net.reichholf.dreamdroid.fragment.interfaces.IMutliPaneContent;
-import net.reichholf.dreamdroid.helpers.Statics;
 
 
 public class FragmentHelper {
@@ -107,32 +103,8 @@ public class FragmentHelper {
 			}
 			walker = walker.getParentFragment();
 		}
-		MultiPaneHandler mph = ((IMutliPaneContent) mFragment).getMultiPaneHandler();
-		if (mph.isMultiPane()) {
-			boolean explicitShow = false;
-			FragmentManager fm = getAppCompatActivity().getSupportFragmentManager();
-			if (fm.getBackStackEntryCount() > 0) {
-				fm.popBackStackImmediate();
-			} else {
-				explicitShow = true;
-			}
-			Fragment target = mFragment.getTargetFragment();
-
-			if (target != null) {
-				if (resultCode != Statics.RESULT_NONE || data != null) {
-					if (explicitShow) {
-						FragmentTransaction ft = getAppCompatActivity().getSupportFragmentManager().beginTransaction();
-						ft.remove(mFragment);
-						ft.commit();
-
-						mph.showDetails(target);
-					}
-					target.onActivityResult(mFragment.getTargetRequestCode(), resultCode, data);
-				}
-			}
-		} else {
-			getAppCompatActivity().setResult(resultCode, data);
-			getAppCompatActivity().finish();
-		}
+		// Nested leaves finish only under PhoneNavHost; remaining hosts close themselves.
+		getAppCompatActivity().setResult(resultCode, data);
+		getAppCompatActivity().finish();
 	}
 }

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/HttpFragmentHelper.java
@@ -6,7 +6,6 @@
 
 package net.reichholf.dreamdroid.fragment.helper;
 
-import android.app.SearchManager;
 import android.content.Context;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -23,12 +22,10 @@ import android.view.View;
 import android.widget.Toast;
 
 import net.reichholf.dreamdroid.R;
-import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler;
 import net.reichholf.dreamdroid.enigma.EnigmaClient;
 import net.reichholf.dreamdroid.enigma.Service;
 import net.reichholf.dreamdroid.enigma.SimpleResultLoadKt;
 import net.reichholf.dreamdroid.enigma.VolumePowerSleepLoadKt;
-import net.reichholf.dreamdroid.fragment.EpgSearchFragment;
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment;
 import net.reichholf.dreamdroid.fragment.ScreenShotFragment;
 import net.reichholf.dreamdroid.fragment.interfaces.IHttpBase;
@@ -270,13 +267,7 @@ public class HttpFragmentHelper {
             }
             walker = walker.getParentFragment();
         }
-        EpgSearchFragment f = new EpgSearchFragment();
-        Bundle args = new Bundle();
-        args.putString(SearchManager.QUERY, query);
-        f.setArguments(args);
-
-        MultiPaneHandler m = (MultiPaneHandler) getAppCompatActivity();
-        m.showDetails(f, true);
+        throw new IllegalStateException("EPG search requires PhoneNavHostFragment");
     }
 
     /**

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -127,6 +127,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | fix-hub-nested-teardown | [#287](https://github.com/sreichholf/dreamDroid/pull/287) | merged | Fix hub TV/Movies bottom bar stuck after leaving hub (remove nested leaf on NavHost route dispose). Keep OkHttp 3.14.9. |
 | widgets-2-6c-config | [#288](https://github.com/sreichholf/dreamDroid/pull/288) | merged | Phase 2.6c: Compose Virtual Remote widget config activity; keep RemoteViews grids. Keep OkHttp 3.14.9. |
 | retire-simple-fragment-activity | [#289](https://github.com/sreichholf/dreamDroid/pull/289) | merged | Drop orphan `SimpleFragmentActivity`; route SEARCH to `MainActivity` / PhoneNavHost EPG search. Keep OkHttp 3.14.9. |
+| assert-navhost-leaf-fallbacks | (this PR) | open | Drop dead bare leaf `showDetails` fallbacks; cold SEARCH mounts `PhoneNavHost` + `queueEpgSearch`. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -206,6 +207,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Nested NavHost leaf teardown (hub bottom bar) **merged** [#287](https://github.com/sreichholf/dreamDroid/pull/287).
 - Phase 2.6c Compose widget config **merged** [#288](https://github.com/sreichholf/dreamDroid/pull/288).
 - Retire `SimpleFragmentActivity` **merged** [#289](https://github.com/sreichholf/dreamDroid/pull/289).
+- Assert NavHost leaf fallbacks **this PR** (drop bare `showDetails`; cold SEARCH mounts host).
 - Out of wave still: Phase 4–5 operator usertests. See Appendix H.
 
 ## How to read this


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Nested bouquet pick, service EPG, and similar-event search no longer fall back to bare `showDetails` leaf fragments; they require `PhoneNavHostFragment` (throw if missing).
- Cold `ACTION_SEARCH` / toolbar submit mounts `PhoneNavHost` (HUB) and `queueEpgSearch` instead of showing orphan `EpgSearchFragment`.
- `FragmentHelper.finish` keeps `deliverPickResult` only; drops multipane `showDetails(target)` / FM-pop path.
- Remove unused `showDetails(Class)` from `MultiPaneHandler` / `MainActivity`.
- Docs: status row for this PR.

## Non-goals
`VideoActivity` / `ShareActivity` stay. No OkHttp 4 / Glance / Media3.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug` (JDK 17)
- [ ] CI green
- [ ] Manual: Zap/EPG bouquet pick; hub → service EPG; similar events; toolbar + system SEARCH

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

