### PR TITLE
Stock PTR + shell bottom nav bind fix

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefreshTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.zIndex
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
@@ -99,9 +100,10 @@ class DreamDroidPullRefreshTest {
     }
 
     /**
-     * Hub layout: bouquet [ScrollableTabRow] above the pull-refresh host. Programmatic
-     * reload must keep tab labels readable — the old [androidx.compose.material3.pulltorefresh.PullToRefreshContainer]
-     * elevated dark disk sat under Provider even when clipped (drawn inside the list host).
+     * Hub layout: bouquet [ScrollableTabRow] (zIndex above the list, as in HubDestination)
+     * over stock [androidx.compose.material3.pulltorefresh.PullToRefreshContainer].
+     * Programmatic reload must keep tab labels readable — Column draws the list after the
+     * tabs, so without zIndex the elevated indicator can paint over Provider.
      */
     @Test
     fun refreshingBelowTabsKeepsBouquetTabLabelsVisible() {
@@ -112,7 +114,9 @@ class DreamDroidPullRefreshTest {
                     val tabs = listOf("Favourites (TV)", "Provider", "All Services")
                     ScrollableTabRow(
                         selectedTabIndex = selected,
-                        modifier = Modifier.testTag("hub_tabs"),
+                        modifier = Modifier
+                            .zIndex(1f)
+                            .testTag("hub_tabs"),
                     ) {
                         tabs.forEachIndexed { index, title ->
                             Tab(
@@ -148,7 +152,7 @@ class DreamDroidPullRefreshTest {
         )
 
         // Root pixels over the Provider label must stay readable text contrast — not a flat
-        // elevated surfaceContainerHigh disk painted over the tab (the #351 clip-only failure).
+        // elevated surfaceContainerHigh disk painted over the tab (draw-order without zIndex).
         val providerBounds = composeRule.onNodeWithText("Provider").getBoundsInRoot()
         val rootBounds = composeRule.onRoot().getBoundsInRoot()
         val rootBitmap = composeRule.onRoot().captureToImage().asAndroidBitmap()

--- a/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/compose/DreamDroidPullRefresh.kt
@@ -3,21 +3,16 @@ package net.reichholf.dreamdroid.ui.compose
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 
 /**
  * Material 3 pull-to-refresh host for Compose lists formerly wrapped in View
@@ -25,12 +20,11 @@ import androidx.compose.ui.unit.dp
  * [androidx.compose.ui.platform.ComposeView] as never scrolled, so scrolling back up
  * always fired reload.
  *
- * Uses [PullToRefreshDefaults.Indicator] only — not [androidx.compose.material3.pulltorefresh.PullToRefreshContainer].
- * The container's elevated `surfaceContainerHigh` disk sits at `TopCenter`; on programmatic
- * reload `verticalOffset` jumps to the positional threshold so the disk is drawn fully
- * *inside* the list host (translationY ≈ +40.dp). [Modifier.clipToBounds] therefore cannot
- * stop it from reading as a dark circle under hub bouquet tabs (e.g. Provider on TV & Movies).
- * Clipping still applies so a mid-pull glyph cannot paint into siblings above the host.
+ * Uses stock [PullToRefreshContainer] (Material's elevated indicator disk + spinner).
+ * [clipToBounds] keeps mid-pull drawing inside this host. Hub screens that place a
+ * bouquet [androidx.compose.material3.ScrollableTabRow] above the list must also raise
+ * that tab row with [androidx.compose.ui.zIndex] so Column draw order cannot let the
+ * list's TopCenter indicator paint over tab labels (e.g. Provider on TV & Movies).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -64,26 +58,13 @@ fun DreamDroidPullRefresh(
             .fillMaxSize(),
     ) {
         content()
-        CompositionLocalProvider(
-            LocalContentColor provides PullToRefreshDefaults.contentColor,
-        ) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .size(IndicatorContainerSize)
-                    .graphicsLayer {
-                        translationY = state.verticalOffset - size.height
-                    }
-                    .testTag(PULL_REFRESH_INDICATOR_TAG),
-                contentAlignment = Alignment.Center,
-            ) {
-                PullToRefreshDefaults.Indicator(state = state)
-            }
-        }
+        PullToRefreshContainer(
+            state = state,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .testTag(PULL_REFRESH_INDICATOR_TAG),
+        )
     }
 }
-
-/** Matches Material3 `SpinnerContainerSize` (PullToRefresh.kt). */
-private val IndicatorContainerSize = 40.dp
 
 const val PULL_REFRESH_INDICATOR_TAG = "pull_refresh_indicator"

--- a/app/src/net/reichholf/dreamdroid/ui/nav/DestinationBar.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/DestinationBar.kt
@@ -17,11 +17,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import net.reichholf.dreamdroid.R
-import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
  * One entry in a phone shell bottom [DestinationBar] (TV & Movies, Tools, …).
@@ -65,12 +63,16 @@ fun DestinationBar(
 }
 
 /**
- * Shows [content] on the activity [R.id.shell_destination_nav] ComposeView and
- * clears it when leaving composition. [content] should read Snapshot state from a
- * stable holder so the shell composition updates when the hub changes selection.
+ * Installs destination-bar composition on the activity [R.id.shell_destination_nav]
+ * ComposeView and clears it when leaving this composition.
+ *
+ * [bind] must call a `ComposeView.bind…(state)` helper that owns a self-contained
+ * `setContent { }` reading Snapshot state. Do **not** capture a `@Composable` lambda
+ * from the NavHost/`detail_view` composition into the shell ComposeView — that
+ * cross-ComposeView bridge goes blank after hub content loads (Tools / TV & Movies).
  */
 @Composable
-fun InstallShellDestinationBar(content: @Composable () -> Unit) {
+fun InstallShellDestinationBar(bind: (ComposeView) -> Unit) {
 	val context = LocalContext.current
 	DisposableEffect(context) {
 		val activity = context.findActivity()
@@ -78,14 +80,7 @@ fun InstallShellDestinationBar(content: @Composable () -> Unit) {
 		val shellNav = activity.findViewById<ComposeView?>(R.id.shell_destination_nav)
 			?: return@DisposableEffect onDispose { }
 		shellNav.visibility = View.VISIBLE
-		shellNav.setViewCompositionStrategy(
-			ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
-		)
-		shellNav.setContent {
-			DreamDroidTheme {
-				content()
-			}
-		}
+		bind(shellNav)
 		onDispose {
 			shellNav.visibility = View.GONE
 			shellNav.disposeComposition()

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.zIndex
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.enigma.Bouquets
@@ -148,13 +149,11 @@ fun HubDestination(
         }
     }
 
-    // Destination bar on activity Coordinator (shell_destination_nav). Putting it in Scaffold
-    // bottomBar inside detail_view pushes it under the system gesture nav.
-    InstallShellDestinationBar {
-        TvMoviesDestinationBar(
-            selected = destinationBarState.selected,
-            onDestinationSelected = { destinationBarState.onDestinationSelected(it) },
-        )
+    // Destination bar on activity Coordinator (shell_destination_nav). Bind a self-contained
+    // shell composition (Snapshot state) — do not capture hub @Composable lambdas into the
+    // sibling ComposeView (that bridge goes blank after bouquet/content load).
+    InstallShellDestinationBar { shellNav ->
+        shellNav.bindTvMoviesDestinationBar(destinationBarState)
     }
 
     DisposableEffect(hostFragment) {
@@ -233,13 +232,17 @@ fun HubDestination(
                 .fillMaxSize()
                 .padding(padding),
         ) {
+            // zIndex above the list: stock PullToRefreshContainer sits TopCenter in the
+            // list slot; Column draws later children on top, so without this the elevated
+            // indicator can paint over bouquet tab labels (e.g. Provider).
             TvMoviesHeader(
                 rows = rows,
                 selectedRow = if (rows.isEmpty()) 0 else selectedRow.coerceIn(0, rows.lastIndex),
                 error = bouquetError,
                 onRowSelected = { onRowSelected(it) },
+                modifier = Modifier.zIndex(1f),
             )
-            // Clip list pages so pull-to-refresh glyphs cannot paint over bouquet tabs above.
+            // Clip list pages so mid-pull glyphs cannot paint outside the list slot.
             Box(
                 modifier = Modifier
                     .weight(1f)

--- a/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubDestination.kt
@@ -34,11 +34,8 @@ fun ToolsHubDestination(modifier: Modifier = Modifier) {
 	destinationBarState.selected = selected
 	destinationBarState.onDestinationSelected = { selected = it }
 
-	InstallShellDestinationBar {
-		ToolsDestinationBar(
-			selected = destinationBarState.selected,
-			onDestinationSelected = { destinationBarState.onDestinationSelected(it) },
-		)
+	InstallShellDestinationBar { shellNav ->
+		shellNav.bindToolsDestinationBar(destinationBarState)
 	}
 
 	Scaffold(

--- a/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubState.kt
@@ -3,13 +3,27 @@ package net.reichholf.dreamdroid.ui.tools
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
  * Shell-facing state for the Tools bottom destination bar.
- * Mutable Snapshot fields so [net.reichholf.dreamdroid.ui.nav.InstallShellDestinationBar]
- * recomposes when the hub updates selection.
+ * Mutable Snapshot fields so [bindToolsDestinationBar] recomposes when the hub updates selection.
  */
 class ToolsHubState {
 	var selected by mutableStateOf(ToolsDestination.SCREENSHOT)
 	var onDestinationSelected: (ToolsDestination) -> Unit = {}
+}
+
+fun ComposeView.bindToolsDestinationBar(state: ToolsHubState) {
+	setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+	setContent {
+		DreamDroidTheme {
+			ToolsDestinationBar(
+				selected = state.selected,
+				onDestinationSelected = { state.onDestinationSelected(it) },
+			)
+		}
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses two regressions after the Tools hub / PTR work:

1. **Pull-to-refresh** — Keep Material’s stock `PullToRefreshContainer` (visible elevated indicator). Fix the Provider-tab overlay by raising the bouquet header with `zIndex(1f)` and keeping list `clipToBounds`, instead of a hand-rolled circular `Surface` behind the spinner.

2. **Bottom nav** — Tools / TV & Movies shell destination bars were capturing a `@Composable` lambda from the NavHost composition into the activity `shell_destination_nav` ComposeView; that cross-ComposeView bridge went blank after hub content loaded. Bind via self-contained `ComposeView.bind…(state)` helpers that own `setContent`.

## Test plan

- [x] `:app:compileGoogleDebugKotlin` / androidTest Kotlin
- [x] `DreamDroidPullRefreshTest` connected — OK (3 tests)
- [ ] Manual: TV & Movies reload — Provider stays readable; PTR disk still visible
- [ ] Manual: Tools + TV & Movies — bottom destination bar remains after content load

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

