### PR TITLE
Bump OkHttp to 4.12.0 for Picasso/TLS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'com.github.StephenVinouze:MaterialNumberPicker:1.0.5'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
     implementation 'com.squareup.picasso:picasso:2.8'
     implementation 'commons-net:commons-net:3.6'

--- a/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
+++ b/app/src/net/reichholf/dreamdroid/activities/abs/BaseActivity.java
@@ -40,7 +40,6 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import okhttp3.internal.tls.OkHostnameVerifier;
 
 /**
  * Created by Stephan on 06.11.13.
@@ -104,7 +103,9 @@ public class BaseActivity extends AppCompatActivity implements ActionDialog.Dial
                         return response.request().newBuilder().header("Authorization", cred).build();
                     })
                     .sslSocketFactory(sc.getSocketFactory(), systemDefaultTrustManager())
-                    .hostnameVerifier(mTrustManager.wrapHostnameVerifier(OkHostnameVerifier.INSTANCE));
+                    // OkHttp 4: avoid okhttp3.internal.*; match HttpsURLConnection verifier wrap.
+                    .hostnameVerifier(mTrustManager.wrapHostnameVerifier(
+                            HttpsURLConnection.getDefaultHostnameVerifier()));
             Picasso.Builder builder = new Picasso.Builder(getApplicationContext());
 			builder.downloader(new OkHttp3Downloader(clientBuilder.build()));
 			try {

--- a/app/src/net/reichholf/dreamdroid/tv/activities/MainActivity.java
+++ b/app/src/net/reichholf/dreamdroid/tv/activities/MainActivity.java
@@ -25,7 +25,6 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import okhttp3.internal.tls.OkHostnameVerifier;
 
 /**
  * Created by Stephan on 16.10.2016.
@@ -89,7 +88,9 @@ public class MainActivity extends FragmentActivity {
 						return response.request().newBuilder().header("Authorization", cred).build();
 					})
 					.sslSocketFactory(sc.getSocketFactory(), systemDefaultTrustManager())
-					.hostnameVerifier(mTrustManager.wrapHostnameVerifier(OkHostnameVerifier.INSTANCE));
+					// OkHttp 4: avoid okhttp3.internal.*; match HttpsURLConnection verifier wrap.
+					.hostnameVerifier(mTrustManager.wrapHostnameVerifier(
+							HttpsURLConnection.getDefaultHostnameVerifier()));
 			Picasso.Builder builder = new Picasso.Builder(getApplicationContext());
 			builder.downloader(new OkHttp3Downloader(clientBuilder.build()));
 			try {

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -130,6 +130,7 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | assert-navhost-leaf-fallbacks | [#291](https://github.com/sreichholf/dreamDroid/pull/291) | merged | Drop dead bare leaf `showDetails` fallbacks; cold SEARCH mounts `PhoneNavHost` + `queueEpgSearch`. Keep OkHttp 3.14.9. |
 | dead-weight-epg-database | [#293](https://github.com/sreichholf/dreamDroid/pull/293) | merged | Drop fully commented `EpgDatabase.java` + empty `epgsync/` package. Keep OkHttp 3.14.9. |
 | vlc-kotlin-wrapper | [#296](https://github.com/sreichholf/dreamDroid/pull/296) | merged | Phase 2.5e: thin Kotlin `VLCInstance`/`VLCPlayer`; keep existing overlay Compose smoke test. Keep OkHttp 3.14.9. |
+| okhttp4-picasso | (this PR) | open | Bump OkHttp 3.14.9 → 4.12.0 for Picasso/TLS; drop `okhttp3.internal` hostname verifier. Enigma2 stays HttpURLConnection. No libVLC / Media3 / Glance. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -212,6 +213,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Assert NavHost leaf fallbacks **merged** [#291](https://github.com/sreichholf/dreamDroid/pull/291).
 - Dead-weight: drop commented `EpgDatabase` **merged** [#293](https://github.com/sreichholf/dreamDroid/pull/293).
 - Phase 2.5e thin Kotlin VLC wrapper **merged** [#296](https://github.com/sreichholf/dreamDroid/pull/296).
+- OkHttp 4.12 for Picasso/TLS **this PR** (Enigma2 HTTP unchanged).
 - Out of wave still: Phase 4–5 operator usertests. See Appendix H.
 
 ## How to read this
@@ -491,7 +493,7 @@ Evernote `@State` + Livefront Bridge retired in Phase 2.3 ([#252](https://github
 
 VLC `VideoActivity` is out of this program.
 
-Kotlin plugin is 1.9.24 with Compose compiler 1.5.14. OkHttp stays 3.14.9. Do not bump OkHttp to 4 as a drive-by.
+Kotlin plugin is 1.9.24 with Compose compiler 1.5.14. OkHttp **this PR** bumps Picasso stack to 4.12.0. Enigma2 HTTP remains HttpURLConnection.
 
 Test APK must define `app_name_debug` / `app_name_tv_debug` or AAPT fails.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump OkHttp **3.14.9 → 4.12.0** (Picasso picon/TLS client).
- Stop using `okhttp3.internal.tls.OkHostnameVerifier`; wrap the platform hostname verifier via `DreamDroidTrustManager` (phone `BaseActivity` + TV `MainActivity`).
- Enigma2 HTTP remains `HttpURLConnection` / `SimpleHttpClient`. No libVLC / Media3 / Glance in this PR.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [ ] CI green
- [ ] Manual (optional): picons load over HTTP(S) with profile auth

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

