### PR TITLE
Bump libvlc-all to 3.7.5; compileSdk 36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.5.5'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
     implementation 'com.google.android.material:material:1.8.0'
-    implementation 'org.videolan.android:libvlc-all:3.5.1'
+    implementation 'org.videolan.android:libvlc-all:3.7.5'
     implementation 'com.simplecityapps:recyclerview-fastscroll:2.0.1'
     implementation 'com.github.StephenVinouze:MaterialNumberPicker:1.0.5'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -130,7 +130,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | assert-navhost-leaf-fallbacks | [#291](https://github.com/sreichholf/dreamDroid/pull/291) | merged | Drop dead bare leaf `showDetails` fallbacks; cold SEARCH mounts `PhoneNavHost` + `queueEpgSearch`. Keep OkHttp 3.14.9. |
 | dead-weight-epg-database | [#293](https://github.com/sreichholf/dreamDroid/pull/293) | merged | Drop fully commented `EpgDatabase.java` + empty `epgsync/` package. Keep OkHttp 3.14.9. |
 | vlc-kotlin-wrapper | [#296](https://github.com/sreichholf/dreamDroid/pull/296) | merged | Phase 2.5e: thin Kotlin `VLCInstance`/`VLCPlayer`; keep existing overlay Compose smoke test. Keep OkHttp 3.14.9. |
-| okhttp4-picasso | (this PR) | open | Bump OkHttp 3.14.9 → 4.12.0 for Picasso/TLS; drop `okhttp3.internal` hostname verifier. Enigma2 stays HttpURLConnection. No libVLC / Media3 / Glance. |
+| okhttp4-picasso | [#299](https://github.com/sreichholf/dreamDroid/pull/299) | merged | Bump OkHttp 3.14.9 → 4.12.0 for Picasso/TLS; drop `okhttp3.internal` hostname verifier. Enigma2 stays HttpURLConnection. No libVLC / Media3 / Glance. |
+| libvlc-375-stable | (this PR) | open | Bump `libvlc-all` 3.5.1 → 3.7.5 (stable); raise `compileSdk` 34→36 (AAR requires ≥36); keep `targetSdk` 34. No Media3 / Glance. |
 
 Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Appendix E / H.
 
@@ -213,7 +214,8 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Assert NavHost leaf fallbacks **merged** [#291](https://github.com/sreichholf/dreamDroid/pull/291).
 - Dead-weight: drop commented `EpgDatabase` **merged** [#293](https://github.com/sreichholf/dreamDroid/pull/293).
 - Phase 2.5e thin Kotlin VLC wrapper **merged** [#296](https://github.com/sreichholf/dreamDroid/pull/296).
-- OkHttp 4.12 for Picasso/TLS **this PR** (Enigma2 HTTP unchanged).
+- OkHttp 4.12 for Picasso/TLS **merged** [#299](https://github.com/sreichholf/dreamDroid/pull/299) (Enigma2 HTTP unchanged).
+- libVLC-all **3.7.5** stable **this PR** (still not Media3).
 - Out of wave still: Phase 4–5 operator usertests. See Appendix H.
 
 ## How to read this
@@ -765,7 +767,7 @@ One program each, still one PR (or small PR series) at a time:
 | `VLCPlayer` | `video/VLCPlayer.java` | ~177 | Singleton `libvlc` `MediaPlayer` wrapper |
 | `VLCInstance` | `video/VLCInstance.java` | ~61 | Singleton `LibVLC` (`--http-reconnect`) |
 | Stream Intent edge | `intents/IntentFactory.java` + `helpers/SimpleHttpClient` stream URL builders | ~170 | Live TS / encoder / recording `/file` URLs; integrated vs external player |
-| Dep | `app/build.gradle` | — | `org.videolan.android:libvlc-all:3.5.1` |
+| Dep | `app/build.gradle` | — | `org.videolan.android:libvlc-all:3.7.5` |
 
 Behaviors to preserve if keeping integrated playback: live + recording streams; external-player pref fallback; PiP; bouquet zap + now/next; audio/subtitle tracks; HW-accel / gesture prefs; phone + TV share one `VideoActivity` (television overlay layout variant).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --enable-native-access=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 BUILD_TOOLS_VERSION 36.0.0
-COMPILE_SDK_VERSION 34
+COMPILE_SDK_VERSION 36
 android.useAndroidX=true
 org.gradle.configuration-cache=true
 android.enableJetifier=false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `org.videolan.android:libvlc-all` **3.5.1 → 3.7.5** (latest stable 3.x).
- Raise `compileSdk` **34 → 36** (3.7.4+ AARs declare `minCompileSdk=36`).
- Keep `targetSdk` **34**; no MediaPlayer / Media3 rewrite.
- Existing Kotlin `VLCPlayer` / `VLCInstance` + `VideoActivity` bindings compile unchanged.

## Test plan
- [x] `./gradlew :app:testGoogleDebugUnitTest :app:assembleGoogleDebug`
- [ ] CI green
- [ ] Manual (optional): live TS + recording seek/audio tracks still OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

