### PR TITLE
Fix video overlay seek nest background color

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/video/VideoOverlayScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/video/VideoOverlayScreenTest.kt
@@ -1,16 +1,24 @@
 package net.reichholf.dreamdroid.ui.video
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
-import net.reichholf.dreamdroid.DreamDroid
 import kotlin.Metadata
+import kotlin.math.abs
+import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.fragment.VideoOverlayFragment
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -78,7 +86,89 @@ class VideoOverlayScreenTest {
     }
 
     @Test
+    fun progressContainerUsesSurfaceVariantNotPrimaryContainer() {
+        var surfaceVariant = Color.Unspecified
+        var primaryContainer = Color.Unspecified
+        val state = VideoOverlayUiState().apply {
+            title = "ZDF HD"
+            showNow = true
+            nowStart = "16:10"
+            nowTitle = "Die Rosenheim-Cops"
+            nowDuration = "50"
+            // Live-style chrome: progress only (no PVR buttons) — the blue nest was most obvious.
+            progressMax = 100
+            progress = 20
+            progressEnabled = true
+            seekable = false
+            showInfoButton = true
+            showListButton = true
+        }
+        composeRule.setContent {
+            DreamDroidTheme {
+                surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
+                primaryContainer = MaterialTheme.colorScheme.primaryContainer
+                VideoOverlayScreen(
+                    state = state,
+                    onPlay = {},
+                    onRewind = {},
+                    onForward = {},
+                    onInfo = {},
+                    onList = {},
+                    onAudio = {},
+                    onSubtitle = {},
+                    onSeekChange = {},
+                )
+            }
+        }
+        composeRule.onNodeWithTag(VIDEO_OVERLAY_PROGRESS_CONTAINER_TAG).assertIsDisplayed()
+        val bitmap = composeRule
+            .onNodeWithTag(VIDEO_OVERLAY_PROGRESS_CONTAINER_TAG)
+            .captureToImage()
+            .asAndroidBitmap()
+        val expected = surfaceVariant.toArgb()
+        val wrong = primaryContainer.toArgb()
+        // Sample the top padding strip (away from the Slider track/thumb).
+        var nearSurface = 0
+        var nearPrimary = 0
+        var samples = 0
+        val yMax = (bitmap.height * 0.15f).toInt().coerceAtLeast(1).coerceAtMost(bitmap.height)
+        var y = 0
+        while (y < yMax) {
+            var x = 0
+            while (x < bitmap.width) {
+                val px = bitmap.getPixel(x, y)
+                if (rgbDistance(px, expected) < rgbDistance(px, wrong)) {
+                    nearSurface++
+                }
+                if (rgbDistance(px, wrong) < 40) {
+                    nearPrimary++
+                }
+                samples++
+                x += 3
+            }
+            y += 1
+        }
+        assertTrue("expected samples along progress nest padding", samples > 10)
+        assertTrue(
+            "progress nest should match surfaceVariant, not primaryContainer " +
+                "(nearSurface=$nearSurface nearPrimary=$nearPrimary samples=$samples " +
+                "surfaceVariant=#${Integer.toHexString(expected)} primaryContainer=#${Integer.toHexString(wrong)})",
+            nearSurface > samples / 2 && nearPrimary < samples / 4,
+        )
+    }
+
+    @Test
     fun videoOverlayFragmentIsKotlinClass() {
         assertNotNull(VideoOverlayFragment::class.java.getAnnotation(Metadata::class.java))
+    }
+
+    private fun rgbDistance(a: Int, b: Int): Int {
+        val ar = (a shr 16) and 0xff
+        val ag = (a shr 8) and 0xff
+        val ab = a and 0xff
+        val br = (b shr 16) and 0xff
+        val bg = (b shr 8) and 0xff
+        val bb = b and 0xff
+        return abs(ar - br) + abs(ag - bg) + abs(ab - bb)
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/video/VideoOverlayScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/video/VideoOverlayScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -42,6 +43,9 @@ import net.reichholf.dreamdroid.ui.dialogs.SimpleChoiceAlertDialog
 import net.reichholf.dreamdroid.ui.epg.EpgDetailModalSheet
 import net.reichholf.dreamdroid.ui.movies.MovieDetailModalSheet
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+
+/** Test tag for the seek/progress nest behind the overlay Slider. */
+const val VIDEO_OVERLAY_PROGRESS_CONTAINER_TAG = "video_overlay_progress_container"
 
 /**
  * Mutable overlay chrome state driven by [net.reichholf.dreamdroid.fragment.VideoOverlayFragment].
@@ -157,8 +161,10 @@ fun VideoOverlayScreen(
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
                 .clip(RoundedCornerShape(4.dp))
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .padding(horizontal = 8.dp, vertical = 4.dp),
+                // Nested chrome on the overlay surface — not primaryContainer (loud blue in night).
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .testTag(VIDEO_OVERLAY_PROGRESS_CONTAINER_TAG),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (state.showPvrControls) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The video player overlay seek/progress nest used `MaterialTheme.colorScheme.primaryContainer`, which is a saturated blue (`#1E4390`) in night mode and read as the wrong background behind the Slider.

## Change
- Paint the nest with `surfaceVariant` (neutral elevated surface used elsewhere for cards).
- Tag the nest and add an instrumented Compose pixel test that asserts the top padding strip matches `surfaceVariant` and is not `primaryContainer`.

## Test plan
- [x] `bash .cursor/cloud/connected-test.sh net.reichholf.dreamdroid.ui.video.VideoOverlayScreenTest` → **OK (3 tests)** including `progressContainerUsesSurfaceVariantNotPrimaryContainer`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c5b3a1-b35d-4501-bf92-9ee9ed2cbd51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c5b3a1-b35d-4501-bf92-9ee9ed2cbd51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

