### PR TITLE
Align hub service list rows with VLC zap layout

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/services/ServiceListScreenTest.kt
@@ -53,8 +53,13 @@ class ServiceListScreenTest {
             }
         }
         composeRule.onNodeWithText("ARD").assertIsDisplayed()
-        composeRule.onNodeWithText("20:00  Tagesschau  15").assertIsDisplayed()
-        composeRule.onNodeWithText("20:15  Wetter  5").assertIsDisplayed()
+        // Now/next use separate start | title | end columns (aligned under each other).
+        composeRule.onNodeWithText("20:00").assertIsDisplayed()
+        composeRule.onNodeWithText("Tagesschau").assertIsDisplayed()
+        composeRule.onNodeWithText("15").assertIsDisplayed()
+        composeRule.onNodeWithText("20:15").assertIsDisplayed()
+        composeRule.onNodeWithText("Wetter").assertIsDisplayed()
+        composeRule.onNodeWithText("5").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -112,7 +112,7 @@ private fun ServiceRow(
         Column(Modifier.fillMaxWidth()) {
             if (item.kind == ServiceRowKind.CHANNEL && item.progressMax > 0) {
                 LinearProgressIndicator(
-                    progress = item.progress.toFloat() / item.progressMax.toFloat(),
+                    progress = { item.progress.toFloat() / item.progressMax.toFloat() },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(ProgressBarHeight),

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -50,8 +50,8 @@ typealias ServiceListTap = (item: ServiceListItem, windowX: Int, windowY: Int) -
 
 private val EventStartColumnWidth = 45.dp
 private val EventEndColumnWidth = 50.dp
-/** Thinner than the VLC zap list's 4dp strip so the bar sits on the card's top border. */
-private val ProgressBarHeight = 2.dp
+/** Slightly taller than the VLC zap list's 4dp strip so the top-edge progress reads clearly. */
+private val ProgressBarHeight = 6.dp
 
 @Composable
 fun ServiceListScreen(

--- a/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/ServiceListScreen.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
@@ -24,10 +26,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.preference.PreferenceManager
@@ -41,6 +47,11 @@ import kotlin.math.roundToInt
 
 /** Window-space top-left of the tapped row — used to anchor View PopupMenus. */
 typealias ServiceListTap = (item: ServiceListItem, windowX: Int, windowY: Int) -> Unit
+
+private val EventStartColumnWidth = 45.dp
+private val EventEndColumnWidth = 50.dp
+/** Thinner than the VLC zap list's 4dp strip so the bar sits on the card's top border. */
+private val ProgressBarHeight = 2.dp
 
 @Composable
 fun ServiceListScreen(
@@ -98,44 +109,105 @@ private fun ServiceRow(
             ),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
-        Column(Modifier.padding(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                if (item.kind == ServiceRowKind.CHANNEL) {
-                    ServicePicon(item)
-                }
+        Column(Modifier.fillMaxWidth()) {
+            if (item.kind == ServiceRowKind.CHANNEL && item.progressMax > 0) {
+                LinearProgressIndicator(
+                    progress = item.progress.toFloat() / item.progressMax.toFloat(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(ProgressBarHeight),
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            ) {
                 Text(
                     text = item.name,
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
-            }
-            if (item.kind == ServiceRowKind.CHANNEL) {
-                if (item.nowTitle.isNotEmpty()) {
-                    Text(
-                        text = "${item.nowStart}  ${item.nowTitle}  ${item.nowDuration}",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(top = 4.dp),
-                    )
-                }
-                if (item.progressMax > 0) {
-                    LinearProgressIndicator(
-                        progress = item.progress.toFloat() / item.progressMax.toFloat(),
+                if (item.kind == ServiceRowKind.CHANNEL &&
+                    (item.nowTitle.isNotEmpty() || item.nextTitle.isNotEmpty())
+                ) {
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 4.dp),
-                    )
-                }
-                if (item.nextTitle.isNotEmpty()) {
-                    Text(
-                        text = "${item.nextStart}  ${item.nextTitle}  ${item.nextDuration}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp),
-                    )
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ServicePicon(item)
+                        Column(modifier = Modifier.weight(1f)) {
+                            if (item.nowTitle.isNotEmpty()) {
+                                EventTimeRow(
+                                    start = item.nowStart,
+                                    title = item.nowTitle,
+                                    endValue = item.nowDuration,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                            if (item.nextTitle.isNotEmpty()) {
+                                EventTimeRow(
+                                    start = item.nextStart,
+                                    title = item.nextTitle,
+                                    endValue = item.nextDuration,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+/**
+ * Start | title | remaining-or-duration, with fixed start/end columns so now and next
+ * stack with dedicated fields aligned underneath each other (same as the VLC zap list).
+ */
+@Composable
+private fun EventTimeRow(
+    start: String,
+    title: String,
+    endValue: String,
+    style: TextStyle,
+    color: Color,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = start,
+            style = style,
+            color = color,
+            maxLines = 1,
+            modifier = Modifier.width(EventStartColumnWidth),
+        )
+        Text(
+            text = title,
+            style = style,
+            color = color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 4.dp),
+        )
+        Text(
+            text = endValue,
+            style = style,
+            color = color,
+            maxLines = 1,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(EventEndColumnWidth),
+        )
     }
 }
 
@@ -151,7 +223,7 @@ private fun ServicePicon(item: ServiceListItem) {
         factory = { ctx -> ImageView(ctx) },
         modifier = Modifier
             .padding(end = 8.dp)
-            .size(48.dp),
+            .size(width = 48.dp, height = 30.dp),
         update = { view ->
             val map = ExtendedHashMap()
             map.put(Service.KEY_REFERENCE, item.reference)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rework the Compose hub `ServiceRow` to match the VLC player zap list: progress strip on the card’s top border, service title full-width, then now/next as stacked `start | title | remaining/duration` columns.
- Progress bar is **6dp** at the top edge (player uses 4dp) so it reads clearly live.
- End column is right-aligned so now remaining sits above next duration; start times and titles likewise stack under each other.
- Update `ServiceListScreenTest` to assert the separate column texts.

## Test plan
- [x] Instrumented `ServiceListScreenTest` via `.cursor/cloud/connected-test.sh` — **OK (3 tests)**
- [ ] Visual spot-check on TV/Radio bouquet list vs VLC zap list (esp. 6dp progress)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

