### PR TITLE
Fix PTR reload dark disk covering bouquet tabs

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
@@ -1,22 +1,35 @@
 package net.reichholf.dreamdroid.ui.compose
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -83,5 +96,83 @@ class DreamDroidPullRefreshTest {
             }
         }
         composeRule.onNodeWithText("Still here").assertIsDisplayed()
+    }
+
+    /**
+     * Hub layout: bouquet [ScrollableTabRow] above the pull-refresh host. Programmatic
+     * reload must keep tab labels readable — the old [androidx.compose.material3.pulltorefresh.PullToRefreshContainer]
+     * elevated dark disk sat under Provider even when clipped (drawn inside the list host).
+     */
+    @Test
+    fun refreshingBelowTabsKeepsBouquetTabLabelsVisible() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                Column(Modifier.fillMaxSize()) {
+                    var selected by remember { mutableIntStateOf(0) }
+                    val tabs = listOf("Favourites (TV)", "Provider", "All Services")
+                    ScrollableTabRow(
+                        selectedTabIndex = selected,
+                        modifier = Modifier.testTag("hub_tabs"),
+                    ) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = index == selected,
+                                onClick = { selected = index },
+                                text = { Text(title) },
+                            )
+                        }
+                    }
+                    DreamDroidPullRefresh(
+                        refreshing = true,
+                        onRefresh = {},
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("hub_pull"),
+                    ) {
+                        Text("list body")
+                    }
+                }
+            }
+        }
+        composeRule.onNodeWithText("Favourites (TV)").assertIsDisplayed()
+        composeRule.onNodeWithText("Provider").assertIsDisplayed()
+        composeRule.onNodeWithText("All Services").assertIsDisplayed()
+        composeRule.onNodeWithText("list body").assertIsDisplayed()
+        composeRule.onNodeWithTag(PULL_REFRESH_INDICATOR_TAG).assertIsDisplayed()
+
+        val tabBounds = composeRule.onNodeWithTag("hub_tabs").getBoundsInRoot()
+        val pullBounds = composeRule.onNodeWithTag("hub_pull").getBoundsInRoot()
+        assertTrue(
+            "pull host must start at or below the tab row (tab.bottom=${tabBounds.bottom}, pull.top=${pullBounds.top})",
+            pullBounds.top.value >= tabBounds.bottom.value - 1f,
+        )
+
+        // Root pixels over the Provider label must stay readable text contrast — not a flat
+        // elevated surfaceContainerHigh disk painted over the tab (the #351 clip-only failure).
+        val providerBounds = composeRule.onNodeWithText("Provider").getBoundsInRoot()
+        val rootBounds = composeRule.onRoot().getBoundsInRoot()
+        val rootBitmap = composeRule.onRoot().captureToImage().asAndroidBitmap()
+        val rootWidthDp = (rootBounds.right - rootBounds.left).value
+        val density = rootBitmap.width / rootWidthDp
+        val left = (providerBounds.left.value * density).toInt().coerceIn(0, rootBitmap.width - 1)
+        val top = (providerBounds.top.value * density).toInt().coerceIn(0, rootBitmap.height - 1)
+        val right = (providerBounds.right.value * density).toInt().coerceIn(left + 1, rootBitmap.width)
+        val bottom = (providerBounds.bottom.value * density).toInt().coerceIn(top + 1, rootBitmap.height)
+        var distinctColors = 0
+        val seen = HashSet<Int>()
+        var y = top
+        while (y < bottom) {
+            var x = left
+            while (x < right) {
+                seen.add(rootBitmap.getPixel(x, y))
+                x += 2
+            }
+            y += 2
+        }
+        distinctColors = seen.size
+        assertTrue(
+            "Provider tab region should keep text contrast during reload, not a flat PTR disk (colors=$distinctColors)",
+            distinctColors >= 3,
+        )
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
@@ -3,20 +3,34 @@ package net.reichholf.dreamdroid.ui.compose
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 
 /**
  * Material 3 pull-to-refresh host for Compose lists formerly wrapped in View
  * [androidx.swiperefreshlayout.widget.SwipeRefreshLayout]. That View parent treated a
  * [androidx.compose.ui.platform.ComposeView] as never scrolled, so scrolling back up
  * always fired reload.
+ *
+ * Uses [PullToRefreshDefaults.Indicator] only — not [androidx.compose.material3.pulltorefresh.PullToRefreshContainer].
+ * The container's elevated `surfaceContainerHigh` disk sits at `TopCenter`; on programmatic
+ * reload `verticalOffset` jumps to the positional threshold so the disk is drawn fully
+ * *inside* the list host (translationY ≈ +40.dp). [Modifier.clipToBounds] therefore cannot
+ * stop it from reading as a dark circle under hub bouquet tabs (e.g. Provider on TV & Movies).
+ * Clipping still applies so a mid-pull glyph cannot paint into siblings above the host.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,11 +57,33 @@ fun DreamDroidPullRefresh(
         }
     }
 
-    Box(modifier.nestedScroll(state.nestedScrollConnection).fillMaxSize()) {
+    Box(
+        modifier
+            .nestedScroll(state.nestedScrollConnection)
+            .clipToBounds()
+            .fillMaxSize(),
+    ) {
         content()
-        PullToRefreshContainer(
-            state = state,
-            modifier = Modifier.align(Alignment.TopCenter),
-        )
+        CompositionLocalProvider(
+            LocalContentColor provides PullToRefreshDefaults.contentColor,
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .size(IndicatorContainerSize)
+                    .graphicsLayer {
+                        translationY = state.verticalOffset - size.height
+                    }
+                    .testTag(PULL_REFRESH_INDICATOR_TAG),
+                contentAlignment = Alignment.Center,
+            ) {
+                PullToRefreshDefaults.Indicator(state = state)
+            }
+        }
     }
 }
+
+/** Matches Material3 `SpinnerContainerSize` (PullToRefresh.kt). */
+private val IndicatorContainerSize = 40.dp
+
+const val PULL_REFRESH_INDICATOR_TAG = "pull_refresh_indicator"

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -247,10 +248,12 @@ fun HubDestination(
                 error = bouquetError,
                 onRowSelected = { onRowSelected(it) },
             )
+            // Clip list pages so pull-to-refresh glyphs cannot paint over bouquet tabs above.
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxSize(),
+                    .fillMaxSize()
+                    .clipToBounds(),
             ) {
                 when (mode) {
                     MODE_TV -> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Root cause of #351 miss: on programmatic reload, Material3 `startRefresh()` parks the elevated `PullToRefreshContainer` disk *inside* the list box (~40dp under the bouquet tabs). `clipToBounds()` only clips overflow, so Provider stayed covered.
- Draw `PullToRefreshDefaults.Indicator` only (no elevated surface disk); keep `clipToBounds()` for mid-pull overflow.
- Also clip the hub list `Box` under the header.
- Strengthen androidTest: hub-shaped layout + Provider-region pixel contrast during reload.

## Test plan
- [x] `DreamDroidPullRefreshTest` via connected-test.sh — 3/3
- [ ] Device: TV & Movies → pull-to-refresh / reload — Provider tab stays readable (no dark circle)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

