### PR TITLE
Fix shell bottom nav: own chrome at PhoneNavHost

### DIFF
--- a/app/androidTest/kotlin/net/reichholf/dreamdroid/ui/nav/ShellDestinationBarHostTest.kt
+++ b/app/androidTest/kotlin/net/reichholf/dreamdroid/ui/nav/ShellDestinationBarHostTest.kt
@@ -1,0 +1,122 @@
+package net.reichholf.dreamdroid.ui.nav
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import net.reichholf.dreamdroid.ui.tools.ToolsDestination
+import net.reichholf.dreamdroid.ui.tools.ToolsHubState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Shell destination bar chrome is owned by the NavHost host, not hub leaves.
+ * Leaves only publish Snapshot state; clearing must not wipe a successor's publish.
+ */
+class ShellDestinationBarHostTest {
+	@get:Rule
+	val composeRule = createComposeRule()
+
+	@Before
+	fun forceAlwaysNight() {
+		PreferenceManager.getDefaultSharedPreferences(
+			InstrumentationRegistry.getInstrumentation().targetContext,
+		).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+	}
+
+	@Test
+	fun registerPublishesToolsStateToController() {
+		val state = ToolsHubState().apply { selected = ToolsDestination.SIGNAL }
+		lateinit var controller: ShellDestinationBarController
+		composeRule.setContent {
+			DreamDroidTheme {
+				ProvideShellDestinationBarForTest { c ->
+					controller = c
+					RegisterShellDestinationBar(ShellDestinationBarContent.Tools(state))
+					Text("hub body")
+				}
+			}
+		}
+		composeRule.onNodeWithText("hub body").assertIsDisplayed()
+		composeRule.runOnIdle {
+			val content = controller.content
+			assertTrue(content is ShellDestinationBarContent.Tools)
+			assertEquals(
+				ToolsDestination.SIGNAL,
+				(content as ShellDestinationBarContent.Tools).state.selected,
+			)
+		}
+	}
+
+	@Test
+	fun disposeClearsOnlyWhenStillOwner() {
+		val first = ToolsHubState().apply { selected = ToolsDestination.SCREENSHOT }
+		val second = ToolsHubState().apply { selected = ToolsDestination.DEVICE_INFO }
+		lateinit var controller: ShellDestinationBarController
+		composeRule.setContent {
+			DreamDroidTheme {
+				var showFirst by remember { mutableStateOf(true) }
+				ProvideShellDestinationBarForTest { c ->
+					controller = c
+					if (showFirst) {
+						RegisterShellDestinationBar(ShellDestinationBarContent.Tools(first))
+					} else {
+						RegisterShellDestinationBar(ShellDestinationBarContent.Tools(second))
+					}
+					Text(if (showFirst) "first" else "second")
+				}
+				// Flip after first frame via side channel Text click substitute:
+				androidx.compose.foundation.layout.Box {
+					if (showFirst) {
+						androidx.compose.material3.Button(onClick = { showFirst = false }) {
+							Text("swap")
+						}
+					}
+				}
+			}
+		}
+		composeRule.onNodeWithText("first").assertIsDisplayed()
+		composeRule.runOnIdle {
+			assertEquals(
+				ToolsDestination.SCREENSHOT,
+				(controller.content as ShellDestinationBarContent.Tools).state.selected,
+			)
+		}
+		composeRule.onNodeWithText("swap").performClick()
+		composeRule.onNodeWithText("second").assertIsDisplayed()
+		composeRule.runOnIdle {
+			assertEquals(
+				ToolsDestination.DEVICE_INFO,
+				(controller.content as ShellDestinationBarContent.Tools).state.selected,
+			)
+		}
+	}
+}
+
+/**
+ * Test double for [ProvideShellDestinationBar] that exposes the controller without
+ * requiring the activity [R.id.shell_destination_nav] ComposeView.
+ */
+@Composable
+private fun ProvideShellDestinationBarForTest(
+	content: @Composable (ShellDestinationBarController) -> Unit,
+) {
+	val controller = remember { ShellDestinationBarController() }
+	CompositionLocalProvider(LocalShellDestinationBarController provides controller) {
+		content(controller)
+	}
+}

--- a/app/src/net/reichholf/dreamdroid/ui/nav/DestinationBar.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/DestinationBar.kt
@@ -1,9 +1,5 @@
 package net.reichholf.dreamdroid.ui.nav
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.WindowInsets
@@ -13,13 +9,9 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import net.reichholf.dreamdroid.R
 
 /**
  * One entry in a phone shell bottom [DestinationBar] (TV & Movies, Tools, …).
@@ -32,6 +24,9 @@ data class DestinationBarItem(
 /**
  * Shared Material 3 bottom destination bar for phone hubs that host chrome on the
  * activity Coordinator slot ([R.id.shell_destination_nav]).
+ *
+ * Installed by [ProvideShellDestinationBar] / [RegisterShellDestinationBar] — not by
+ * capturing NavHost `@Composable` lambdas into the sibling activity ComposeView.
  */
 @Composable
 fun DestinationBar(
@@ -60,39 +55,4 @@ fun DestinationBar(
 			)
 		}
 	}
-}
-
-/**
- * Installs destination-bar composition on the activity [R.id.shell_destination_nav]
- * ComposeView and clears it when leaving this composition.
- *
- * [bind] must call a `ComposeView.bind…(state)` helper that owns a self-contained
- * `setContent { }` reading Snapshot state. Do **not** capture a `@Composable` lambda
- * from the NavHost/`detail_view` composition into the shell ComposeView — that
- * cross-ComposeView bridge goes blank after hub content loads (Tools / TV & Movies).
- */
-@Composable
-fun InstallShellDestinationBar(bind: (ComposeView) -> Unit) {
-	val context = LocalContext.current
-	DisposableEffect(context) {
-		val activity = context.findActivity()
-			?: return@DisposableEffect onDispose { }
-		val shellNav = activity.findViewById<ComposeView?>(R.id.shell_destination_nav)
-			?: return@DisposableEffect onDispose { }
-		shellNav.visibility = View.VISIBLE
-		bind(shellNav)
-		onDispose {
-			shellNav.visibility = View.GONE
-			shellNav.disposeComposition()
-		}
-	}
-}
-
-private fun Context.findActivity(): Activity? {
-	var ctx: Context? = this
-	while (ctx is ContextWrapper) {
-		if (ctx is Activity) return ctx
-		ctx = ctx.baseContext
-	}
-	return ctx as? Activity
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -61,6 +61,22 @@ fun PhoneNavHost(
         hostFragment.attachNavController(navController)
         onDispose { hostFragment.detachNavController(navController) }
     }
+    // Shell destination bar lives for the NavHost lifetime; hubs only publish Snapshot state.
+    ProvideShellDestinationBar {
+        PhoneNavHostGraph(
+            hostFragment = hostFragment,
+            navController = navController,
+            startDestination = startDestination,
+        )
+    }
+}
+
+@Composable
+private fun PhoneNavHostGraph(
+    hostFragment: PhoneNavHostFragment,
+    navController: NavHostController,
+    startDestination: String,
+) {
     NavHost(
         navController = navController,
         startDestination = startDestination,

--- a/app/src/net/reichholf/dreamdroid/ui/nav/ShellDestinationBarHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/ShellDestinationBarHost.kt
@@ -1,0 +1,129 @@
+package net.reichholf.dreamdroid.ui.nav
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.R
+import net.reichholf.dreamdroid.ui.services.TvMoviesDestinationBar
+import net.reichholf.dreamdroid.ui.services.TvMoviesHubState
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import net.reichholf.dreamdroid.ui.tools.ToolsDestinationBar
+import net.reichholf.dreamdroid.ui.tools.ToolsHubState
+
+/**
+ * Which hub (if any) currently owns the activity Coordinator destination bar.
+ *
+ * Held as Snapshot state so the *shell* ComposeView composition can recompose when hubs
+ * publish / clear themselves — without capturing NavHost `@Composable` lambdas into that
+ * sibling ComposeView (the #355 regression).
+ */
+sealed interface ShellDestinationBarContent {
+	data object Hidden : ShellDestinationBarContent
+	data class Tools(val state: ToolsHubState) : ShellDestinationBarContent
+	data class TvMovies(val state: TvMoviesHubState) : ShellDestinationBarContent
+}
+
+/**
+ * Activity-chrome controller for [R.id.shell_destination_nav].
+ * Owned by [ProvideShellDestinationBar] for the lifetime of [PhoneNavHost], not by hub leaves.
+ */
+class ShellDestinationBarController {
+	var content by mutableStateOf<ShellDestinationBarContent>(ShellDestinationBarContent.Hidden)
+}
+
+val LocalShellDestinationBarController = staticCompositionLocalOf<ShellDestinationBarController> {
+	error("ShellDestinationBarController not provided — wrap PhoneNavHost in ProvideShellDestinationBar")
+}
+
+/**
+ * Installs a long-lived composition on the activity [R.id.shell_destination_nav] ComposeView
+ * for the lifetime of this host (the phone NavHost), then provides [LocalShellDestinationBarController].
+ *
+ * Hub destinations only publish [ShellDestinationBarContent] via [RegisterShellDestinationBar].
+ * That keeps shell chrome out of hub content recomposition / load cycles — the failure mode when
+ * [InstallShellDestinationBar] lived inside Tools / TV & Movies and vanished after screenshot or
+ * bouquet load finished.
+ */
+@Composable
+fun ProvideShellDestinationBar(content: @Composable () -> Unit) {
+	val controller = remember { ShellDestinationBarController() }
+	val view = LocalView.current
+	DisposableEffect(view) {
+		val activity = view.context.findActivity()
+			?: return@DisposableEffect onDispose { }
+		val shellNav = activity.findViewById<ComposeView?>(R.id.shell_destination_nav)
+			?: return@DisposableEffect onDispose { }
+		shellNav.setViewCompositionStrategy(
+			ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
+		)
+		shellNav.setContent {
+			DreamDroidTheme {
+				val shown = controller.content
+				SideEffect {
+					shellNav.visibility =
+						if (shown is ShellDestinationBarContent.Hidden) View.GONE else View.VISIBLE
+					if (shown !is ShellDestinationBarContent.Hidden) {
+						shellNav.bringToFront()
+					}
+				}
+				when (shown) {
+					ShellDestinationBarContent.Hidden -> Unit
+					is ShellDestinationBarContent.Tools -> ToolsDestinationBar(
+						selected = shown.state.selected,
+						onDestinationSelected = { shown.state.onDestinationSelected(it) },
+					)
+					is ShellDestinationBarContent.TvMovies -> TvMoviesDestinationBar(
+						selected = shown.state.selected,
+						onDestinationSelected = { shown.state.onDestinationSelected(it) },
+					)
+				}
+			}
+		}
+		onDispose {
+			shellNav.visibility = View.GONE
+			shellNav.disposeComposition()
+		}
+	}
+	CompositionLocalProvider(LocalShellDestinationBarController provides controller) {
+		content()
+	}
+}
+
+/**
+ * Publishes [content] to the shell Coordinator bar while this leaf is composed.
+ * Clears only if we still own the slot (so rapid hub→hub swaps do not blank a successor).
+ */
+@Composable
+fun RegisterShellDestinationBar(content: ShellDestinationBarContent) {
+	val controller = LocalShellDestinationBarController.current
+	DisposableEffect(controller, content) {
+		controller.content = content
+		onDispose {
+			if (controller.content == content) {
+				controller.content = ShellDestinationBarContent.Hidden
+			}
+		}
+	}
+}
+
+private fun Context.findActivity(): Activity? {
+	var ctx: Context? = this
+	while (ctx is ContextWrapper) {
+		if (ctx is Activity) return ctx
+		ctx = ctx.baseContext
+	}
+	return ctx as? Activity
+}

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubDestination.kt
@@ -34,7 +34,8 @@ import net.reichholf.dreamdroid.enigma.launchLocationsAndTagsLoad
 import net.reichholf.dreamdroid.enigma.loadBouquetList
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.helpers.Statics
-import net.reichholf.dreamdroid.ui.nav.InstallShellDestinationBar
+import net.reichholf.dreamdroid.ui.nav.RegisterShellDestinationBar
+import net.reichholf.dreamdroid.ui.nav.ShellDestinationBarContent
 
 private const val MODE_TV = "TV"
 private const val MODE_RADIO = "Radio"
@@ -44,8 +45,9 @@ private const val MODE_TIMER = "Timer"
 /**
  * Phase 2.7h: TV & Movies hub as a direct Compose NavHost destination.
  * Owns mode + bouquet/location tabs (parity with former ServiceListPager),
- * hosts [TvMoviesDestinationBar] via [InstallShellDestinationBar] on [R.id.shell_destination_nav]
- * (Scaffold bottomBar inside detail_view sits under the system nav — dualpane ScrollingViewBehavior),
+ * publishes [TvMoviesDestinationBar] through [RegisterShellDestinationBar] onto the
+ * NavHost-owned [R.id.shell_destination_nav] Coordinator slot (Scaffold bottomBar inside
+ * detail_view sits under the system nav — dualpane ScrollingViewBehavior),
  * and routes MultiChoice / timer-edit results for the active child page.
  */
 @Composable
@@ -149,12 +151,10 @@ fun HubDestination(
         }
     }
 
-    // Destination bar on activity Coordinator (shell_destination_nav). Bind a self-contained
-    // shell composition (Snapshot state) — do not capture hub @Composable lambdas into the
-    // sibling ComposeView (that bridge goes blank after bouquet/content load).
-    InstallShellDestinationBar { shellNav ->
-        shellNav.bindTvMoviesDestinationBar(destinationBarState)
-    }
+    // Publish Snapshot state to the NavHost-owned shell ComposeView. Installing
+    // shell_destination_nav from this leaf tied chrome disposal to hub content load
+    // (bar vanished after bouquet / list refresh finished).
+    RegisterShellDestinationBar(ShellDestinationBarContent.TvMovies(destinationBarState))
 
     DisposableEffect(hostFragment) {
         val listener = PhoneNavHostFragment.ActivityResultListener { requestCode, resultCode, _ ->

--- a/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesHubState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/TvMoviesHubState.kt
@@ -4,41 +4,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
+/**
+ * Snapshot state for the TV & Movies hub chrome (header tabs + shell destination bar).
+ * The shell bar is published through [net.reichholf.dreamdroid.ui.nav.RegisterShellDestinationBar].
+ */
 class TvMoviesHubState {
 	var selected by mutableStateOf(TvMoviesDestination.TV)
 	var rows by mutableStateOf(listOf<String>())
 	var selectedRow by mutableIntStateOf(0)
 	var error by mutableStateOf<String?>(null)
-	/** Latest hub destination click handler; shell ComposeView reads this on each click. */
+	/** Latest hub destination click handler; shell composition reads this on each click. */
 	var onDestinationSelected: (TvMoviesDestination) -> Unit = {}
-}
-
-fun ComposeView.bindTvMoviesHeader(state: TvMoviesHubState, onRowSelected: (Int) -> Unit) {
-	setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-	setContent {
-		DreamDroidTheme {
-			TvMoviesHeader(
-				rows = state.rows,
-				selectedRow = state.selectedRow,
-				error = state.error,
-				onRowSelected = onRowSelected,
-			)
-		}
-	}
-}
-
-fun ComposeView.bindTvMoviesDestinationBar(state: TvMoviesHubState) {
-	setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-	setContent {
-		DreamDroidTheme {
-			TvMoviesDestinationBar(
-				selected = state.selected,
-				onDestinationSelected = { state.onDestinationSelected(it) },
-			)
-		}
-	}
 }

--- a/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubDestination.kt
@@ -19,13 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import net.reichholf.dreamdroid.R
 import net.reichholf.dreamdroid.ui.device.DeviceInfoDestination
-import net.reichholf.dreamdroid.ui.nav.InstallShellDestinationBar
+import net.reichholf.dreamdroid.ui.nav.RegisterShellDestinationBar
+import net.reichholf.dreamdroid.ui.nav.ShellDestinationBarContent
 import net.reichholf.dreamdroid.ui.screenshot.ScreenshotDestination
 import net.reichholf.dreamdroid.ui.signal.SignalDestination
 
 /**
  * Tools hub: Screenshot / Device Info / Signal Meter with a shell bottom destination bar
- * (same Coordinator slot pattern as TV & Movies).
+ * (Coordinator slot owned by [net.reichholf.dreamdroid.ui.nav.ProvideShellDestinationBar]).
  */
 @Composable
 fun ToolsHubDestination(modifier: Modifier = Modifier) {
@@ -34,9 +35,9 @@ fun ToolsHubDestination(modifier: Modifier = Modifier) {
 	destinationBarState.selected = selected
 	destinationBarState.onDestinationSelected = { selected = it }
 
-	InstallShellDestinationBar { shellNav ->
-		shellNav.bindToolsDestinationBar(destinationBarState)
-	}
+	// Publish Snapshot state to the NavHost-owned shell ComposeView — do not install or
+	// setContent on shell_destination_nav from this leaf (content load must not dispose chrome).
+	RegisterShellDestinationBar(ShellDestinationBarContent.Tools(destinationBarState))
 
 	Scaffold(
 		modifier = modifier.fillMaxSize(),

--- a/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/tools/ToolsHubState.kt
@@ -3,27 +3,14 @@ package net.reichholf.dreamdroid.ui.tools
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 /**
- * Shell-facing state for the Tools bottom destination bar.
- * Mutable Snapshot fields so [bindToolsDestinationBar] recomposes when the hub updates selection.
+ * Snapshot state for the Tools shell destination bar.
+ * Published to [net.reichholf.dreamdroid.ui.nav.ProvideShellDestinationBar] via
+ * [net.reichholf.dreamdroid.ui.nav.RegisterShellDestinationBar]; the shell ComposeView
+ * reads these fields directly (no hub `@Composable` capture).
  */
 class ToolsHubState {
 	var selected by mutableStateOf(ToolsDestination.SCREENSHOT)
 	var onDestinationSelected: (ToolsDestination) -> Unit = {}
-}
-
-fun ComposeView.bindToolsDestinationBar(state: ToolsHubState) {
-	setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-	setContent {
-		DreamDroidTheme {
-			ToolsDestinationBar(
-				selected = state.selected,
-				onDestinationSelected = { state.onDestinationSelected(it) },
-			)
-		}
-	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Tools hub centralization (#355) installed the Coordinator `shell_destination_nav` bar from inside hub leaves (`InstallShellDestinationBar`). That tied chrome lifecycle to hub content composition, so the bottom nav disappeared after screenshot / bouquet load finished — including on TV & Movies after the shared helper replaced the old working leaf `DisposableEffect`+bind path.

## Proper fix

- **`ProvideShellDestinationBar`** at `PhoneNavHost`: one long-lived composition on the activity Coordinator ComposeView for the NavHost lifetime.
- Hubs only **`RegisterShellDestinationBar`** with Snapshot state (`ToolsHubState` / `TvMoviesHubState`).
- No hub `@Composable` lambdas captured into the sibling ComposeView.
- `bringToFront()` when shown so ScrollingViewBehavior overlap cannot bury the bar.

## Test plan

- [x] `:app:compileGoogleDebugKotlin` / androidTest Kotlin
- [x] Connected: `ShellDestinationBarHostTest` + `DestinationBarTest` + `ToolsDestinationBarTest` — OK (5 tests)
- [ ] Manual: Tools → wait for screenshot → bottom nav stays
- [ ] Manual: TV & Movies → wait for list load → bottom nav stays

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9edcdf48-9bd0-47fe-a68f-b1e81b48c88a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

