### PR TITLE
Sign debug builds with repo keystore; upload arm64 CI APK

### DIFF
--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -41,11 +41,20 @@ emu_wait_boot
 echo "== connected-test: installing app + test APKs (streamed) =="
 # The TCG emulator occasionally drops the package-service socket mid-install
 # ("Broken pipe"); retry rather than fail the whole run.
+# A leftover install signed with ~/.android/debug.keystore fails with
+# INSTALL_FAILED_UPDATE_INCOMPATIBLE after switching to the repo keystore.
 adb_install() {
-  local apk="$1" attempt
+  local apk="$1" attempt out
   for attempt in 1 2 3; do
-    if "$ADB" -s "$SERIAL" install -r -t "$apk"; then
+    if out=$("$ADB" -s "$SERIAL" install -r -t "$apk" 2>&1); then
+      printf '%s\n' "$out"
       return 0
+    fi
+    printf '%s\n' "$out" >&2
+    if printf '%s\n' "$out" | grep -q INSTALL_FAILED_UPDATE_INCOMPATIBLE; then
+      echo "connected-test: signature mismatch; uninstalling debug packages" >&2
+      "$ADB" -s "$SERIAL" uninstall net.reichholf.dreamdroid.debug || true
+      "$ADB" -s "$SERIAL" uninstall net.reichholf.dreamdroid.debug.test || true
     fi
     echo "connected-test: install attempt $attempt failed, retrying..." >&2
     "$ADB" -s "$SERIAL" wait-for-device || true

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -67,13 +67,27 @@ jobs:
       # .temp path; dependency/build caches already make the real work ~30s.
       # -Pci disables ABI splits (one APK). androidTest compile catches broken
       # Compose tests without an emulator.
-      - name: Unit tests + assemble + compile androidTest
+      - name: Unit tests + compile androidTest
         run: >
           ./gradlew -Pci --no-configuration-cache
           :app:testGoogleDebugUnitTest
-          :app:assembleGoogleDebug
           :app:compileGoogleDebugAndroidTestKotlin
           :app:compileGoogleDebugAndroidTestJavaWithJavac
+
+      # Separate assemble so the artifact zip is arm64-only (~57MB), not the
+      # -Pci fat APK (~197MB). -Parm64Apk enables a single ABI split.
+      - name: Assemble googleDebug arm64 APK
+        run: >
+          ./gradlew --no-configuration-cache -Parm64Apk
+          :app:assembleGoogleDebug
+
+      - name: Upload googleDebug arm64 APK
+        uses: actions/upload-artifact@v6
+        with:
+          name: dreamdroid-google-debug-apk
+          path: app/build/outputs/apk/google/debug/app-google-arm64-v8a-debug.apk
+          if-no-files-found: error
+          retention-days: 2
 
       - name: Upload unit test reports
         if: always()

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -74,14 +74,16 @@ jobs:
           :app:compileGoogleDebugAndroidTestKotlin
           :app:compileGoogleDebugAndroidTestJavaWithJavac
 
-      # Separate assemble so the artifact zip is arm64-only (~57MB), not the
-      # -Pci fat APK (~197MB). -Parm64Apk enables a single ABI split.
+      # Phone-installable arm64 APK for main only (not every PR). -Parm64Apk
+      # builds a single ABI split (~57MB) instead of the fat -Pci APK.
       - name: Assemble googleDebug arm64 APK
+        if: github.event_name != 'pull_request'
         run: >
           ./gradlew --no-configuration-cache -Parm64Apk
           :app:assembleGoogleDebug
 
       - name: Upload googleDebug arm64 APK
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: dreamdroid-google-debug-apk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use `JAVA_HOME` pointing at JDK 25. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, assemble, androidTest compile (all with `-Pci` to skip ABI splits). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`); uploads arm64 `dreamdroid-google-debug-apk` (2-day retention). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` exists for a shell-only dump when there is no instrumented test yet. It is not the verification loop.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use `JAVA_HOME` pointing at JDK 25. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`); uploads arm64 `dreamdroid-google-debug-apk` (2-day retention). Emulator `connectedGoogleDebugAndroidTest` (API 30) runs on `main` pushes and manual `workflow_dispatch` only (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`). On `main` pushes / `workflow_dispatch` only: uploads arm64 `dreamdroid-google-debug-apk` (2-day retention) and emulator `connectedGoogleDebugAndroidTest` (API 30). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` exists for a shell-only dump when there is no instrumented test yet. It is not the verification loop.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -149,11 +149,17 @@ android {
     }
     splits {
         abi {
-            // CI passes -Pci (unit + androidTest jobs) so we build one APK.
-            enable !project.hasProperty("ci")
+            // -Pci: one fat APK (unit/androidTest jobs).
+            // -Parm64Apk: ABI-split arm64-only (CI artifact upload).
+            enable project.hasProperty("arm64Apk") || !project.hasProperty("ci")
             reset()
-            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-            universalApk true
+            if (project.hasProperty("arm64Apk")) {
+                include 'arm64-v8a'
+                universalApk false
+            } else {
+                include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+                universalApk true
+            }
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,16 @@ android {
             }
         }
     }
+    // Shared debug cert (repo-root debug.keystore) so CI, Cloud, and local
+    // googleDebug APKs are interchangeable. AGP's default is ~/.android/debug.keystore.
+    signingConfigs {
+        debug {
+            storeFile rootProject.file("debug.keystore")
+            storePassword "android"
+            keyAlias "androiddebugkey"
+            keyPassword "android"
+        }
+    }
     flavorDimensions "distribution"
     productFlavors {
         google {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Sign googleDebug with the repo `debug.keystore` so CI / Cloud / local APKs share one cert
- Upload arm64-only `dreamdroid-google-debug-apk` (**main pushes / `workflow_dispatch` only**, not PRs; 2-day retention)
- `-Parm64Apk` builds a single ABI-split APK for phone install

## Why
Cursor agent artifact paths 404; GitHub Actions on `main` is the reliable download path. Skip APK assemble on PRs to keep PR CI lighter.

## Test plan
- [x] PR CI runs unit tests without uploading the APK artifact
- [ ] After merge, `main` CI uploads `dreamdroid-google-debug-apk` with `app-google-arm64-v8a-debug.apk`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-798a7540-1355-4c62-b052-9bcd7238fdc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-798a7540-1355-4c62-b052-9bcd7238fdc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

