### PR TITLE
Docs: mark #293 EpgDatabase dead-weight cleanup merged

### DIFF
--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -128,7 +128,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | widgets-2-6c-config | [#288](https://github.com/sreichholf/dreamDroid/pull/288) | merged | Phase 2.6c: Compose Virtual Remote widget config activity; keep RemoteViews grids. Keep OkHttp 3.14.9. |
 | retire-simple-fragment-activity | [#289](https://github.com/sreichholf/dreamDroid/pull/289) | merged | Drop orphan `SimpleFragmentActivity`; route SEARCH to `MainActivity` / PhoneNavHost EPG search. Keep OkHttp 3.14.9. |
 | assert-navhost-leaf-fallbacks | [#291](https://github.com/sreichholf/dreamDroid/pull/291) | merged | Drop dead bare leaf `showDetails` fallbacks; cold SEARCH mounts `PhoneNavHost` + `queueEpgSearch`. Keep OkHttp 3.14.9. |
-| dead-weight-epg-database | (this PR) | open | Drop fully commented `EpgDatabase.java` + empty `epgsync/` package. Keep OkHttp 3.14.9. |
+| dead-weight-epg-database | [#293](https://github.com/sreichholf/dreamDroid/pull/293) | merged | Drop fully commented `EpgDatabase.java` + empty `epgsync/` package. Keep OkHttp 3.14.9. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -209,7 +209,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 2.6c Compose widget config **merged** [#288](https://github.com/sreichholf/dreamDroid/pull/288).
 - Retire `SimpleFragmentActivity` **merged** [#289](https://github.com/sreichholf/dreamDroid/pull/289).
 - Assert NavHost leaf fallbacks **merged** [#291](https://github.com/sreichholf/dreamDroid/pull/291).
-- Dead-weight: drop commented `EpgDatabase` **this PR**.
+- Dead-weight: drop commented `EpgDatabase` **merged** [#293](https://github.com/sreichholf/dreamDroid/pull/293).
 - Out of wave still: Phase 4–5 operator usertests. See Appendix H.
 
 ## How to read this
@@ -796,7 +796,7 @@ Why:
 | 2.5b | Typed overlay state (`ServiceNowNext` / movie) — stop hashing for overlay UI lists | **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244). No Media3 |
 | 2.5c | Compose overlay controls inside existing `VideoActivity` | **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245). Keep libVLC + Intent edge; ButterKnife drop folded |
 | 2.5d | Drop ButterKnife binds + dependency (last phone binds) | **done in #245** (folded into 2.5c) |
-| 2.5e | Optional: thin Kotlin VLC wrapper + instrumented overlay smoke | No codec / server work |
+| 2.5e | Optional: thin Kotlin VLC wrapper + instrumented overlay smoke | Still open (optional; not required to close this chassis stretch). No codec / server work |
 
 #### Explicit non-goals of 2.5c ([#245](https://github.com/sreichholf/dreamDroid/pull/245))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Mark dead-weight EpgDatabase cleanup [#293](https://github.com/sreichholf/dreamDroid/pull/293) merged.
- Note Phase 2.5e (thin Kotlin VLC wrapper) remains optional for this chassis stretch.

## Test plan
- [x] Docs-only
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

