### PR TITLE
ci: arm64 APK on main push or workflow_dispatch flag

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      upload_apk:
+        description: Build and upload arm64 googleDebug APK artifact
+        type: boolean
+        default: false
 
 concurrency:
   group: android-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -74,16 +79,20 @@ jobs:
           :app:compileGoogleDebugAndroidTestKotlin
           :app:compileGoogleDebugAndroidTestJavaWithJavac
 
-      # Phone-installable arm64 APK for main only (not every PR). -Parm64Apk
-      # builds a single ABI split (~57MB) instead of the fat -Pci APK.
+      # Phone-installable arm64 APK on main pushes, or workflow_dispatch with
+      # upload_apk=true. -Parm64Apk builds one ABI split (~57MB), not fat -Pci.
       - name: Assemble googleDebug arm64 APK
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.upload_apk)
         run: >
           ./gradlew --no-configuration-cache -Parm64Apk
           :app:assembleGoogleDebug
 
       - name: Upload googleDebug arm64 APK
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.upload_apk)
         uses: actions/upload-artifact@v6
         with:
           name: dreamdroid-google-debug-apk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use `JAVA_HOME` pointing at JDK 25. Tests live in `app/androidTest/java`. Add Co
 
 Do not pass `-Pandroid.testInstrumentationRunnerArguments...`. Gradle then sets project property `android` to a String and `android.applicationVariants` breaks. Filter a class with `adb shell am instrument -w -e class ... net.reichholf.dreamdroid.debug.test/androidx.test.runner.AndroidJUnitRunner`.
 
-CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`). On `main` pushes / `workflow_dispatch` only: uploads arm64 `dreamdroid-google-debug-apk` (2-day retention) and emulator `connectedGoogleDebugAndroidTest` (API 30). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
+CI: `.github/workflows/android-ci.yml` — on every PR/`main` push: `:app:testGoogleDebugUnitTest`, androidTest compile (with `-Pci`). Arm64 `dreamdroid-google-debug-apk` (2-day retention) uploads on `main` pushes, or `workflow_dispatch` with `upload_apk=true`. Emulator `connectedGoogleDebugAndroidTest` (API 30) on `main` pushes / `workflow_dispatch` (slow/flaky on PR). Local cloud helper: `bash .cursor/cloud/connected-test.sh`.
 
 `verify-dreamdroid.py` exists for a shell-only dump when there is no instrumented test yet. It is not the verification loop.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Upload `dreamdroid-google-debug-apk` on **`main` pushes** (after merge)
- Also on **`workflow_dispatch`** when input **`upload_apk=true`**
- PRs still skip assemble/upload (unit tests only)
- Manual dispatch without the flag does not upload an APK

## Why
Keep PR CI light while still allowing an on-demand arm64 debug APK from Actions → Run workflow.

## Test plan
- [ ] PR CI succeeds and skips Assemble/Upload arm64 steps
- [ ] After merge, `main` push CI uploads the APK artifact
- [ ] `workflow_dispatch` with `upload_apk=true` uploads the APK
- [ ] `workflow_dispatch` with `upload_apk=false` skips upload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a24b2376-10b5-4568-9f50-c115e54070b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a24b2376-10b5-4568-9f50-c115e54070b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

