### PR TITLE
Upgrade to Gradle 9.6, AGP 9.4, and JDK 25

### DIFF
--- a/.cursor/cloud/connected-test.sh
+++ b/.cursor/cloud/connected-test.sh
@@ -20,7 +20,7 @@ fi
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/emulator.sh"
 
-export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-25-openjdk-amd64}"
 export PATH="$JAVA_HOME/bin:$PATH"
 APP_APK="$REPO_ROOT/app/build/outputs/apk/google/debug/app-google-x86_64-debug.apk"
 TEST_APK="$REPO_ROOT/app/build/outputs/apk/androidTest/google/debug/app-google-debug-androidTest.apk"

--- a/.cursor/cloud/install.sh
+++ b/.cursor/cloud/install.sh
@@ -1,50 +1,50 @@
 #!/usr/bin/env bash
 # Cloud Agent install phase for dreamDroid.
-# Idempotent: installs JDK 17, the Android SDK, an emulator AVD, and warms the
+# Idempotent: installs JDK 25, the Android SDK, an emulator AVD, and warms the
 # Gradle build. Safe to re-run. Heavy stable state that a build snapshot keeps.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
-JAVA_HOME_17="/usr/lib/jvm/java-17-openjdk-amd64"
+JAVA_HOME_25="/usr/lib/jvm/java-25-openjdk-amd64"
 CMDLINE_TOOLS_VERSION="11076708"
 AVD_NAME="dreamdroid-verify"
 SYSTEM_IMAGE="system-images;android-34;google_apis;x86_64"
 SDK_PACKAGES=(
   "platform-tools"
   "platforms;android-34"
-  "build-tools;34.0.0"
+  "build-tools;36.0.0"
   "emulator"
   "$SYSTEM_IMAGE"
 )
 ENV_FILE="$HOME/.cursor/dreamdroid/env.sh"
 
-echo "== install: system packages (JDK 17, KVM, tools) =="
+echo "== install: system packages (JDK 25, KVM, tools) =="
 sudo apt-get update -qq
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-  openjdk-17-jdk qemu-kvm unzip curl
+  openjdk-25-jdk qemu-kvm unzip curl
 
-# AGP 8.2's jlink transform fails on JDK 21, so pin the JVM to 17 and fail if
-# that JDK is missing. Also write env.sh so later shells (start/tests) inherit it.
-if [ ! -x "$JAVA_HOME_17/bin/java" ]; then
-  echo "install: JDK 17 missing at $JAVA_HOME_17" >&2
+# Pin the Gradle JVM to JDK 25 (AGP 9.4 + Gradle 9.6). Fail if missing.
+# Also write env.sh so later shells (start/tests) inherit it.
+if [ ! -x "$JAVA_HOME_25/bin/java" ]; then
+  echo "install: JDK 25 missing at $JAVA_HOME_25" >&2
   exit 1
 fi
-sudo update-java-alternatives -s java-1.17.0-openjdk-amd64 >/dev/null 2>&1 || \
-  echo "install: update-java-alternatives failed; relying on JAVA_HOME=$JAVA_HOME_17" >&2
-export JAVA_HOME="$JAVA_HOME_17"
+sudo update-java-alternatives -s java-1.25.0-openjdk-amd64 >/dev/null 2>&1 || \
+  echo "install: update-java-alternatives failed; relying on JAVA_HOME=$JAVA_HOME_25" >&2
+export JAVA_HOME="$JAVA_HOME_25"
 export PATH="$JAVA_HOME/bin:$PATH"
 mkdir -p "$(dirname "$ENV_FILE")"
 cat > "$ENV_FILE" <<EOF
-export JAVA_HOME="$JAVA_HOME_17"
+export JAVA_HOME="$JAVA_HOME_25"
 export PATH="\$JAVA_HOME/bin:\$PATH"
 export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
 export ANDROID_HOME="$ANDROID_SDK_ROOT"
 EOF
 echo "JAVA_HOME=$JAVA_HOME"
 java -version
-java -version 2>&1 | grep -q 'version "17\.' || {
-  echo "install: expected JDK 17 on PATH, got:" >&2
+java -version 2>&1 | grep -q 'version "25\.' || {
+  echo "install: expected JDK 25 on PATH, got:" >&2
   java -version >&2
   exit 1
 }

--- a/.cursor/cloud/start.sh
+++ b/.cursor/cloud/start.sh
@@ -12,7 +12,7 @@ if [ -f "$ENV_FILE" ]; then
   # shellcheck source=/dev/null
   source "$ENV_FILE"
 fi
-export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-25-openjdk-amd64}"
 export PATH="$JAVA_HOME/bin:$PATH"
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
 export ANDROID_HOME="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"

--- a/.cursor/skills/verify-dreamdroid/SKILL.md
+++ b/.cursor/skills/verify-dreamdroid/SKILL.md
@@ -11,7 +11,7 @@ dreamDroid is a phone/tablet Enigma2 remote (`net.reichholf.dreamdroid`). **Defa
 ./gradlew.bat :app:connectedGoogleDebugAndroidTest
 ```
 
-Use **JDK 17** (`JAVA_HOME`). AGP 8.2's `jlink` transform fails on JDK 21. Do not pass `-Pandroid.testInstrumentationRunnerArguments...` — that sets Gradle property `android` to a String and breaks `android.applicationVariants`. Filter a class with:
+Use **JDK 25** (`JAVA_HOME`). App `compileOptions` stay on Java 17; Gradle/AGP run on JDK 25. Do not pass `-Pandroid.testInstrumentationRunnerArguments...` — that sets Gradle property `android` to a String and breaks `android.applicationVariants`. Filter a class with:
 
 ```bash
 adb shell am instrument -w -e class net.reichholf.dreamdroid.ui.about.AboutScreenTest net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner
@@ -37,7 +37,7 @@ Read [features/README.md](features/README.md) before driving. Exercise the mappe
 
 ## Launch (optional look)
 
-1. `JAVA_HOME` at JDK 17. `gradle.properties` must not pass `-XX:MaxPermSize` or CMS flags.
+1. `JAVA_HOME` at JDK 25. `gradle.properties` must not pass `-XX:MaxPermSize` or CMS flags.
 2. Install if needed: `./gradlew.bat :app:installGoogleDebug`
 3. Disposable session: `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch --clear-data`
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: temurin
 
       # ubuntu-latest already ships Android SDK + ANDROID_HOME. Do not use
@@ -48,7 +48,7 @@ jobs:
           # Image has 34+; AGP still auto-fetches platform 33 mid-build and leaves
           # $SDK/.temp/PackageOperation* fingerprints that poison config-cache.
           yes | "$SDKMANAGER" --licenses >/dev/null || true
-          "$SDKMANAGER" "platforms;android-33" "platforms;android-34" "build-tools;34.0.0"
+          "$SDKMANAGER" "platforms;android-33" "platforms;android-34" "build-tools;36.0.0"
           rm -rf "$SDK/.temp"
 
       - name: Setup Gradle
@@ -103,10 +103,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: temurin
 
       - name: Ensure Android SDK platforms
@@ -126,7 +126,7 @@ jobs:
           # Image has 34+; AGP still auto-fetches platform 33 mid-build and leaves
           # $SDK/.temp/PackageOperation* fingerprints that poison config-cache.
           yes | "$SDKMANAGER" --licenses >/dev/null || true
-          "$SDKMANAGER" "platforms;android-33" "platforms;android-34" "build-tools;34.0.0"
+          "$SDKMANAGER" "platforms;android-33" "platforms;android-34" "build-tools;36.0.0"
           rm -rf "$SDK/.temp"
 
       - name: Setup Gradle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # dreamDroid agent notes
 
-Phone Enigma2 remote. Rewrite trunk is `main`. Sources live in `app/src` and `app/res`, not `src/main`. Debug package is `net.reichholf.dreamdroid.debug`. Build with **JDK 17**.
+Phone Enigma2 remote. Rewrite trunk is `main`. Sources live in `app/src` and `app/res`, not `src/main`. Debug package is `net.reichholf.dreamdroid.debug`. Build with **JDK 25**.
 
 **New code is Kotlin.** Do not add new `.java` types for modernization work (helpers, UI, loaders, widgets). Edit existing Java surgically when needed; convert to Kotlin when touching a file heavily or extracting a new type. Prefer coroutines over executors/`AsyncTask`/`JobIntentService`.
 
@@ -18,7 +18,7 @@ Default proof for Compose and in-app UI:
 ./gradlew.bat :app:connectedGoogleDebugAndroidTest
 ```
 
-Use `JAVA_HOME` pointing at JDK 17. Tests live in `app/androidTest/java`. Add Compose UI tests next to each new screen (`createComposeRule` / `createAndroidComposeRule`). If the UI is Compose inside an XML dialog or `ComposeView`, the test must host it that way — a naked `setContent { }` will not catch `LocalContentColor` leaks from the View theme.
+Use `JAVA_HOME` pointing at JDK 25. Tests live in `app/androidTest/java`. Add Compose UI tests next to each new screen (`createComposeRule` / `createAndroidComposeRule`). If the UI is Compose inside an XML dialog or `ComposeView`, the test must host it that way — a naked `setContent { }` will not catch `LocalContentColor` leaks from the View theme.
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
@@ -28,7 +28,7 @@ CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGo
 
 ## Cloud Agent environment
 
-Setup lives in [`.cursor/environment.json`](.cursor/environment.json) with scripts under `.cursor/cloud/`. `install.sh` installs JDK 17 + the Android SDK (build-tools 34, platform 34, `google_apis;x86_64` image), creates the `dreamdroid-verify` AVD, warms the Gradle build, and bakes a booted quickboot snapshot. `start.sh` boots that emulator each session.
+Setup lives in [`.cursor/environment.json`](.cursor/environment.json) with scripts under `.cursor/cloud/`. `install.sh` installs JDK 25 + the Android SDK (build-tools 36, platform 34, `google_apis;x86_64` image), creates the `dreamdroid-verify` AVD, warms the Gradle build, and bakes a booted quickboot snapshot. `start.sh` boots that emulator each session.
 
 Nested KVM guest execution hangs on Cursor Cloud VMs: `/dev/kvm` exists and `kvm-ok` passes, but under `-enable-kvm` the guest vCPU never runs (0% CPU, no kernel output). The emulator therefore runs under software (`-accel off`, TCG). It works but is slow. Set `DREAMDROID_EMU_ACCEL=auto` to try KVM on a host that supports nested virt.
 
@@ -42,5 +42,5 @@ bash .cursor/cloud/connected-test.sh net.reichholf.dreamdroid.ui.about.AboutScre
 ## Other traps
 
 - `main` is the rewrite. Do not merge rewrite work into `master`.
-- AGP 8.2 `jlink` fails on JDK 21.
+- Gradle 9.6 / AGP 9.4; run the build on JDK 25 (app bytecode stays Java 17).
 - Two googleDebug processes cannot share one device.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,17 +6,15 @@ buildscript {
         }
         google()
     }
+    ext.kotlin_version = rootProject.ext.kotlin_version
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:9.4.0'
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
     }
-    ext.kotlin_version = '1.9.24'
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-
 }
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+// AGP 9: Kotlin is built-in. Compose needs the Compose compiler Gradle plugin.
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 repositories {
     google()
@@ -75,12 +73,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
-configurations.configureEach { cfg ->
-    if (cfg.name.startsWith("kotlinCompilerPluginClasspath") && !cfg.name.contains("Native")) {
-        project.dependencies.add(cfg.name, "androidx.compose.compiler:compiler:1.5.14")
-    }
-}
-
 android {
     namespace = "net.reichholf.dreamdroid"
     compileSdk Integer.parseInt(project.COMPILE_SDK_VERSION)
@@ -101,14 +93,22 @@ android {
                     exclude 'test/**'
                     exclude 'androidTest/**'
                 }
+                // AGP 9 built-in Kotlin does not compile .kt from java srcDirs.
+                kotlin {
+                    srcDirs = ['src']
+                    exclude 'test/**'
+                    exclude 'androidTest/**'
+                }
                 res.srcDirs = ['res']
             }
             test {
                 java.srcDirs = ['src/test/java']
+                kotlin.srcDirs = ['src/test/java']
                 resources.srcDirs = ['src/test/resources']
             }
             androidTest {
                 java.srcDirs = ['androidTest/java']
+                kotlin.srcDirs = ['androidTest/java']
                 res.srcDirs = ['androidTest/res']
             }
         }
@@ -138,15 +138,7 @@ android {
         }
     }
 
-    project.ext.versionCodes = ['armeabi': 1, 'armeabi-v7a': 2, 'arm64-v8a': 3, 'mips': 5, 'mips64': 6, 'x86': 8, 'x86_64': 9]
-
-    android.applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            output.versionCodeOverride =
-                    project.ext.versionCodes.get(output.getFilter(
-                            com.android.build.OutputFile.ABI), 99) * 10000000 + android.defaultConfig.versionCode
-        }
-    }
+    // ABI versionCode overrides moved to androidComponents (AGP 9 removed applicationVariants).
 
     buildTypes {
         debug {
@@ -170,17 +162,28 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     lint {
         abortOnError false
     }
     buildFeatures {
         buildConfig true
         compose true
+        // AGP 9 defaults resValues to false; debug/release use resValue.
+        resValues true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion '1.5.14'
+}
+
+// ABI versionCode overrides via the AGP 9 Variant API.
+ext.abiVersionCodes = ['armeabi': 1, 'armeabi-v7a': 2, 'arm64-v8a': 3, 'mips': 5, 'mips64': 6, 'x86': 8, 'x86_64': 9]
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.forEach { output ->
+            def abiFilter = output.filters.find {
+                it.filterType == com.android.build.api.variant.FilterConfiguration.FilterType.ABI
+            }
+            def abiCode = project.ext.abiVersionCodes.get(abiFilter?.identifier, 99)
+            def base = output.versionCode.orNull ?: android.defaultConfig.versionCode
+            output.versionCode.set(abiCode * 10000000 + base)
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,12 @@ buildscript {
         mavenCentral()
         google()
     }
-    ext.kotlin_version = '1.9.24'
+    // AGP 9 ships built-in Kotlin (KGP >= 2.2.10). Compose compiler plugin
+    // version must match that KGP line.
+    ext.kotlin_version = '2.2.10'
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:9.4.0'
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
     }
 }
 allprojects {

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -4,11 +4,11 @@ Phone users get a Compose Material 3 remote. TV stays Leanback until a later pro
 
 Rewrite trunk is **`main`**. `master` is last 1.15 stable. Do not merge `master` or branches cut from `master` into `main`.
 
-Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap loops. See [`AGENTS.md`](../AGENTS.md). AVD `dreamdroid-verify`. JDK 17. Debug package `net.reichholf.dreamdroid.debug`.
+Default UI proof is instrumented Compose tests, not `verify-dreamdroid.py` tap loops. See [`AGENTS.md`](../AGENTS.md). AVD `dreamdroid-verify`. JDK 25. Debug package `net.reichholf.dreamdroid.debug`.
 
 **Language:** new types are **Kotlin** (not Java). Prefer coroutines. Existing Java may stay until edited; heavy edits / extracted helpers go Kotlin. See [`AGENTS.md`](../AGENTS.md).
 
-GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/android-ci.yml) runs on PRs/`main` — unit tests + assemble + androidTest compile (JDK 17), plus instrumented Compose tests on an API 30 emulator (`-Pci` disables ABI splits for a single installable APK).
+GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/android-ci.yml) runs on PRs/`main` — unit tests + assemble + androidTest compile (JDK 25), plus instrumented Compose tests on an API 30 emulator (`-Pci` disables ABI splits for a single installable APK).
 
 ## Status as of 2026-09-09
 
@@ -144,7 +144,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Theme follows `DreamDroid.getThemeType()`. Default `"1"` is always night. Do not reopen `colorSchemeFromViewTheme`. Version/license `Text` uses `onSurface`. Dialog-hosted Compose must be tested in a dialog/`ComposeView`, not only `setContent { }`.
 - `captureToImage` on this AVD returns black pixels even for light content. Do not use pixel-luminance tests.
 - Java calling Kotlin `(T) -> Unit` must `return kotlin.Unit.INSTANCE`. `DisposeOnViewTreeLifecycleDestroyed` is set from Kotlin, not Java.
-- Two googleDebug processes cannot share one device. AGP 8.2 `jlink` fails on JDK 21.
+- Two googleDebug processes cannot share one device. Gradle 9.6 / AGP 9.4 on JDK 25 (bytecode Java 17).
 
 ### Not done, recorded so it is not pretended done
 
@@ -236,7 +236,7 @@ The original playbook wanted ten live `verify-dreamdroid.py` lanes plus a perf r
 ### PR mechanics, for every PR
 
 - [x] PRs opened ready, never draft, `--base main`.
-- [x] JDK 17 assemble / connected tests before push where UI changed.
+- [x] JDK 25 assemble / connected tests before push where UI changed.
 - [x] Cursor git wrapper injects `--trailer`; Git 2.23 rejects it. Commit via Python calling `git.exe` with `-F`.
 
 ## Raise the device floor (pr-floor)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,14 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --enable-native-access=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-BUILD_TOOLS_VERSION 34.0.0
+BUILD_TOOLS_VERSION 36.0.0
 COMPILE_SDK_VERSION 34
 android.useAndroidX=true
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
+# Keep final R fields so existing Java switch(R.id...) / Statics.ITEM_* keep compiling.
 android.nonFinalResIds=false
+android.enableAppCompileTimeRClass=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Mar 19 21:41:36 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip

--- a/libraries/AttributionPresenter/build.gradle
+++ b/libraries/AttributionPresenter/build.gradle
@@ -1,24 +1,2 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        jcenter()
-        maven { url 'https://maven.google.com' }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-    }
-}
-
-allprojects {
-    repositories {
-        jcenter()
-        google()
-        maven { url 'https://jitpack.io' }
-    }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+// Intermediate project for the vendored AttributionPresenter tree.
+// Build logic lives in the root build.gradle and library/build.gradle.

--- a/libraries/AttributionPresenter/library/build.gradle
+++ b/libraries/AttributionPresenter/library/build.gradle
@@ -5,6 +5,8 @@ version = '1.0.1'
 
 android {
     compileSdk 33
+    // Java-only library — skip AGP 9 built-in Kotlin for this module.
+    enableKotlin false
 
     defaultConfig {
         minSdkVersion 15
@@ -24,7 +26,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     namespace 'com.franmontiel.attributionpresenter'

--- a/libraries/simple-gauge-android/build.gradle
+++ b/libraries/simple-gauge-android/build.gradle
@@ -1,27 +1,2 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    ext.kotlin_version = '1.6.21'
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+// Intermediate project for the vendored simple-gauge-android tree.
+// Build logic lives in the root build.gradle and gaugelibrary/build.gradle.

--- a/libraries/simple-gauge-android/gaugelibrary/build.gradle
+++ b/libraries/simple-gauge-android/gaugelibrary/build.gradle
@@ -6,6 +6,8 @@ plugins {
 
 android {
     compileSdk 33
+    // Java-only library — skip AGP 9 built-in Kotlin for this module.
+    enableKotlin false
 
 
 
@@ -20,7 +22,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     namespace 'com.ekndev.gaugelibrary'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+    }
+}
+
 include ':app'
 include ':libraries:AttributionPresenter:library'
 include ':libraries:simple-gauge-android:gaugelibrary'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump the Android build to **Gradle 9.6.0** + **AGP 9.4.0** (Google’s current AGP 9.4 recommendation) and run the Gradle JVM on **JDK 25**.
- App bytecode stays on **Java 17**; only the build/runtime JDK moves to 25.
- Migrate AGP 9 breakages: built-in Kotlin (drop `kotlin-android`), Compose compiler Gradle plugin, `androidComponents` ABI `versionCode` overrides, Kotlin source sets for the non-standard `src/` layout, and library `enableKotlin false`.
- Update CI, Cloud Agent install/start scripts, and agent docs accordingly. Build-tools → 36.0.0.

## Test plan
- [x] `JAVA_HOME` = JDK 25
- [x] `./gradlew -Pci --no-configuration-cache :app:testGoogleDebugUnitTest :app:assembleGoogleDebug :app:compileGoogleDebugAndroidTestKotlin :app:compileGoogleDebugAndroidTestJavaWithJavac` — **54 unit tests, 0 failures**
- [ ] CI unit job on the PR
- [ ] Optional after env rebuild: `bash .cursor/cloud/connected-test.sh`

[JDK 25 + Gradle 9.6 build proof](https://cursor.com/agents/bc-925a9585-0081-4831-8e04-716c5b940a15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjdk25-gradle96-build-proof.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-925a9585-0081-4831-8e04-716c5b940a15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-925a9585-0081-4831-8e04-716c5b940a15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

