### PR TITLE
Phase 2.1g-ii-b: About as Navigation Compose dialog

### DIFF
--- a/.cursor/skills/verify-dreamdroid/features/about.md
+++ b/.cursor/skills/verify-dreamdroid/features/about.md
@@ -18,11 +18,11 @@ Preconditions:
 - A device or emulator in `device` state.
 - No Enigma2 box is required.
 
-- **Proof.** Run `./gradlew.bat :app:connectedGoogleDebugAndroidTest`. `AboutScreenTest` and `AboutDialogHostTest` must pass. Night `LocalContentColor` is asserted equal to `onSurface` (light) inside `DreamDroidTheme`, including when hosted in a Material night `AlertDialog`.
+- **Proof.** Run `./gradlew.bat :app:connectedGoogleDebugAndroidTest`. `AboutScreenTest` and `AboutDialogHostTest` must pass. Night `LocalContentColor` equals `onSurface` (light) inside `DreamDroidTheme`, including when About is hosted as a Navigation Compose `dialog`.
 - **Look (optional).** `python .cursor/skills/verify-dreamdroid/scripts/verify-dreamdroid.py launch`, open the drawer, tap `Settings`, scroll to `About`, then `screenshot --path .cursor/skills/verify-dreamdroid/artifacts/about/screen.png`.
 
 ## Gotchas
 
 - Instrumented tests are the pass criteria. A screenshot is not a substitute.
-- About is a Settings footer row, not a drawer destination.
+- About opens as a Navigation Compose dialog from Settings (and the drawer), not a drawer destination.
 - Licenses is a separate button inside the dialog and is not this feature's pass criteria.

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutDialogHostTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/about/AboutDialogHostTest.kt
@@ -1,25 +1,22 @@
 package net.reichholf.dreamdroid.ui.about
 
-import android.view.ContextThemeWrapper
-import android.view.ViewGroup
 import androidx.activity.ComponentActivity
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
+import androidx.navigation.compose.rememberNavController
 import androidx.preference.PreferenceManager
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import net.reichholf.dreamdroid.DreamDroid
-import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -27,6 +24,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+/**
+ * Phase 2.1g-ii-b: About is a Navigation Compose `dialog`, not a DialogFragment /
+ * MaterialAlertDialogBuilder ComposeView host. Host the dialog the same way production does.
+ */
 class AboutDialogHostTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
@@ -39,37 +40,32 @@ class AboutDialogHostTest {
     }
 
     @Test
-    fun contentColorIsOnSurfaceInsideNightAlertDialog() {
+    fun contentColorIsOnSurfaceInsideNavDialog() {
         var localContent = Color.Unspecified
         var onSurface = Color.Unspecified
-        val activity = composeRule.activity
-        composeRule.runOnUiThread {
-            val themed = ContextThemeWrapper(activity, R.style.Theme_DreamDroid_Night)
-            val composeView = ComposeView(themed).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-                setViewTreeLifecycleOwner(activity)
-                setViewTreeViewModelStoreOwner(activity)
-                setViewTreeSavedStateRegistryOwner(activity)
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-                setContent {
-                    DreamDroidTheme {
+        composeRule.setContent {
+            DreamDroidTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = "home",
+                ) {
+                    composable("home") {
+                        LaunchedEffect(Unit) {
+                            navController.navigate(PhoneNavRoutes.ABOUT)
+                        }
+                    }
+                    dialog(PhoneNavRoutes.ABOUT) {
                         localContent = LocalContentColor.current
                         onSurface = MaterialTheme.colorScheme.onSurface
-                        AboutScreen(content = sampleAboutContent(), onLicensesClick = {})
+                        AboutDialog(onDismiss = { navController.popBackStack() })
                     }
                 }
             }
-            MaterialAlertDialogBuilder(themed)
-                .setTitle(R.string.about)
-                .setView(composeView)
-                .show()
         }
         composeRule.waitForIdle()
-        composeRule.onNodeWithText("1.15.460", substring = true).assertIsDisplayed()
         composeRule.onNodeWithText("Licenses").assertIsDisplayed()
+        composeRule.onNodeWithText("Close").assertIsDisplayed()
         composeRule.runOnIdle {
             assertEquals(onSurface, localContent)
             assertTrue(

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
@@ -813,7 +813,6 @@ class MainActivity :
 
         @JvmField
         val NAVIGATION_DIALOG_TAGS: List<String> = listOf(
-            "about_dialog",
             "powerstate_dialog",
             "sendmessage_dialog",
             "sleeptimer_dialog",

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -29,6 +29,7 @@ import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerSettings
+import net.reichholf.dreamdroid.ui.nav.navigateToAbout
 import net.reichholf.dreamdroid.ui.nav.navigateToBackup
 import net.reichholf.dreamdroid.ui.nav.navigateToEpgSearch
 import net.reichholf.dreamdroid.ui.nav.navigateToServiceEpg
@@ -261,6 +262,13 @@ class PhoneNavHostFragment : BaseFragment(), MultiChoiceDialog.MultiChoiceDialog
     fun navigateToBackup(): Boolean {
         val controller = navController ?: return false
         controller.navigateToBackup()
+        return true
+    }
+
+    /** Push About as a Navigation `dialog`. Back / dismiss pops it. */
+    fun navigateToAbout(): Boolean {
+        val controller = navController ?: return false
+        controller.navigateToAbout()
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.kt
@@ -29,7 +29,6 @@ import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
 import net.reichholf.dreamdroid.helpers.enigma2.SleepTimer
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.MessageRequestHandler
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SimpleResultRequestHandler
-import net.reichholf.dreamdroid.ui.about.AboutComposeDialog
 import net.reichholf.dreamdroid.ui.drawer.DrawerListState
 import net.reichholf.dreamdroid.ui.drawer.bindDrawerScreen
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
@@ -184,9 +183,16 @@ open class NavigationHelper(
                     "powerstate_dialog",
                 )
 
-            R.id.menu_navigation_about ->
-                getMainActivity().showDialogFragment(AboutComposeDialog.newInstance(), "about_dialog")
-
+            R.id.menu_navigation_about -> {
+                val aboutHost = getMainActivity().supportFragmentManager
+                    .findFragmentById(R.id.detail_view)
+                if (!(aboutHost is PhoneNavHostFragment && aboutHost.navigateToAbout())) {
+                    navigatePhoneNavRoot(PhoneNavRoutes.SETTINGS)
+                    val host = getMainActivity().supportFragmentManager
+                        .findFragmentById(R.id.detail_view)
+                    (host as? PhoneNavHostFragment)?.navigateToAbout()
+                }
+            }
             Statics.ITEM_CHECK_CONN ->
                 getMainActivity().onProfileChanged(DreamDroid.getCurrentProfile())
 

--- a/app/src/net/reichholf/dreamdroid/ui/about/AboutScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/about/AboutScreen.kt
@@ -1,8 +1,5 @@
 package net.reichholf.dreamdroid.ui.about
 
-import android.app.Dialog
-import android.os.Bundle
-import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,28 +7,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.setViewTreeLifecycleOwner
-import androidx.lifecycle.setViewTreeViewModelStoreOwner
-import androidx.savedstate.setViewTreeSavedStateRegistryOwner
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.fragment.dialogs.DreamDroidAttributionPresenter
-import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 data class AboutContent(
     val title: String,
@@ -40,6 +32,17 @@ data class AboutContent(
     val sourceLink: String,
     val licensesLabel: String,
 )
+
+@Composable
+fun rememberAboutContent(): AboutContent {
+    return AboutContent(
+        title = stringResource(R.string.about),
+        version = DreamDroid.VERSION_STRING,
+        license = stringResource(R.string.license_gplv3),
+        sourceLink = stringResource(R.string.source_code_link),
+        licensesLabel = stringResource(R.string.licenses),
+    )
+}
 
 @Composable
 fun AboutScreen(
@@ -71,6 +74,35 @@ fun AboutScreen(
     }
 }
 
+/**
+ * Phase 2.1g-ii-b: Material 3 [AlertDialog] About (no DialogFragment / AlertDialogBuilder host).
+ */
+@Composable
+fun AboutDialog(
+    onDismiss: () -> Unit,
+    content: AboutContent = rememberAboutContent(),
+) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(content.title) },
+        text = {
+            AboutScreen(
+                content = content,
+                onLicensesClick = {
+                    DreamDroidAttributionPresenter.newInstance(context)
+                        .showDialog(content.licensesLabel)
+                },
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.close))
+            }
+        },
+    )
+}
+
 @Composable
 private fun SourceLinkText(sourceLink: String) {
     val uriHandler = LocalUriHandler.current
@@ -87,7 +119,7 @@ private fun SourceLinkText(sourceLink: String) {
             SpanStyle(
                 color = MaterialTheme.colorScheme.primary,
                 textDecoration = TextDecoration.Underline,
-            )
+            ),
         ) {
             append(url)
         }
@@ -102,50 +134,4 @@ private fun SourceLinkText(sourceLink: String) {
                 ?.let { uriHandler.openUri(it.item) }
         },
     )
-}
-
-class AboutComposeDialog : DialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val host = this
-        val aboutContent = AboutContent(
-            title = getString(R.string.about),
-            version = DreamDroid.VERSION_STRING,
-            license = getString(R.string.license_gplv3),
-            sourceLink = getString(R.string.source_code_link),
-            licensesLabel = getString(R.string.licenses),
-        )
-        val composeView = ComposeView(requireContext()).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            )
-            setViewTreeLifecycleOwner(host)
-            setViewTreeViewModelStoreOwner(host)
-            setViewTreeSavedStateRegistryOwner(host)
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-            setContent {
-                DreamDroidTheme {
-                    AboutScreen(
-                        content = aboutContent,
-                        onLicensesClick = {
-                            DreamDroidAttributionPresenter.newInstance(requireContext())
-                                .showDialog(getString(R.string.licenses))
-                        },
-                    )
-                }
-            }
-        }
-        return MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.about)
-            .setView(composeView)
-            .setCancelable(true)
-            .create()
-    }
-
-    companion object {
-        @JvmStatic
-        fun newInstance(): AboutComposeDialog {
-            return AboutComposeDialog()
-        }
-    }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -15,8 +15,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import net.reichholf.dreamdroid.ui.about.AboutDialog
 import net.reichholf.dreamdroid.ui.backup.BackupDestination
 import net.reichholf.dreamdroid.ui.current.CurrentServiceDestination
 import net.reichholf.dreamdroid.ui.device.DeviceInfoDestination
@@ -144,7 +146,16 @@ fun PhoneNavHost(
         composable(PhoneNavRoutes.TIMER_SERVICE_PICK) {
             TimerServicePickDestination(hostFragment = hostFragment)
         }
+        dialog(PhoneNavRoutes.ABOUT) {
+            AboutDialog(onDismiss = { navController.popBackStack() })
+        }
     }
+}
+
+/** Push About as a Navigation `dialog` (back / dismiss pops it). */
+fun NavHostController.navigateToAbout() {
+    if (currentDestination?.route == PhoneNavRoutes.ABOUT) return
+    navigate(PhoneNavRoutes.ABOUT)
 }
 
 /** Drawer-style top-level navigate: single-top + save/restore under the start destination. */

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavRoutes.kt
@@ -17,6 +17,9 @@ object PhoneNavRoutes {
     const val SETTINGS = "settings"
     const val HUB = "hub"
 
+    /** Phase 2.1g-ii-b: About as a Navigation Compose `dialog` destination. */
+    const val ABOUT = "about"
+
     /** Nested service EPG (typed string args). */
     const val SERVICE_EPG = "service_epg/{serviceRef}?serviceName={serviceName}"
 

--- a/app/src/net/reichholf/dreamdroid/ui/settings/SettingsDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/settings/SettingsDestination.kt
@@ -14,9 +14,7 @@ import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.activities.MainActivity
 import net.reichholf.dreamdroid.activities.abs.BaseActivity
-import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
-import net.reichholf.dreamdroid.ui.about.AboutComposeDialog
 
 /**
  * Phase 2.7e: Settings as a direct Compose NavHost destination.
@@ -54,10 +52,8 @@ fun SettingsDestination(
             (context as? BaseActivity)?.startPiconSync()
         },
         onAbout = {
-            (context as? MultiPaneHandler)?.showDialogFragment(
-                AboutComposeDialog.newInstance(),
-                "about_dialog",
-            )
+            // Phase 2.1g-ii-b: Navigation Compose dialog (no DialogFragment).
+            hostFragment.navigateToAbout()
         },
         onChangelog = {
             (context as? MainActivity)?.showChangeLog(false)

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -94,7 +94,8 @@ GitHub Actions: [`.github/workflows/android-ci.yml`](../.github/workflows/androi
 | tv-compose-hub-iv-d | [#338](https://github.com/sreichholf/dreamDroid/pull/338) | merged | Phase 3.1c-iv-d: Compose TV hub service/now-next rows + picon cards behind debug flag; bouquet headers from typed `loadServiceList`/`loadEpgNowNext`. Stream Intent edge unchanged. Movies still Leanback / iv-e. |
 | tv-compose-hub-iv-e | [#339](https://github.com/sreichholf/dreamDroid/pull/339) | merged | Phase 3.1c-iv-e: Compose TV hub movie location headers + lazy `loadMovieList` on select; text cards; stream file Intent edge unchanged. Leanback remains default behind debug flag. |
 | tv-compose-hub-iv-f | [#340](https://github.com/sreichholf/dreamDroid/pull/340) | merged | Phase 3.1c-iv-f: Compose TV hub is the only browse host; delete Leanback `RootBrowseFragment` / `BaseHttpBrowseFragment` / `CardPresenter` / Leanback card wrappers / `tv_main`; drop `leanback-preference`; keep `leanback` for VideoOverlay `HorizontalGridView`. |
-| tv-compose-hub-iv-g | | open | Phase 3.1c-iv-g: TV hub instrumented coverage (header select, loading/error, movie loading) + Phase 4 operator Android TV / box smoke notes. No phone drive-bys. |
+| tv-compose-hub-iv-g | [#341](https://github.com/sreichholf/dreamDroid/pull/341) | merged | Phase 3.1c-iv-g: TV hub instrumented coverage (header select, loading/error, movie loading) + Phase 4 operator Android TV / box smoke notes. No phone drive-bys. |
+| dialogs-2-1g-ii-b | | open | Phase 2.1g-ii-b: About → Navigation Compose `dialog` + Material 3 `AlertDialog`; delete `AboutComposeDialog` DialogFragment wrapper. |
 | room-backup-finish | [#242](https://github.com/sreichholf/dreamDroid/pull/242) | merged | Phase 2.4: Android BackupAgent includes Room `dreambox` (and legacy `dreamdroid` for restore compat); drop legacy file after migrate; widget stops using `DatabaseHelper` keys. Keep migrate-only `DatabaseHelper`. Keep OkHttp 3.14.9. |
 | docs-vlc-product-decision | [#243](https://github.com/sreichholf/dreamDroid/pull/243) | merged | Phase 2.5 (docs only): VLC/streaming inventory + product options; **decision A** keep libVLC + Compose overlay rewrite path. No player code. Keep OkHttp 3.14.9. |
 | vlc-overlay-typed-state | [#244](https://github.com/sreichholf/dreamDroid/pull/244) | merged | Phase 2.5b typed VideoOverlay state (`ServiceNowNext` / `Movie`); hash only at stream Intent / legacy edges. Keep OkHttp 3.14.9. |
@@ -176,7 +177,7 @@ Wave 1 of this plan is on `main`. It is **not** a finished modernization. See Ap
 
 Wave 2 (operator choice): (1) TV & Movies lists (#170), (4) dead-weight (#172/#175/#177), and (2) typed list paths (#173/#176/#179/#180/#181/#183/#203/#209/#210) are on `main`. Dead-weight deletes must not drop ButterKnife (still used by phone VLC overlay).
 
-Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Wave 3 phone screens complete on `main` through #206** (plus CI #204). Phone Phase 2.7 (Fragment shells → Kotlin Compose destinations) **2.7b–i merged** ([#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#315](https://github.com/sreichholf/dreamDroid/pull/315)). **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** (TV hub instrumented tests + Phase 4 operator box smoke notes). **Next:** Phase **4** operator usertests / dialogs **2.1g-ii** parallel SOTA backlog.
+Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose + Kotlin, **one PR per screen**. Checklist in Appendix G. **Wave 3 phone screens complete on `main` through #206** (plus CI #204). Phone Phase 2.7 (Fragment shells → Kotlin Compose destinations) **2.7b–i merged** ([#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#315](https://github.com/sreichholf/dreamDroid/pull/315)). **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** (About Nav `dialog` beachhead). **Next:** **2.1g-ii-c** remaining drawer modals / Phase **4** operator usertests.
 
 ### Operator overrides (this program)
 
@@ -197,7 +198,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Wave 3 phone Compose screens complete on `main` through #206; CI #204.
 - Appendix G phone UI checklist: all 19 items merged.
 - Remaining typed API (not Wave 3 UI): none on phone list paths (hub now/next #209; movies list #210; detail edge #206). Phase 0 Leanback dive #211 on `main`.
-- Phone NavHost Device Info through Hub are **Kotlin Compose destinations**; Phase **2.7b–i** **merged** ([#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#315](https://github.com/sreichholf/dreamDroid/pull/315); decision [#304](https://github.com/sreichholf/dreamDroid/pull/304)). **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** (TV hub instrumented tests + Phase 4 operator box smoke notes). **Next:** Phase **4** operator usertests / dialogs **2.1g-ii** parallel SOTA backlog.
+- Phone NavHost Device Info through Hub are **Kotlin Compose destinations**; Phase **2.7b–i** **merged** ([#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#315](https://github.com/sreichholf/dreamDroid/pull/315); decision [#304](https://github.com/sreichholf/dreamDroid/pull/304)). **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** (About Nav `dialog` beachhead). **Next:** **2.1g-ii-c** remaining drawer modals / Phase **4** operator usertests.
 - Phase 2.1a drawer chrome **merged** [#212](https://github.com/sreichholf/dreamDroid/pull/212). Phase 2.1b–e (through hub) **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Widgets **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272).
 - Phase 2.2a Device Info coroutines **merged** [#213](https://github.com/sreichholf/dreamDroid/pull/213).
 - Phase 2.2b Signal coroutines **merged** [#214](https://github.com/sreichholf/dreamDroid/pull/214).
@@ -225,7 +226,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - Phase 3.1c-i Compose `TextCardView` beachhead **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239).
 - Phase 3.1c-ii Compose service/settings image cards **merged** [#240](https://github.com/sreichholf/dreamDroid/pull/240).
 - Phase 3.1c-iii hub shell decision **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241) (kept Leanback + Compose cards at the time).
-- Phase 3.1c-iv full Compose TV hub (**option C**) scheduled **merged** [#308](https://github.com/sreichholf/dreamDroid/pull/308); **3.1c-iv-b–f** **merged** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#340](https://github.com/sreichholf/dreamDroid/pull/340). **This PR:** **3.1c-iv-g** hub instrumented tests + Phase 4 smoke notes.
+- Phase 3.1c-iv full Compose TV hub (**option C**) **merged** through **iv-g** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#341](https://github.com/sreichholf/dreamDroid/pull/341). **This PR:** Phase **2.1g-ii-b** About Nav `dialog` beachhead.
 - Phase 2.4 Room backup finish **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242).
 - Phase 2.5 VLC product decision **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243) (keep libVLC; Compose overlay rewrite path).
 - Phase 2.5b typed overlay state **merged** [#244](https://github.com/sreichholf/dreamDroid/pull/244) (`ServiceNowNext` / `Movie`; hash only at stream Intent / legacy edges).
@@ -259,7 +260,7 @@ Wave 3 (operator choice): convert remaining **non-Compose phone UIs** to Compose
 - OkHttp 4.12 for Picasso/TLS **merged** [#299](https://github.com/sreichholf/dreamDroid/pull/299) (Enigma2 HTTP unchanged).
 - libVLC-all **3.7.5** stable **merged** [#300](https://github.com/sreichholf/dreamDroid/pull/300) (still not Media3).
 - Phase 2.7 phone Fragment→**Kotlin** Compose destination rework **2.7b–i merged** ([#304](https://github.com/sreichholf/dreamDroid/pull/304) docs; [#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#315](https://github.com/sreichholf/dreamDroid/pull/315)).
-- **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** — TV hub instrumented tests + Phase 4 operator Android TV / box smoke notes. Former keepers remain **SOTA backlog** (dialogs **2.1g-ii**, Glance, OkHttp Enigma2, VideoOverlay Kotlin) in parallel.
+- **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** — About as Navigation Compose `dialog` (delete DialogFragment wrapper). Remaining dialogs **2.1g-ii-c…f**; Glance / OkHttp Enigma2 / VideoOverlay Kotlin still SOTA backlog. Phase **4** operator box smoke remains.
 
 ## How to read this
 
@@ -647,7 +648,7 @@ One PR per screen. Pattern: Compose + Kotlin Material 3 like About (#164) / Prof
 
 ## Appendix H. After Wave 3 — one-by-one modernization plan
 
-Operator intent: **migrate everything** (phone leftovers + Leanback → Compose TV), then operator usertests, then bugfix pass. Do **one PR at a time**. Phase 3 hybrid Leanback path is on `main`; **full Compose hub (option C / 3.1c-iv)** code path is on `main` through **iv-f**; **this PR is 3.1c-iv-g** (tests + Phase 4 notes).
+Operator intent: **migrate everything** (phone leftovers + Leanback → Compose TV), then operator usertests, then bugfix pass. Do **one PR at a time**. Phase 3 hybrid Leanback path is on `main`; **full Compose hub (option C / 3.1c-iv)** code path is on `main` through **iv-f**; **3.1c-iv complete through iv-g**; **this PR is 2.1g-ii-b** (About Nav dialog).
 
 Phone Wave 3 + Phase 2.1–2.6 left **Compose UI inside Java Fragment shells** nested under `PhoneNavHost`. Phase **2.7** converts those shells to **Kotlin** Compose destinations (operator ask 2026-09-11): leave Java Fragments, move behavior into Kotlin screens/ViewModels, delete the shell. Do **not** stop at a same-shape Java→Kotlin Fragment rewrite.
 
@@ -705,7 +706,7 @@ Prefer **typed browse data → details → hub → prefs** (not prefs-first; not
 4. Leanback prefs → Compose — **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236) (Phase 3.1d)
 5. TV ButterKnife cleared — **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237); phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c)
 
-**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H phone NavHost/widgets/VLC/state **merged**. Phone Phase **2.7b–h** destinations **merged**; **2.7i merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** (hub tests + Phase 4 notes). **Next:** Phase **4** operator usertests (dialogs **2.1g-ii** parallel).
+**Safe next after Phase 0 / 3.1c focus dive landed:** Phase 3 cards/prefs (done). Broader Appendix H phone NavHost/widgets/VLC/state **merged**. Phone Phase **2.7b–h** destinations **merged**; **2.7i merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** (About Nav `dialog`). **Next:** **2.1g-ii-c** drawer modals / Phase **4** operator usertests.
 
 
 ### Phase 3.1c — TV hub focus dive (this PR; docs only)
@@ -787,7 +788,7 @@ Why B was right at the time:
 | 3.1c-iv-d | Service / now-next rows + picon cards (reuse typed loads + card Compose from 3.1c-i/ii where possible) | **merged** [#338](https://github.com/sreichholf/dreamDroid/pull/338) |
 | 3.1c-iv-e | Movie location rows + lazy load on row select | **merged** [#339](https://github.com/sreichholf/dreamDroid/pull/339) |
 | 3.1c-iv-f | Delete Leanback browse path: `RootBrowseFragment`, `BaseHttpBrowseFragment`, `CardPresenter`, Leanback-only card view wrappers; drop unused leanback-preference | **merged** [#340](https://github.com/sreichholf/dreamDroid/pull/340) |
-| 3.1c-iv-g | TV hub instrumented tests + Phase 4 operator box smoke notes | **this PR** — header/loading/error coverage + box smoke checklist |
+| 3.1c-iv-g | TV hub instrumented tests + Phase 4 operator box smoke notes | **merged** [#341](https://github.com/sreichholf/dreamDroid/pull/341) |
 
 **Order gate:** Phase **2.7** is complete — **3.1c-iv-b+** is allowed. One PR per slice unless the operator says otherwise.
 
@@ -1042,7 +1043,7 @@ Order may slip for dependency (e.g. edit forms before pick), but **one PR per sl
 - No Leanback / Glance / Media3 / Enigma2 server work (TV Compose hub is **Phase 3.1c-iv after 2.7**, not interleaved)
 - Do not merge `master` into `main`
 
-**Phase 2.7i merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** (hub tests + Phase 4 notes). **Next:** Phase **4** operator usertests (dialogs **2.1g-ii** parallel).
+**Phase 2.7i merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** (About Nav `dialog`). **Next:** **2.1g-ii-c** drawer modals / Phase **4** operator usertests.
 
 #### Chassis (after 2.3f)
 
@@ -1152,7 +1153,7 @@ Host: `MainActivity` / `MultiPaneHandler.showDialogFragment`. Drawer tags in `Ma
 
 | Dialog | UI | Host |
 | --- | --- | --- |
-| `AboutComposeDialog` | Compose alert (`ui/about/AboutScreen.kt`) | Drawer About |
+| About (Nav `dialog`) | M3 `AboutDialog` on `PhoneNavRoutes.ABOUT` (`ui/about/AboutScreen.kt`) | Settings + drawer About — **2.1g-ii-b** |
 | `SendMessageDialog` / `PowerStateDialog` / `SleepTimerDialog` | Compose | Drawer message / power / sleep |
 | `ChangelogDialog` | Compose + Markwon | Drawer changelog / `MainActivity.showChangeLog` |
 | `ConnectionErrorDialog` | Compose | Profile-check fail |
@@ -1209,7 +1210,7 @@ Host: `MainActivity` / `MultiPaneHandler.showDialogFragment`. Drawer tags in `Ma
 | Slice | Scope | Proof |
 | --- | --- | --- |
 | 2.1g-ii-a | Docs reopen (this PR) | Doc review |
-| 2.1g-ii-b | Beachhead: one drawer modal (About or connection error) → Compose `AlertDialog` or Nav `dialog` route; delete its DialogFragment wrapper | Instrumented Compose test hosts the new path (composition or NavHost `dialog`), not only naked `setContent` while any View host remains |
+| 2.1g-ii-b | Beachhead: About → Nav `dialog` + M3 `AlertDialog`; delete `AboutComposeDialog` | **this PR** — Settings/drawer open `PhoneNavRoutes.ABOUT`; `AboutDialogHostTest` hosts Nav `dialog` |
 | 2.1g-ii-c | Remaining drawer modals (power / sleep / send message / changelog) | Same |
 | 2.1g-ii-d | Contextual sheets (EPG / movie detail) → `ModalBottomSheet` | Same |
 | 2.1g-ii-e | Multi/simple choice + indeterminate progress → Compose; delete Java FM helpers | Same |
@@ -1230,11 +1231,11 @@ Separate PRs; do not mix with phone shell PRs. Order fixed by Phase 0 dive:
 | --- | --- | --- |
 | 3.1a | Typed `BrowseItem` | Sealed Kotlin `Service`/`Movie`/`Settings`; hash only at stream Intent edge; keep Leanback UI. Keep OkHttp 3.14.9. **merged** [#234](https://github.com/sreichholf/dreamDroid/pull/234). |
 | 3.1b | TV detail dialogs → Compose | Shared phone detail + `DreamDroidTheme`; hide EPG actions on TV; drop ButterKnife on Epg/Movie detail. Keep OkHttp 3.14.9. **merged** [#235](https://github.com/sreichholf/dreamDroid/pull/235). |
-| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). Cards **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239)/[#240](https://github.com/sreichholf/dreamDroid/pull/240). Shell **B** **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241). Option C scheduled **merged** [#308](https://github.com/sreichholf/dreamDroid/pull/308). **3.1c-iv-b–f** **merged** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#340](https://github.com/sreichholf/dreamDroid/pull/340). **This PR:** **3.1c-iv-g** hub tests + Phase 4 notes. |
+| 3.1c | Browse hub → TV Compose | Focus dive **merged** [#238](https://github.com/sreichholf/dreamDroid/pull/238). Cards **merged** [#239](https://github.com/sreichholf/dreamDroid/pull/239)/[#240](https://github.com/sreichholf/dreamDroid/pull/240). Shell **B** **merged** [#241](https://github.com/sreichholf/dreamDroid/pull/241). Option C **merged** through **iv-g** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#341](https://github.com/sreichholf/dreamDroid/pull/341). |
 | 3.1d | Leanback prefs → Compose | **merged** [#236](https://github.com/sreichholf/dreamDroid/pull/236). |
 | 3.1e | Drop ButterKnife | TV binds cleared **merged** [#237](https://github.com/sreichholf/dreamDroid/pull/237). Phone library drop **merged** [#245](https://github.com/sreichholf/dreamDroid/pull/245) (2.5c / 2.5d). |
 
-**Phase 3 hybrid Leanback path complete** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub still Leanback shell until **3.1c-iv**). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote through drawer root map **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277)–[#285](https://github.com/sreichholf/dreamDroid/pull/285) (dialog policy [#278](https://github.com/sreichholf/dreamDroid/pull/278); nested resume crash [#286](https://github.com/sreichholf/dreamDroid/pull/286); drawer IA [#282](https://github.com/sreichholf/dreamDroid/pull/282)). Hub nested-leaf teardown **merged** [#287](https://github.com/sreichholf/dreamDroid/pull/287). Phase 2.6c Compose widget config **merged** [#288](https://github.com/sreichholf/dreamDroid/pull/288). `SimpleFragmentActivity` retired **merged** [#289](https://github.com/sreichholf/dreamDroid/pull/289). Assert NavHost leaf fallbacks **merged** [#291](https://github.com/sreichholf/dreamDroid/pull/291). Phase 2.5e thin Kotlin VLC wrapper **merged** [#296](https://github.com/sreichholf/dreamDroid/pull/296). OkHttp 4.12 **merged** [#299](https://github.com/sreichholf/dreamDroid/pull/299); libVLC 3.7.5 **merged** [#300](https://github.com/sreichholf/dreamDroid/pull/300). Phase **2.7b–h** phone Compose destinations **merged** [#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#314](https://github.com/sreichholf/dreamDroid/pull/314) (decision [#304](https://github.com/sreichholf/dreamDroid/pull/304)). Phase **2.7i** chassis cleanup **merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#340 merged**. **This PR:** Phase **3.1c-iv-g** (hub tests + Phase 4 notes). **Next:** Phase **4** operator usertests (dialogs **2.1g-ii** parallel).
+**Phase 3 hybrid Leanback path complete** (typed browse, details, prefs, Compose cards, TV ButterKnife cleared; hub still Leanback shell until **3.1c-iv**). Phase 2.4 Room backup **merged** [#242](https://github.com/sreichholf/dreamDroid/pull/242). Phase 2.5 VLC through Compose overlay **merged** [#243](https://github.com/sreichholf/dreamDroid/pull/243)/[#244](https://github.com/sreichholf/dreamDroid/pull/244)/[#245](https://github.com/sreichholf/dreamDroid/pull/245). Phase 2.3 **complete** [#246](https://github.com/sreichholf/dreamDroid/pull/246)–[#252](https://github.com/sreichholf/dreamDroid/pull/252). Phase 2.1b–e through hub **merged** [#254](https://github.com/sreichholf/dreamDroid/pull/254)–[#270](https://github.com/sreichholf/dreamDroid/pull/270). Phase 2.6a–b **merged** [#271](https://github.com/sreichholf/dreamDroid/pull/271)/[#272](https://github.com/sreichholf/dreamDroid/pull/272). Phase 2.1f nested typed routes **merged** [#274](https://github.com/sreichholf/dreamDroid/pull/274)–[#276](https://github.com/sreichholf/dreamDroid/pull/276). Phase 2.1h phone remote through drawer root map **merged** [#277](https://github.com/sreichholf/dreamDroid/pull/277)–[#285](https://github.com/sreichholf/dreamDroid/pull/285) (dialog policy [#278](https://github.com/sreichholf/dreamDroid/pull/278); nested resume crash [#286](https://github.com/sreichholf/dreamDroid/pull/286); drawer IA [#282](https://github.com/sreichholf/dreamDroid/pull/282)). Hub nested-leaf teardown **merged** [#287](https://github.com/sreichholf/dreamDroid/pull/287). Phase 2.6c Compose widget config **merged** [#288](https://github.com/sreichholf/dreamDroid/pull/288). `SimpleFragmentActivity` retired **merged** [#289](https://github.com/sreichholf/dreamDroid/pull/289). Assert NavHost leaf fallbacks **merged** [#291](https://github.com/sreichholf/dreamDroid/pull/291). Phase 2.5e thin Kotlin VLC wrapper **merged** [#296](https://github.com/sreichholf/dreamDroid/pull/296). OkHttp 4.12 **merged** [#299](https://github.com/sreichholf/dreamDroid/pull/299); libVLC 3.7.5 **merged** [#300](https://github.com/sreichholf/dreamDroid/pull/300). Phase **2.7b–h** phone Compose destinations **merged** [#306](https://github.com/sreichholf/dreamDroid/pull/306)–[#314](https://github.com/sreichholf/dreamDroid/pull/314) (decision [#304](https://github.com/sreichholf/dreamDroid/pull/304)). Phase **2.7i** chassis cleanup **merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). **#316–#341 merged**. **This PR:** Phase **2.1g-ii-b** (About Nav `dialog`). **Next:** **2.1g-ii-c** drawer modals / Phase **4** operator usertests.
 
 ### Phase 4 — Operator usertests
 
@@ -1274,7 +1275,7 @@ One PR per fix or small related cluster. Prefer regressions covered by Compose t
 
 - Do not merge `master` into `main`.
 - Do not rewrite VLC codecs or Enigma2 server side.
-- Phase **2.7i** chassis cleanup **merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). Keepers reopen **merged** [#335](https://github.com/sreichholf/dreamDroid/pull/335). **3.1c-iv-b–f** **merged** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#340](https://github.com/sreichholf/dreamDroid/pull/340). **This PR:** **3.1c-iv-g**; next Phase **4** (dialogs **2.1g-ii** remains parallel SOTA backlog).
+- Phase **2.7i** chassis cleanup **merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). Keepers reopen **merged** [#335](https://github.com/sreichholf/dreamDroid/pull/335). **3.1c-iv-b–g** **merged** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#341](https://github.com/sreichholf/dreamDroid/pull/341). **This PR:** **2.1g-ii-b** About Nav `dialog`; next **2.1g-ii-c** / Phase **4**.
 
 ## Appendix F. Links
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phase **2.1g-ii-b**: migrate About off `AboutComposeDialog` (DialogFragment) to a Navigation Compose `dialog` hosting Material 3 `AboutDialog`.
- Settings footer and drawer About both call `PhoneNavHostFragment.navigateToAbout()`.
- Drop `about_dialog` from `NAVIGATION_DIALOG_TAGS`.
- `AboutDialogHostTest` hosts the Nav `dialog` path (not a View `AlertDialog` + `ComposeView`).

## Test plan
- [x] `./gradlew :app:compileGoogleDebugKotlin` / androidTest compile
- [x] Connected `AboutScreenTest` + `AboutDialogHostTest` — **OK (3 tests)**
- [ ] CI green
- [ ] Manual: Settings → About opens Compose dialog; Close / back dismisses; Licenses still opens attribution presenter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

