### PR TITLE
Keep profile check on the NavHost back stack

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/profilecheck/ProfileCheckBackStackTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/profilecheck/ProfileCheckBackStackTest.kt
@@ -13,17 +13,19 @@ import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.nav.navigateAboveProfileCheck
+import net.reichholf.dreamdroid.ui.nav.navigateReplacingProfileCheck
 import net.reichholf.dreamdroid.ui.nav.navigateToProfileCheck
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 /**
- * PROFILE_CHECK is pushed onto the NavHost back stack; navigating to a root above it
- * must leave the gate so Back returns to the check.
+ * After a successful check, PROFILE_CHECK must leave the back stack.
+ * From a failed check, Profiles may keep the gate underneath for Recheck.
  */
 class ProfileCheckBackStackTest {
     @get:Rule
@@ -37,7 +39,39 @@ class ProfileCheckBackStackTest {
     }
 
     @Test
-    fun profileCheckRemainsUnderDestinationOnBackStack() {
+    fun successfulLeaveRemovesProfileCheckFromBackStack() {
+        var backStackRoutes = emptyList<String>()
+        composeRule.setContent {
+            DreamDroidTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = PhoneNavRoutes.HUB,
+                ) {
+                    composable(PhoneNavRoutes.HUB) { Text("Hub") }
+                    composable(PhoneNavRoutes.PROFILE_CHECK) { Text("ProfileCheck") }
+                    composable(PhoneNavRoutes.PROFILES) { Text("Profiles") }
+                }
+                LaunchedEffect(Unit) {
+                    navController.navigateToProfileCheck()
+                    navController.navigateReplacingProfileCheck(PhoneNavRoutes.HUB)
+                    backStackRoutes = navController.currentBackStack.value.mapNotNull { it.destination.route }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Hub").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertFalse(
+                "profile_check must not remain under the service list: $backStackRoutes",
+                PhoneNavRoutes.PROFILE_CHECK in backStackRoutes,
+            )
+            assertEquals(PhoneNavRoutes.HUB, backStackRoutes.last())
+        }
+    }
+
+    @Test
+    fun failedProfilesKeepsProfileCheckUnderneath() {
         var backStackRoutes = emptyList<String>()
         composeRule.setContent {
             DreamDroidTheme {
@@ -61,7 +95,7 @@ class ProfileCheckBackStackTest {
         composeRule.onNodeWithText("Profiles").assertIsDisplayed()
         composeRule.runOnIdle {
             assertTrue(
-                "back stack should contain profile_check: $backStackRoutes",
+                "failed-check → Profiles should keep profile_check underneath: $backStackRoutes",
                 PhoneNavRoutes.PROFILE_CHECK in backStackRoutes,
             )
             assertEquals(PhoneNavRoutes.PROFILES, backStackRoutes.last())

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/profilecheck/ProfileCheckBackStackTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/profilecheck/ProfileCheckBackStackTest.kt
@@ -1,0 +1,70 @@
+package net.reichholf.dreamdroid.ui.profilecheck
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.preference.PreferenceManager
+import androidx.test.platform.app.InstrumentationRegistry
+import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
+import net.reichholf.dreamdroid.ui.nav.navigateAboveProfileCheck
+import net.reichholf.dreamdroid.ui.nav.navigateToProfileCheck
+import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * PROFILE_CHECK is pushed onto the NavHost back stack; navigating to a root above it
+ * must leave the gate so Back returns to the check.
+ */
+class ProfileCheckBackStackTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun forceAlwaysNight() {
+        PreferenceManager.getDefaultSharedPreferences(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        ).edit().putString(DreamDroid.PREFS_KEY_THEME_TYPE, "1").commit()
+    }
+
+    @Test
+    fun profileCheckRemainsUnderDestinationOnBackStack() {
+        var backStackRoutes = emptyList<String>()
+        composeRule.setContent {
+            DreamDroidTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = PhoneNavRoutes.HUB,
+                ) {
+                    composable(PhoneNavRoutes.HUB) { Text("Hub") }
+                    composable(PhoneNavRoutes.PROFILE_CHECK) { Text("ProfileCheck") }
+                    composable(PhoneNavRoutes.PROFILES) { Text("Profiles") }
+                }
+                LaunchedEffect(Unit) {
+                    navController.navigateToProfileCheck()
+                    navController.navigateAboveProfileCheck(PhoneNavRoutes.PROFILES)
+                    backStackRoutes = navController.currentBackStack.value.mapNotNull { it.destination.route }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Profiles").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertTrue(
+                "back stack should contain profile_check: $backStackRoutes",
+                PhoneNavRoutes.PROFILE_CHECK in backStackRoutes,
+            )
+            assertEquals(PhoneNavRoutes.PROFILES, backStackRoutes.last())
+        }
+    }
+}

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
@@ -192,7 +192,8 @@ class MainActivity :
             } else {
                 StartScreen.navRoute(this)
             }
-            detail.navigateAboveProfileCheck(route)
+            // Drop the gate so Back from the service list does not return to the check.
+            detail.navigateReplacingProfileCheck(route)
             return
         }
         if (isFirstStart) {

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
@@ -131,7 +131,8 @@ class MainActivity :
             detail.navigateToProfileCheck(ui)
             return
         }
-        val host = PhoneNavHostFragment.newInstance(PhoneNavRoutes.PROFILE_CHECK)
+        // Start under the configured home route, then push the gate so it is in the back stack.
+        val host = PhoneNavHostFragment.newInstance(StartScreen.navRoute(this))
         host.queueProfileCheck(ui)
         showDetails(host)
     }
@@ -152,7 +153,7 @@ class MainActivity :
             detail.navigateToProfileCheck(ui)
             return
         }
-        val host = PhoneNavHostFragment.newInstance(PhoneNavRoutes.PROFILE_CHECK)
+        val host = PhoneNavHostFragment.newInstance(StartScreen.navRoute(this))
         host.queueProfileCheck(ui)
         showDetails(host)
     }
@@ -174,7 +175,31 @@ class MainActivity :
 
     fun openProfilesFromProfileCheckFailed() {
         mOpenStartOnProfileSuccess = false
+        val detail = supportFragmentManager.findFragmentById(R.id.detail_view)
+        if (detail is PhoneNavHostFragment && detail.isOnProfileCheckRoute()) {
+            // Keep the gate under Profiles so Back returns to the check.
+            detail.navigateAboveProfileCheck(PhoneNavRoutes.PROFILES)
+            return
+        }
         mNavigationHelper?.navigateTo(R.id.menu_navigation_profiles)
+    }
+
+    private fun leaveProfileCheckGate(isFirstStart: Boolean) {
+        val detail = supportFragmentManager.findFragmentById(R.id.detail_view) as? PhoneNavHostFragment
+        if (detail != null && detail.isOnProfileCheckRoute()) {
+            val route = if (isFirstStart) {
+                PhoneNavRoutes.PROFILES
+            } else {
+                StartScreen.navRoute(this)
+            }
+            detail.navigateAboveProfileCheck(route)
+            return
+        }
+        if (isFirstStart) {
+            mNavigationHelper!!.navigateTo(R.id.menu_navigation_profiles)
+        } else {
+            mNavigationHelper!!.navigateTo(StartScreen.menuId(this))
+        }
     }
 
     private fun isPaused(): Boolean {
@@ -216,9 +241,12 @@ class MainActivity :
             mOpenStartOnProfileSuccess = false
             val onGate = (supportFragmentManager.findFragmentById(R.id.detail_view) as? PhoneNavHostFragment)
                 ?.isOnProfileCheckRoute() == true
-            if (isFirstStart) {
+            if (onGate || openStart) {
+                // Leave PROFILE_CHECK on the back stack so Back returns to the gate.
+                leaveProfileCheckGate(isFirstStart)
+            } else if (isFirstStart) {
                 mNavigationHelper!!.navigateTo(R.id.menu_navigation_profiles)
-            } else if (getCurrentDetailFragment() == null || openStart || onGate) {
+            } else if (getCurrentDetailFragment() == null) {
                 mNavigationHelper!!.navigateTo(StartScreen.menuId(this))
             }
         }

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -27,6 +27,7 @@ import net.reichholf.dreamdroid.ui.nav.NavExtras
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.profilecheck.ProfileCheckUi
 import net.reichholf.dreamdroid.ui.nav.navigateAboveProfileCheck
+import net.reichholf.dreamdroid.ui.nav.navigateReplacingProfileCheck
 import net.reichholf.dreamdroid.ui.nav.navigateToProfileCheck
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
@@ -383,12 +384,22 @@ class PhoneNavHostFragment : BaseFragment() {
     }
 
     /**
-     * Navigate to [route] while leaving [PhoneNavRoutes.PROFILE_CHECK] on the back stack.
-     * Used when leaving the gate for Profiles / start so Back returns to the check.
+     * Navigate to [route] while leaving [PhoneNavRoutes.PROFILE_CHECK] on the back stack
+     * (failed check → Profiles; Back can return to Recheck).
      */
     fun navigateAboveProfileCheck(route: String): Boolean {
         val controller = navController ?: return false
         controller.navigateAboveProfileCheck(route)
+        return true
+    }
+
+    /**
+     * Navigate to [route] and drop [PhoneNavRoutes.PROFILE_CHECK] from the back stack
+     * (successful check → start route).
+     */
+    fun navigateReplacingProfileCheck(route: String): Boolean {
+        val controller = navController ?: return false
+        controller.navigateReplacingProfileCheck(route)
         return true
     }
 

--- a/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
+++ b/app/src/net/reichholf/dreamdroid/fragment/PhoneNavHostFragment.kt
@@ -26,6 +26,7 @@ import net.reichholf.dreamdroid.helpers.enigma2.Timer
 import net.reichholf.dreamdroid.ui.nav.NavExtras
 import net.reichholf.dreamdroid.ui.nav.PhoneNavRoutes
 import net.reichholf.dreamdroid.ui.profilecheck.ProfileCheckUi
+import net.reichholf.dreamdroid.ui.nav.navigateAboveProfileCheck
 import net.reichholf.dreamdroid.ui.nav.navigateToProfileCheck
 import net.reichholf.dreamdroid.ui.nav.bindPhoneNavHost
 import net.reichholf.dreamdroid.ui.nav.navigateDrawerRoot
@@ -379,6 +380,16 @@ class PhoneNavHostFragment : BaseFragment() {
         updateProfileCheckUi(ui)
         pendingProfileCheck = true
         flushPendingNavigations()
+    }
+
+    /**
+     * Navigate to [route] while leaving [PhoneNavRoutes.PROFILE_CHECK] on the back stack.
+     * Used when leaving the gate for Profiles / start so Back returns to the check.
+     */
+    fun navigateAboveProfileCheck(route: String): Boolean {
+        val controller = navController ?: return false
+        controller.navigateAboveProfileCheck(route)
+        return true
     }
 
 

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -254,12 +254,25 @@ fun NavHostController.navigateToProfileCheck() {
 }
 
 /**
- * Open a drawer root above [PhoneNavRoutes.PROFILE_CHECK] without popping the gate,
- * so Back returns to the profile-check screen.
+ * Open a drawer root above [PhoneNavRoutes.PROFILE_CHECK] without popping the gate
+ * (e.g. Profiles from a failed check so Back can return to Recheck).
  */
 fun NavHostController.navigateAboveProfileCheck(route: String) {
     if (currentDestination?.route == route) return
     navigate(route) {
+        launchSingleTop = true
+    }
+}
+
+/**
+ * Leave the profile-check gate for [route], removing [PhoneNavRoutes.PROFILE_CHECK]
+ * from the back stack so Back from the service list does not return to the check.
+ */
+fun NavHostController.navigateReplacingProfileCheck(route: String) {
+    navigate(route) {
+        popUpTo(PhoneNavRoutes.PROFILE_CHECK) {
+            inclusive = true
+        }
         launchSingleTop = true
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/PhoneNavHost.kt
@@ -245,10 +245,21 @@ fun NavHostController.navigateToChangelog() {
     navigate(PhoneNavRoutes.CHANGELOG)
 }
 
-/** Show the full-screen profile-check gate (checking / failed). */
+/** Push the full-screen profile-check gate (checking / failed) onto the back stack. */
 fun NavHostController.navigateToProfileCheck() {
     if (currentDestination?.route == PhoneNavRoutes.PROFILE_CHECK) return
     navigate(PhoneNavRoutes.PROFILE_CHECK) {
+        launchSingleTop = true
+    }
+}
+
+/**
+ * Open a drawer root above [PhoneNavRoutes.PROFILE_CHECK] without popping the gate,
+ * so Back returns to the profile-check screen.
+ */
+fun NavHostController.navigateAboveProfileCheck(route: String) {
+    if (currentDestination?.route == route) return
+    navigate(route) {
         launchSingleTop = true
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/nav/StartScreen.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/nav/StartScreen.kt
@@ -51,4 +51,18 @@ object StartScreen {
 
 	@IdRes
 	fun menuId(context: Context): Int = menuId(read(context))
+
+	/** PhoneNavHost route for the configured start screen (drawer roots only). */
+	fun navRoute(value: String): String = when (value) {
+		VALUE_EPG -> PhoneNavRoutes.EPG
+		VALUE_REMOTE -> PhoneNavRoutes.REMOTE
+		VALUE_CURRENT -> PhoneNavRoutes.CURRENT
+		VALUE_ZAP -> PhoneNavRoutes.ZAP
+		VALUE_TOOLS -> PhoneNavRoutes.TOOLS
+		else -> PhoneNavRoutes.HUB
+	}
+
+	fun navRoute(prefs: SharedPreferences): String = navRoute(read(prefs))
+
+	fun navRoute(context: Context): String = navRoute(read(context))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Clarifies profile-check back-stack behavior:

- Cold start still mounts the start route and **pushes** `profile_check` (NavHost destination, not an overlay dialog).
- **Success** → open start/Profiles with `popUpTo(profile_check, inclusive)` so the gate is **removed**. Back from the service list no longer returns to the check.
- **Failed check → Profiles** still keeps the gate underneath so Back can return to Recheck.

## Test plan
- [x] Compile Google debug + androidTest
- [x] Connected: `ProfileCheckBackStackTest` + `ProfileCheckScreenTest` (**OK, 4 tests**)
- [ ] Success → service list → Back does **not** show the check again
- [ ] Failed → Profiles → Back returns to check / Recheck

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cea76c1-be9c-459e-a046-3c7423b76009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cea76c1-be9c-459e-a046-3c7423b76009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

