### PR TITLE
Fix pull-to-refresh dark surface overlaying hub bouquet tabs

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
@@ -1,10 +1,18 @@
 package net.reichholf.dreamdroid.ui.compose
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
@@ -83,5 +91,44 @@ class DreamDroidPullRefreshTest {
             }
         }
         composeRule.onNodeWithText("Still here").assertIsDisplayed()
+    }
+
+    /**
+     * Hub layout: bouquet [ScrollableTabRow] above the pull-refresh host. Programmatic
+     * refresh must keep tab labels readable (the container's dark circular surface used to
+     * paint over "Provider").
+     */
+    @Test
+    fun refreshingBelowTabsKeepsBouquetTabLabelsVisible() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                Column(Modifier.fillMaxSize()) {
+                    var selected by remember { mutableIntStateOf(0) }
+                    val tabs = listOf("Favourites (TV)", "Provider", "All Services")
+                    ScrollableTabRow(selectedTabIndex = selected) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = index == selected,
+                                onClick = { selected = index },
+                                text = { Text(title) },
+                            )
+                        }
+                    }
+                    DreamDroidPullRefresh(
+                        refreshing = true,
+                        onRefresh = {},
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("hub_pull"),
+                    ) {
+                        Text("list body")
+                    }
+                }
+            }
+        }
+        composeRule.onNodeWithText("Favourites (TV)").assertIsDisplayed()
+        composeRule.onNodeWithText("Provider").assertIsDisplayed()
+        composeRule.onNodeWithText("All Services").assertIsDisplayed()
+        composeRule.onNodeWithText("list body").assertIsDisplayed()
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 
 /**
@@ -17,6 +18,10 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
  * [androidx.swiperefreshlayout.widget.SwipeRefreshLayout]. That View parent treated a
  * [androidx.compose.ui.platform.ComposeView] as never scrolled, so scrolling back up
  * always fired reload.
+ *
+ * [clipToBounds] is required: [PullToRefreshContainer] sits at [Alignment.TopCenter] and
+ * animates in from above its host. Without clipping, its dark circular surface paints over
+ * siblings above the list (hub bouquet [ScrollableTabRow] — e.g. the Provider tab).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,7 +48,12 @@ fun DreamDroidPullRefresh(
         }
     }
 
-    Box(modifier.nestedScroll(state.nestedScrollConnection).fillMaxSize()) {
+    Box(
+        modifier
+            .nestedScroll(state.nestedScrollConnection)
+            .clipToBounds()
+            .fillMaxSize(),
+    ) {
         content()
         PullToRefreshContainer(
             state = state,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On TV & Movies, a reload paints `PullToRefreshContainer`’s dark circular surface over the bouquet `ScrollableTabRow` (e.g. the **Provider** tab). The indicator sits at `TopCenter` and animates in from above its host; Compose does not clip by default, so it draws onto the tabs above the list.

## Fix
- Clip `DreamDroidPullRefresh` with `Modifier.clipToBounds()` so the refresh surface cannot paint outside the list host.
- Add a hub-shaped Compose test (`ScrollableTabRow` above a refreshing pull host) that asserts bouquet tab labels stay visible.

## Test plan
- [x] `DreamDroidPullRefreshTest` (3 tests) via `bash .cursor/cloud/connected-test.sh` — PASSED
- [ ] Manual: open TV & Movies, reload Favourites — Provider / All Services tabs stay fully readable while the list refreshes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

