### PR TITLE
docs: Graphical MultiEPG plan (Accepted)

### DIFF
--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -1284,12 +1284,12 @@ One PR per fix or small related cluster. Prefer regressions covered by Compose t
 
 ## Appendix I. Graphical MultiEPG (product plan)
 
-**Docs only until operator lock-in.** Full design: [`docs/multiepg.md`](multiepg.md).
+**Accepted** 2026-09-12. Full design: [`docs/multiepg.md`](multiepg.md). No feature code until Phase 0 spike notes land.
 
 - **UX reference:** DreamOS on-box GraphMultiEPG (`enigma2-plugin-extensions-graphmultiepg`) — horizontal channel×time grid (not stock web column MultiEPG).
 - **Data path:** bounded Dreambox `/web/epgmulti?bRef=&time=&endTime=` + Room TTL (on-box plugin uses `eEPGCache`; the phone cannot).
-- **Defaults pending OK:** keep list EPG + drawer MultiEPG; 2 h visible / 24 h cache chunks; no idle sync; phone-only v1; timer clocks in v1.1.
-- Implementation phases 0–4 live in that doc; **do not start code** until the Decision brief is Accepted there.
+- **Locked defaults:** keep list EPG + drawer MultiEPG; 2 h visible / 24 h cache chunks; no idle sync; phone-only v1; timer clocks in v1.1.
+- Implementation phases 0–4 live in that doc; next step is Phase 0 spike on a real Dreambox.
 
 ## Appendix F. Links
 

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -1282,6 +1282,14 @@ One PR per fix or small related cluster. Prefer regressions covered by Compose t
 - Do not rewrite VLC codecs or Enigma2 server side.
 - Phase **2.7i** chassis cleanup **merged** [#315](https://github.com/sreichholf/dreamDroid/pull/315). Keepers reopen **merged** [#335](https://github.com/sreichholf/dreamDroid/pull/335). **3.1c-iv-b–g** **merged** [#336](https://github.com/sreichholf/dreamDroid/pull/336)–[#341](https://github.com/sreichholf/dreamDroid/pull/341). **#343 merged**. **#344–#346 merged** (dialogs 2.1g-ii-d…f). **This PR:** Kotlin-port TV `MainActivity`. **Next:** Phase **4** operator usertests.
 
+## Appendix I. Graphical MultiEPG (product plan)
+
+**Docs only until operator lock-in.** Full design: [`docs/multiepg.md`](multiepg.md).
+
+- Target: GraphMultiEPG-style phone grid + local EPG cache so the box is not overloaded.
+- API: genuine Dreambox WebIf `/web/epgmulti?bRef=&time=&endTime=` (verified in [opendreambox webinterface](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface)); windowed fetches + Room TTL; no webif patches.
+- Implementation phases 0–4 live in that doc; **do not start code** until defaults are accepted there.
+
 ## Appendix F. Links
 
-[`AGENTS.md`](../AGENTS.md), [`.cursor/skills/verify-dreamdroid/SKILL.md`](../.cursor/skills/verify-dreamdroid/SKILL.md), [`app/build.gradle`](../app/build.gradle), [`NavigationHelper.java`](../app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java), [`MainActivity.java`](../app/src/net/reichholf/dreamdroid/activities/MainActivity.java), [`URIStore.java`](../app/src/net/reichholf/dreamdroid/helpers/enigma2/URIStore.java), [`themes.xml`](../app/res/values/themes.xml).
+[`AGENTS.md`](../AGENTS.md), [`.cursor/skills/verify-dreamdroid/SKILL.md`](../.cursor/skills/verify-dreamdroid/SKILL.md), [`docs/multiepg.md`](multiepg.md), [`app/build.gradle`](../app/build.gradle), [`NavigationHelper.java`](../app/src/net/reichholf/dreamdroid/fragment/helper/NavigationHelper.java), [`MainActivity.java`](../app/src/net/reichholf/dreamdroid/activities/MainActivity.java), [`URIStore.java`](../app/src/net/reichholf/dreamdroid/helpers/enigma2/URIStore.java), [`themes.xml`](../app/res/values/themes.xml).

--- a/docs/modernize-dreamdroid.md
+++ b/docs/modernize-dreamdroid.md
@@ -1286,9 +1286,10 @@ One PR per fix or small related cluster. Prefer regressions covered by Compose t
 
 **Docs only until operator lock-in.** Full design: [`docs/multiepg.md`](multiepg.md).
 
-- Target: GraphMultiEPG-style phone grid + local EPG cache so the box is not overloaded.
-- API: genuine Dreambox WebIf `/web/epgmulti?bRef=&time=&endTime=` (verified in [opendreambox webinterface](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface)); windowed fetches + Room TTL; no webif patches.
-- Implementation phases 0–4 live in that doc; **do not start code** until defaults are accepted there.
+- **UX reference:** DreamOS on-box GraphMultiEPG (`enigma2-plugin-extensions-graphmultiepg`) — horizontal channel×time grid (not stock web column MultiEPG).
+- **Data path:** bounded Dreambox `/web/epgmulti?bRef=&time=&endTime=` + Room TTL (on-box plugin uses `eEPGCache`; the phone cannot).
+- **Defaults pending OK:** keep list EPG + drawer MultiEPG; 2 h visible / 24 h cache chunks; no idle sync; phone-only v1; timer clocks in v1.1.
+- Implementation phases 0–4 live in that doc; **do not start code** until the Decision brief is Accepted there.
 
 ## Appendix F. Links
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -30,7 +30,7 @@ Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer mode
 
 ## 2. Dreambox WebIf — verified EPG surface
 
-Source of truth: `webinterface/src/WebComponents/Sources/EPG.py`, `WebScreens.py`, and `web/epg*.xml` in opendreambox.
+Source of truth (opendreambox tree): `webinterface/src/WebComponents/Sources/EPG.py`, `WebScreens.py` (`EpgWebScreen` / `EpgMulti`), and `web/epgmulti.xml` (`bRef,time,endTime`).
 
 | Endpoint | XML params | Role |
 | --- | --- | --- |
@@ -88,16 +88,43 @@ One windowed `epgmulti` is still one heavy cache lookup on the box; bounds + TTL
 Drawer MultiEPG
   → PhoneNavRoutes.MULTI_EPG
   → MultiEpgDestination (Compose)
-       ├── MultiEpgSync / EnigmaClient.getEpgMulti
+       ├── MultiEpgSync / EnigmaClient.getEvents(…, URIStore.EPG_MULTI)
        ├── Room EpgDao
        └── MultiEpgScreen (grid)
             └── tap → existing EpgDetail sheet / timer session
 ```
 
+### Existing hooks (no code yet — for implementers)
+
+| Concern | Current beachhead |
+| --- | --- |
+| Route table | `ui/nav/PhoneNavRoutes.kt` (`EPG`, `SERVICE_EPG`, `EPG_SEARCH`) — add `MULTI_EPG` |
+| NavHost | `ui/nav/PhoneNavHost.kt` — register composable |
+| Drawer | `ui/drawer/DrawerScreen.kt` + `res/menu/navigation.xml` — new item beside list EPG |
+| Drawer → EPG | `fragment/helper/NavigationHelper.kt` (`menu_navigation_epg`) — parallel MultiEPG case |
+| HTTP | `enigma/EnigmaClient.getEvents(params, uri)` already takes a URI; pass `URIStore.EPG_MULTI` |
+| Params | Same style as `EpgBouquetDestination`: `NameValuePair("bRef", …)` plus `time` / `endTime` |
+| Parse | Reuse `EventParser` / typed `enigma.Event` (XML tags match `epgservice`) |
+| Detail / timer | Reuse `EpgEventDialogSession` (`ui/epg/EpgEventDialogSession.kt`) from bouquet/service EPG |
+| Room today | `room/AppDatabase.kt` is **Profile-only** (v1) — MultiEPG needs a schema bump + entities |
+| Proof | `bash .cursor/cloud/connected-test.sh …` (not emulator tap loops); see `AGENTS.md` |
+
+### Room sketch (Phase 1 — illustrative)
+
+```text
+EpgEventEntity
+  profileId, serviceRef, eventId, start, duration, title, description, …
+  PK / unique: (profileId, serviceRef, eventId) or (profileId, serviceRef, start)
+
+EpgChunkMeta
+  profileId, bouquetRef, windowStart, windowEnd, fetchedAtMs
+  → TTL freshness for that chunk
+```
+
+Do **not** revive orphan `DatabaseHelper` `events` table writers.
+
 - Kotlin + Compose + coroutines only (see `AGENTS.md`).
-- Reuse: bouquet pick, typed `enigma.Event`, detail/timer session.
 - Grid: custom Compose layout (synced H-scroll time header + V-scroll channels); do not revive deleted `EpgTimelineFragment` / `multiepg*.xml`.
-- Proof: instrumented Compose tests + `bash .cursor/cloud/connected-test.sh …` (no emulator tap loops).
 
 ---
 
@@ -105,13 +132,28 @@ Drawer MultiEPG
 
 | Phase | Deliverable | Gate |
 | --- | --- | --- |
-| **0 — Spike** | Call windowed `epgmulti` on a real Dreambox WebIf; confirm `time`/`endTime` units; note payload size for 24 h × typical bouquet; fixture XML if needed | Operator or lab box result recorded in this doc / PR |
-| **1 — Client + cache** | `EnigmaClient.getEpgMulti`, Room schema, TTL, single-flight | Unit tests + androidTest parse |
+| **0 — Spike** | Lab/operator: windowed `epgmulti` on real Dreambox WebIf; confirm units + size | Notes pasted into this doc / PR |
+| **1 — Client + cache** | `getEvents(…, EPG_MULTI)`, Room schema, TTL, single-flight | Unit + androidTest parse |
 | **2 — Grid beachhead** | Nav + bouquet + now line + pan + tap → detail | `MultiEpgScreenTest` via connected-test helper |
 | **3 — Polish** | Zoom / day jump / empty+error / pull-refresh | Same |
 | **4 — Timers (optional)** | Overlay from `timerlist` | Optional follow-on |
 
 **No Phase 1+ code until Phase 0 spike notes are accepted and this plan is lock-in.**
+
+### Phase 0 spike checklist
+
+On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
+
+1. Unbounded (stock UI behaviour — expect large):  
+   `GET /web/epgmulti?bRef=BREF`
+2. Windowed 24 h (intended app behaviour):  
+   `GET /web/epgmulti?bRef=BREF&time=T0&endTime=T1`  
+   where `T0` = now (unix), `T1 = T0 + 86400`
+3. Compare to single channel:  
+   `GET /web/epgservice?sRef=SREF&time=T0&endTime=T1`
+4. Record: HTTP status, wall time, uncompressed byte size, event count, whether `endTime` is treated as unix end (not minutes).
+5. Optional: omit `endTime` but set `time` — note whether result is “from time onward unbounded”.
+6. Capture a trimmed XML fixture for androidTest if shape differs from `epgservice.xml`.
 
 ---
 
@@ -127,6 +169,13 @@ Drawer MultiEPG
 | 6 | Timer bars | v1.1 |
 
 Reply with **defaults OK** or a short override list. After lock-in, mark this doc **Accepted** and only then start Phase 0.
+
+### Shared-understanding checklist
+
+- [ ] Operator agrees §6 defaults (or lists overrides)
+- [ ] Doc status line set to **Accepted**
+- [ ] Phase 0 spike owner / box availability noted
+- [ ] Explicit: no feature code before Phase 0 notes land
 
 ---
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -231,6 +231,19 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 
 ## 6. Defaults pending operator confirmation
 
+### Already settled in this thread (not re-opened)
+
+| Topic | Settlement |
+| --- | --- |
+| Box API | Genuine **Dreambox WebInterface** only; OpenWebif-only APIs out of scope |
+| Webif source | [opendreambox webinterface](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface) is **reference-only** — no patches |
+| Primary EPG fetch | `/web/epgmulti` (confirmed in official webif `EPG.py` / `epgmulti.xml`) |
+| UX metaphor | On-box **GraphMultiEPG** (horizontal grid), not stock web column MultiEPG |
+| Sync | Required: windowed fetches + local cache so the box is not overloaded |
+| Process | Plan + shared understanding **before** any feature implementation |
+
+### Still need your OK (§6)
+
 | # | Decision | Proposed default |
 | --- | --- | --- |
 | 1 | Navigation | Keep list EPG; add drawer **MultiEPG** |
@@ -240,9 +253,8 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 | 5 | Fallback | Defer `epgservice` fallback until spike proves need |
 | 6 | TV | Phone-only v1 |
 | 7 | Timer bars | v1.1 (`show_record_clocks`) |
-| 8 | UX reference | On-box GraphMultiEPG, not stock web column MultiEPG |
 
-Reply with **defaults OK** or a short override list. After lock-in, mark this doc **Accepted** and only then start Phase 0.
+Reply **defaults OK** or a short override list (e.g. “3 → 48 h”). After lock-in, mark this doc **Accepted** and only then start Phase 0.
 
 ### Shared-understanding checklist
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -40,6 +40,24 @@ Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
 
 Not in v1: STB colour-key remapping, AutoTimer, TMDb/IMDB from skin mods.
 
+### Phone layout sketch (v1)
+
+```text
+┌─ MultiEPG · Favourites ────────── 14:32 ┐
+│ [Bouquet ▾]  [Now] [−day] [+day]  [2h▾] │
+├────────┬─────15:00─────16:00─────17:00──┤
+│ Das 1  │████ News ███│░░░░ Magazin ░░░░│
+│ ZDF    │░░ Sport ░░░░│████ Serie █████│
+│ RTL    │████ Film ────────────────────│
+│ …      │                              │
+├────────┴──────────────────────────────┤
+│ │ ← now                               │
+└───────────────────────────────────────┘
+  tap bar → existing EPG detail sheet
+```
+
+Sticky channel column + time header; vertical channel scroll; horizontal time pan; density via `[2h▾]` (1/2/4/5 h).
+
 ### On-box GraphMultiEPG → phone mapping
 
 | GraphMultiEPG (DreamOS plugin) | dreamDroid v1 |

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -7,6 +7,19 @@
 
 Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished timeline UI removed in [#177](https://github.com/sreichholf/dreamDroid/pull/177), commented `EpgDatabase` dropped in [#293](https://github.com/sreichholf/dreamDroid/pull/293). Unused constant already exists: `URIStore.EPG_MULTI` (`/web/epgmulti?`).
 
+### Decision brief (lock-in target)
+
+| | |
+| --- | --- |
+| **UI** | Phone Compose grid (rows = channels, bars = programmes); keep list EPG; new drawer **MultiEPG** |
+| **Fetch** | Dreambox `/web/epgmulti?bRef=&time=&endTime=` with **unix** window (default 24 h); never unbounded |
+| **Sync** | Room cache + ~20–30 min TTL; **one** in-flight request; no idle background sync in v1 |
+| **Fallback** | Throttled `/web/epgservice` only if spike shows `epgmulti` missing |
+| **Out** | No webif patches; no OpenWebif-only APIs; no TV v1; timer overlays = v1.1 |
+| **Next after OK** | Mark **Accepted** → Phase 0 spike on a real Dreambox → then Phase 1+ code |
+
+Reply **defaults OK** (or overrides). Full detail in §§1–7 below.
+
 ---
 
 ## 1. Product summary (phone v1)
@@ -30,7 +43,7 @@ Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer mode
 
 ## 2. Dreambox WebIf — verified EPG surface
 
-Source of truth (opendreambox tree): `webinterface/src/WebComponents/Sources/EPG.py`, `WebScreens.py` (`EpgWebScreen` / `EpgMulti`), and `web/epgmulti.xml` (`bRef,time,endTime`).
+Source of truth (opendreambox tree): `webinterface/src/WebComponents/Sources/EPG.py`, `WebScreens.py` (`EpgWebScreen` registers `EpgMulti`), and `web/epgmulti.xml` (`bRef,time,endTime`).
 
 | Endpoint | XML params | Role |
 | --- | --- | --- |
@@ -121,7 +134,7 @@ EpgChunkMeta
   → TTL freshness for that chunk
 ```
 
-Do **not** revive orphan `DatabaseHelper` `events` table writers.
+`DatabaseHelper` (`DatabaseHelper.kt`) still creates a legacy SQLite `events` table, but MultiEPG sync writers were removed with the old `epgsync` package. **Do not** revive those writers. New cache goes through **Room** (`AppDatabase`) with a schema version bump; optional later cleanup can drop the unused `events` table from `DatabaseHelper`.
 
 - Kotlin + Compose + coroutines only (see `AGENTS.md`).
 - Grid: custom Compose layout (synced H-scroll time header + V-scroll channels); do not revive deleted `EpgTimelineFragment` / `multiepg*.xml`.

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -201,20 +201,31 @@ EpgChunkMeta
 
 **No Phase 1+ code until Phase 0 spike notes are accepted and this plan is lock-in.**
 
+### Phase exit criteria
+
+| Phase | Done when |
+| --- | --- |
+| **0** | Documented: `endTime` units (unix vs minutes); byte size + event count for unbounded vs 2 h vs 24 h on a real bouquet; fixture XML checked into androidTest if needed |
+| **1** | `EnigmaClient.getEvents(…, URIStore.EPG_MULTI)` returns typed `Event`s; Room chunk upsert + TTL hit/miss; single-flight covered by unit tests |
+| **2** | Drawer → MultiEPG opens; bouquet context works; grid shows now-line; pan loads adjacent chunk from cache/network; tap opens existing detail sheet; `MultiEpgScreenTest` green via `connected-test.sh` |
+| **3** | Zoom 1/2/4/5 h; ±day + now jump; empty/error/pull-refresh UX; no unbounded requests in code paths |
+| **4** | Timer clocks (or equivalent) on bars from `timerlist` join; optional |
+
 ### Phase 0 spike checklist
 
 On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 
-1. Unbounded (stock UI behaviour — expect large):  
+1. Unbounded (stock web MultiEPG behaviour — expect large):  
    `GET /web/epgmulti?bRef=BREF`
-2. Windowed 24 h (intended app behaviour):  
-   `GET /web/epgmulti?bRef=BREF&time=T0&endTime=T1`  
-   where `T0` = now (unix), `T1 = T0 + 86400`
-3. Compare to single channel:  
-   `GET /web/epgservice?sRef=SREF&time=T0&endTime=T1`
-4. Record: HTTP status, wall time, uncompressed byte size, event count, whether `endTime` is treated as unix end (not minutes).
-5. Optional: omit `endTime` but set `time` — note whether result is “from time onward unbounded”.
-6. Capture a trimmed XML fixture for androidTest if shape differs from `epgservice.xml`.
+2. Windowed **2 h** (GraphMultiEPG default visible window):  
+   `GET /web/epgmulti?bRef=BREF&time=T0&endTime=T0+7200`
+3. Windowed **24 h** (intended Room chunk):  
+   `GET /web/epgmulti?bRef=BREF&time=T0&endTime=T0+86400`
+4. Compare to single channel:  
+   `GET /web/epgservice?sRef=SREF&time=T0&endTime=T0+86400`
+5. Record: HTTP status, wall time, uncompressed byte size, event count, whether `endTime` is unix end (not minutes).
+6. Optional: omit `endTime` but set `time` — note whether result is “from time onward unbounded”.
+7. Capture a trimmed XML fixture for androidTest if shape differs from `epgservice.xml`.
 
 ---
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -1,13 +1,14 @@
 # Graphical MultiEPG (plan)
 
-**Status:** design only — **no implementation until operator lock-in.**  
+**Status:** **Accepted** (operator lock-in 2026-09-12 — “Defaults look good”).  
+**Implementation gate:** no MultiEPG feature code until Phase 0 spike notes land (real Dreambox `/web/epgmulti` sizes + `endTime` units).  
 **Product reference:** on-box **GraphMultiEPG** (`enigma2-plugin-extensions-graphmultiepg` on DreamOS; same family as [Vu+ GraphMultiEPG](https://wiki.vuplus-support.org/index.php?title=GraphMultiEPG)) — channel rows × time columns, prime time, zoom, timer clocks.  
 **Target API:** genuine Dreambox WebInterface only (not OpenWebif extensions). On-box GraphMultiEPG reads `eEPGCache` locally; dreamDroid must use `/web/epgmulti` over the network.  
 **Reference (read-only):** [opendreambox/enigma2-plugins `webinterface`](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface) — we will **not** patch or extend the box webif. GraphMultiEPG plugin source (behaviour reference): Enigma2 `Plugins/Extensions/GraphMultiEPG/` (e.g. OpenPLi tree; DreamOS ships the same plugin package).
 
 Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished timeline UI removed in [#177](https://github.com/sreichholf/dreamDroid/pull/177), commented `EpgDatabase` dropped in [#293](https://github.com/sreichholf/dreamDroid/pull/293). Unused constant already exists: `URIStore.EPG_MULTI` (`/web/epgmulti?`).
 
-### Decision brief (lock-in target)
+### Decision brief (locked)
 
 | | |
 | --- | --- |
@@ -17,9 +18,9 @@ Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished t
 | **Sync** | Room cache + ~20–30 min TTL; **one** in-flight request; no idle background sync in v1 |
 | **Fallback** | Throttled `/web/epgservice` only if spike shows `epgmulti` missing |
 | **Out** | No webif patches; no OpenWebif-only APIs; no TV v1; timer overlays = v1.1 (GraphMultiEPG `show_record_clocks`) |
-| **Next after OK** | Mark **Accepted** → Phase 0 spike on a real Dreambox → then Phase 1+ code |
+| **Next** | Phase 0 spike on a real Dreambox → then Phase 1+ implementation |
 
-Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
+Full detail in §§1–8 below.
 
 ---
 
@@ -256,9 +257,9 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 
 ---
 
-## 6. Defaults pending operator confirmation
+## 6. Locked defaults (Accepted 2026-09-12)
 
-### Already settled in this thread (not re-opened)
+### Already settled (not re-opened)
 
 | Topic | Settlement |
 | --- | --- |
@@ -269,9 +270,9 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 | Sync | Required: windowed fetches + local cache so the box is not overloaded |
 | Process | Plan + shared understanding **before** any feature implementation |
 
-### Still need your OK (§6)
+### Operator-confirmed defaults
 
-| # | Decision | Proposed default |
+| # | Decision | Locked default |
 | --- | --- | --- |
 | 1 | Navigation | Keep list EPG; add drawer **MultiEPG** |
 | 2 | Visible window | **2 h** default (GraphMultiEPG); zoom 1 / 2 / 4 / 5 h |
@@ -281,25 +282,23 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 | 6 | TV | Phone-only v1 |
 | 7 | Timer bars | v1.1 (`show_record_clocks`) |
 
-Reply **defaults OK** or a short override list (e.g. “3 → 48 h”). After lock-in, mark this doc **Accepted** and only then start Phase 0.
+Operator confirmed 2026-09-12 (“Defaults look good”). No overrides.
 
 ### Shared-understanding checklist
 
-- [ ] Operator agrees §6 defaults (or lists overrides)
-- [ ] Doc status line set to **Accepted**
+- [x] Operator agrees §6 defaults (or lists overrides)
+- [x] Doc status line set to **Accepted**
 - [ ] Phase 0 spike owner / box availability noted
-- [ ] Explicit: no feature code before Phase 0 notes land
+- [x] Explicit: no feature code before Phase 0 notes land
 
 ### Planning Definition of Done
 
 This **planning** goal is complete when all of the following are true:
 
-1. `docs/multiepg.md` describes product, Dreambox `/web/epgmulti` sync model, phases 0–4, and non-goals (present).
-2. Operator has explicitly accepted the Decision brief / §6 (or recorded overrides in this doc).
-3. Status line is **Accepted** (not merely “design only”).
-4. No MultiEPG feature implementation has started before that acceptance.
-
-Until (2)–(3), keep status as design-only and do not open implementation PRs.
+1. `docs/multiepg.md` describes product, Dreambox `/web/epgmulti` sync model, phases 0–4, and non-goals — **done**.
+2. Operator has explicitly accepted the Decision brief / §6 (or recorded overrides in this doc) — **done** (2026-09-12).
+3. Status line is **Accepted** — **done**.
+4. No MultiEPG feature implementation has started before that acceptance — **still holds**; Phase 0 is the next step (separate work).
 
 ---
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -1,9 +1,9 @@
 # Graphical MultiEPG (plan)
 
 **Status:** design only — **no implementation until operator lock-in.**  
-**Inspiration:** [Vu+ GraphMultiEPG](https://wiki.vuplus-support.org/index.php?title=GraphMultiEPG) (channel rows × time columns).  
-**Target API:** genuine Dreambox WebInterface only (not OpenWebif extensions).  
-**Reference (read-only):** [opendreambox/enigma2-plugins `webinterface`](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface) — we will **not** patch or extend the box webif.
+**Product reference:** on-box **GraphMultiEPG** (`enigma2-plugin-extensions-graphmultiepg` on DreamOS; same family as [Vu+ GraphMultiEPG](https://wiki.vuplus-support.org/index.php?title=GraphMultiEPG)) — channel rows × time columns, prime time, zoom, timer clocks.  
+**Target API:** genuine Dreambox WebInterface only (not OpenWebif extensions). On-box GraphMultiEPG reads `eEPGCache` locally; dreamDroid must use `/web/epgmulti` over the network.  
+**Reference (read-only):** [opendreambox/enigma2-plugins `webinterface`](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface) — we will **not** patch or extend the box webif. GraphMultiEPG plugin source (behaviour reference): Enigma2 `Plugins/Extensions/GraphMultiEPG/` (e.g. OpenPLi tree; DreamOS ships the same plugin package).
 
 Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished timeline UI removed in [#177](https://github.com/sreichholf/dreamDroid/pull/177), commented `EpgDatabase` dropped in [#293](https://github.com/sreichholf/dreamDroid/pull/293). Unused constant already exists: `URIStore.EPG_MULTI` (`/web/epgmulti?`).
 
@@ -11,11 +11,12 @@ Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished t
 
 | | |
 | --- | --- |
-| **UI** | Phone Compose grid (rows = channels, bars = programmes); keep list EPG; new drawer **MultiEPG** |
-| **Fetch** | Dreambox `/web/epgmulti?bRef=&time=&endTime=` with **unix** window (default 24 h); never unbounded |
+| **UI** | Phone Compose grid mirroring on-box GraphMultiEPG (rows = channels, bars = programmes); keep list EPG; new drawer **MultiEPG** |
+| **Fetch** | Dreambox `/web/epgmulti?bRef=&time=&endTime=` with **unix** window (default 24 h cache chunk); never unbounded |
+| **Visible** | Default **~2 h** (GraphMultiEPG `prev_time_period` default 120, range 60–300); zoom 1 / 2 / 4 / 5 h |
 | **Sync** | Room cache + ~20–30 min TTL; **one** in-flight request; no idle background sync in v1 |
 | **Fallback** | Throttled `/web/epgservice` only if spike shows `epgmulti` missing |
-| **Out** | No webif patches; no OpenWebif-only APIs; no TV v1; timer overlays = v1.1 |
+| **Out** | No webif patches; no OpenWebif-only APIs; no TV v1; timer overlays = v1.1 (GraphMultiEPG `show_record_clocks`) |
 | **Next after OK** | Mark **Accepted** → Phase 0 spike on a real Dreambox → then Phase 1+ code |
 
 Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
@@ -28,29 +29,29 @@ Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
 | --- | --- |
 | Layout | Channels as rows, programs as timed bars, sticky channel column + time header, “now” line |
 | Scope | One bouquet (reuse bouquet picker) |
-| Visible span | ~3–4 hours (matches stock web MultiEPG JS default `visibleMinutes = 240`), pan horizontally / vertically |
+| Visible span | Default **~2 h** (GraphMultiEPG `prev_time_period` = 120; limits 60–300), pan horizontally / vertically |
 | Prefetch window | Bounded **+24 h** per fetch (see sync) |
-| Density | Time-scale zoom (e.g. 2 / 4 / 6 h visible) |
-| Jump | Now, ±1 day; prime-time optional later |
-| Tap | Existing EPG detail sheet (timer / zap / search) |
-| Timer bars | **Not** in v1 (v1.1) |
+| Density | Time-scale zoom **1 / 2 / 4 / 5 h** (within GraphMultiEPG 60–300 min range) |
+| Jump | Now, ±1 day; prime time (GraphMultiEPG `prime_time`) in polish |
+| Tap | Existing EPG detail sheet (timer / zap / search); OK semantics later: info vs zap |
+| Timer bars | **Not** in v1 (v1.1 — GraphMultiEPG `show_record_clocks`) |
 | TV / Leanback | Out of scope for v1 |
 | List EPG | **Keep** drawer list EPG; add separate **MultiEPG** entry |
 
-Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer modes from the Vu+ skin.
+Not in v1: STB colour-key remapping, AutoTimer, TMDb/IMDB from skin mods.
 
-### Vu+ GraphMultiEPG → phone mapping
+### On-box GraphMultiEPG → phone mapping
 
-| Vu+ / skin behaviour | dreamDroid v1 |
+| GraphMultiEPG (DreamOS plugin) | dreamDroid v1 |
 | --- | --- |
 | Channel rows × time columns | Same metaphor (Compose grid) |
-| Bouquet switch (CH±) | Bouquet picker (reuse existing) |
-| Zoom density (1/2/3) | Time-scale zoom (2 / 4 / 6 h visible) |
-| Jump now / ±day / prime time | Now + ±day; prime time later |
-| OK → channel list EPG | Tap bar → existing detail sheet |
-| Green timer create | Via detail sheet actions (already present) |
-| Timer bars on grid | **v1.1** |
-| Colour remote keys / AutoTimer / TMDb | Out of scope |
+| Bouquet switch | Bouquet picker (reuse existing) |
+| `prev_time_period` 60–300 (default 120) | Zoom 1 / 2 / 4 / 5 h (default 2 h) |
+| Now / ±day / prime time | Now + ±day; prime time in polish |
+| OK → info / zap / zap+exit | Tap → detail sheet (info); zap from sheet |
+| Record clocks on events | **v1.1** |
+| `items_per_page` (default 6) | Vertically scrollable channel list (no hard page size) |
+| Reads `eEPGCache` on box | `/web/epgmulti` + Room cache on phone |
 
 ### Stock Dreambox web MultiEPG vs our target
 
@@ -61,7 +62,7 @@ Official webif MultiEPG (`tplMultiEpg.htm` + `/web/epgmulti?bRef=…` only):
 - Interaction: popup ~900×570; tap → detail with add/zap/edit timer, IMDB, RSS search
 - Default visible window in JS helpers: **240 minutes** when grouping (`visibleMinutes`)
 
-dreamDroid v1 targets **Vu+ GraphMultiEPG** (channels as **rows**, time as **horizontal** axis) and uses the **same** `/web/epgmulti` API with **bounded** `time`/`endTime`. We are not cloning the stock web column layout.
+dreamDroid v1 mirrors **on-box GraphMultiEPG** (horizontal timeline), not the stock web column UI, while still calling bounded `/web/epgmulti`.
 
 ---
 
@@ -107,7 +108,7 @@ Open MultiEPG(bouquet B)
 | --- | --- |
 | Primary API | Windowed `/web/epgmulti` |
 | Chunk size | Rolling **24 h** windows (`endTime = time + 86400`), aligned to the viewport’s day/hour floor — not “full EPG dump” |
-| Visible span | 3–4 h (UI only; data is the chunk) |
+| Visible span | Default 2 h UI (data chunk still 24 h) |
 | Concurrency | **One** in-flight MultiEPG request (no parallel bouquet dumps) |
 | TTL | ~20–30 minutes |
 | Idle background sync | **No** in v1 |
@@ -222,11 +223,13 @@ On a genuine Dreambox WebIf (no OpenWebif), with bouquet ref `BREF` URL-encoded:
 | # | Decision | Proposed default |
 | --- | --- | --- |
 | 1 | Navigation | Keep list EPG; add drawer **MultiEPG** |
-| 2 | Prefetch | +24 h chunks |
-| 3 | Cache TTL | ~20–30 min; no idle sync |
-| 4 | Fallback | Defer `epgservice` fallback until spike proves need |
-| 5 | TV | Phone-only v1 |
-| 6 | Timer bars | v1.1 |
+| 2 | Visible window | **2 h** default (GraphMultiEPG); zoom 1 / 2 / 4 / 5 h |
+| 3 | Prefetch | +24 h Room chunks |
+| 4 | Cache TTL | ~20–30 min; no idle sync |
+| 5 | Fallback | Defer `epgservice` fallback until spike proves need |
+| 6 | TV | Phone-only v1 |
+| 7 | Timer bars | v1.1 (`show_record_clocks`) |
+| 8 | UX reference | On-box GraphMultiEPG, not stock web column MultiEPG |
 
 Reply with **defaults OK** or a short override list. After lock-in, mark this doc **Accepted** and only then start Phase 0.
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -28,7 +28,7 @@ Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
 | --- | --- |
 | Layout | Channels as rows, programs as timed bars, sticky channel column + time header, “now” line |
 | Scope | One bouquet (reuse bouquet picker) |
-| Visible span | ~3–4 hours, pan horizontally / vertically |
+| Visible span | ~3–4 hours (matches stock web MultiEPG JS default `visibleMinutes = 240`), pan horizontally / vertically |
 | Prefetch window | Bounded **+24 h** per fetch (see sync) |
 | Density | Time-scale zoom (e.g. 2 / 4 / 6 h visible) |
 | Jump | Now, ±1 day; prime-time optional later |
@@ -51,6 +51,17 @@ Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer mode
 | Green timer create | Via detail sheet actions (already present) |
 | Timer bars on grid | **v1.1** |
 | Colour remote keys / AutoTimer / TMDb | Out of scope |
+
+### Stock Dreambox web MultiEPG vs our target
+
+Official webif MultiEPG (`tplMultiEpg.htm` + `/web/epgmulti?bRef=…` only):
+
+- Layout: **one column per channel**, events stacked **vertically** by duration height (`item.size = remaining * scale` in `helpers.js` `MultiEPGList`)
+- Fetch: **unbounded** `bRef` alone (heavy on the box)
+- Interaction: popup ~900×570; tap → detail with add/zap/edit timer, IMDB, RSS search
+- Default visible window in JS helpers: **240 minutes** when grouping (`visibleMinutes`)
+
+dreamDroid v1 targets **Vu+ GraphMultiEPG** (channels as **rows**, time as **horizontal** axis) and uses the **same** `/web/epgmulti` API with **bounded** `time`/`endTime`. We are not cloning the stock web column layout.
 
 ---
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -1,0 +1,138 @@
+# Graphical MultiEPG (plan)
+
+**Status:** design only — **no implementation until operator lock-in.**  
+**Inspiration:** [Vu+ GraphMultiEPG](https://wiki.vuplus-support.org/index.php?title=GraphMultiEPG) (channel rows × time columns).  
+**Target API:** genuine Dreambox WebInterface only (not OpenWebif extensions).  
+**Reference (read-only):** [opendreambox/enigma2-plugins `webinterface`](https://github.com/opendreambox/enigma2-plugins/tree/master/webinterface) — we will **not** patch or extend the box webif.
+
+Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished timeline UI removed in [#177](https://github.com/sreichholf/dreamDroid/pull/177), commented `EpgDatabase` dropped in [#293](https://github.com/sreichholf/dreamDroid/pull/293). Unused constant already exists: `URIStore.EPG_MULTI` (`/web/epgmulti?`).
+
+---
+
+## 1. Product summary (phone v1)
+
+| Capability | v1 |
+| --- | --- |
+| Layout | Channels as rows, programs as timed bars, sticky channel column + time header, “now” line |
+| Scope | One bouquet (reuse bouquet picker) |
+| Visible span | ~3–4 hours, pan horizontally / vertically |
+| Prefetch window | Bounded **+24 h** per fetch (see sync) |
+| Density | Time-scale zoom (e.g. 2 / 4 / 6 h visible) |
+| Jump | Now, ±1 day; prime-time optional later |
+| Tap | Existing EPG detail sheet (timer / zap / search) |
+| Timer bars | **Not** in v1 (v1.1) |
+| TV / Leanback | Out of scope for v1 |
+| List EPG | **Keep** drawer list EPG; add separate **MultiEPG** entry |
+
+Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer modes from the Vu+ skin.
+
+---
+
+## 2. Dreambox WebIf — verified EPG surface
+
+Source of truth: `webinterface/src/WebComponents/Sources/EPG.py`, `WebScreens.py`, and `web/epg*.xml` in opendreambox.
+
+| Endpoint | XML params | Role |
+| --- | --- | --- |
+| `/web/epgmulti` | `bRef`, `time`, `endTime` | **MultiEPG primary.** All services in bouquet; each queried with `(service, 0, time, endTime)` via `eEPGCache.lookupEvent` |
+| `/web/epgbouquet` | `bRef`, `time` | List EPG / “at this instant” (no `endTime`) — keep for existing bouquet list UI |
+| `/web/epgservice` | `sRef`, `time`, `endTime` | Single-channel schedule; **fallback** if `epgmulti` fails on very old webif |
+| `/web/epgnow`, `epgnext`, `epgnownext` | bouquet / service | Hub now/next — unchanged |
+| `/web/epgsearch` | search | Existing search — unchanged |
+
+`EPG.getBouquetEPGMulti` is `getEPGofBouquet(param, multi=True)`. With `multi=True`, Dreambox passes **both** `time` and `endTime` into the cache lookup; `epgbouquet` does not. Response XML shape matches existing dreamDroid `Event` / `EventParser` fields (`e2eventid`, `e2eventstart`, `e2eventduration`, …).
+
+### Parameter semantics (plan assumption — confirm in Phase 0)
+
+- Treat `time` / `endTime` as **unix timestamps** (same parsing path as `epgservice` in `EPG.getEPGofService`), **not** OpenWebif’s documented “minutes ahead” for its `epgmulti`.
+- Omitting them (`-1`) is what the stock web UI MultiEPG does (`bRef` only) and can dump a large unbounded schedule — **dreamDroid must always send a bounded window**.
+
+OpenWebif’s wiki note that `epgmulti` is “not in Enigma2 WebInterface API” is **incorrect** for this Dreambox tree. dreamDroid will not rely on OpenWebif-only endpoints (`epgmultigz`, `/api/…`, etc.).
+
+---
+
+## 3. Sync / box-load model
+
+Goal: GraphMultiEPG without hammering the box (historical reason for EPG-sync).
+
+```text
+Open MultiEPG(bouquet B)
+  → Room hit for (profileId, bRef, day-chunk)?
+       yes + fresh TTL → paint from cache
+       no  → GET /web/epgmulti?bRef=B&time=T0&endTime=T1
+            → upsert Room → paint
+  → pan past chunk edge → fetch adjacent chunk (dedupe in-flight)
+  → pull-to-refresh → invalidate chunk + refetch
+  → leave screen → cancel HTTP; keep Room until TTL/evict
+```
+
+| Rule | Default |
+| --- | --- |
+| Primary API | Windowed `/web/epgmulti` |
+| Chunk size | 24 h (`endTime = time + 86400`) |
+| Visible span | 3–4 h (UI only; data is the chunk) |
+| Concurrency | **One** in-flight MultiEPG request (no parallel bouquet dumps) |
+| TTL | ~20–30 minutes |
+| Idle background sync | **No** in v1 |
+| Cache store | **Room** EPG entities (do **not** revive orphan `DatabaseHelper.events`) |
+| Fallback | Throttled serial `/web/epgservice` per channel only if `epgmulti` unavailable |
+| Unbounded `epgmulti` | Forbidden in app code |
+
+One windowed `epgmulti` is still one heavy cache lookup on the box; bounds + TTL + single-flight are the load controls. Progressive row paint is optional polish if responses are large.
+
+---
+
+## 4. App architecture (when implementing)
+
+```text
+Drawer MultiEPG
+  → PhoneNavRoutes.MULTI_EPG
+  → MultiEpgDestination (Compose)
+       ├── MultiEpgSync / EnigmaClient.getEpgMulti
+       ├── Room EpgDao
+       └── MultiEpgScreen (grid)
+            └── tap → existing EpgDetail sheet / timer session
+```
+
+- Kotlin + Compose + coroutines only (see `AGENTS.md`).
+- Reuse: bouquet pick, typed `enigma.Event`, detail/timer session.
+- Grid: custom Compose layout (synced H-scroll time header + V-scroll channels); do not revive deleted `EpgTimelineFragment` / `multiepg*.xml`.
+- Proof: instrumented Compose tests + `bash .cursor/cloud/connected-test.sh …` (no emulator tap loops).
+
+---
+
+## 5. Phases (implementation gates)
+
+| Phase | Deliverable | Gate |
+| --- | --- | --- |
+| **0 — Spike** | Call windowed `epgmulti` on a real Dreambox WebIf; confirm `time`/`endTime` units; note payload size for 24 h × typical bouquet; fixture XML if needed | Operator or lab box result recorded in this doc / PR |
+| **1 — Client + cache** | `EnigmaClient.getEpgMulti`, Room schema, TTL, single-flight | Unit tests + androidTest parse |
+| **2 — Grid beachhead** | Nav + bouquet + now line + pan + tap → detail | `MultiEpgScreenTest` via connected-test helper |
+| **3 — Polish** | Zoom / day jump / empty+error / pull-refresh | Same |
+| **4 — Timers (optional)** | Overlay from `timerlist` | Optional follow-on |
+
+**No Phase 1+ code until Phase 0 spike notes are accepted and this plan is lock-in.**
+
+---
+
+## 6. Defaults pending operator confirmation
+
+| # | Decision | Proposed default |
+| --- | --- | --- |
+| 1 | Navigation | Keep list EPG; add drawer **MultiEPG** |
+| 2 | Prefetch | +24 h chunks |
+| 3 | Cache TTL | ~20–30 min; no idle sync |
+| 4 | Fallback | Defer `epgservice` fallback until spike proves need |
+| 5 | TV | Phone-only v1 |
+| 6 | Timer bars | v1.1 |
+
+Reply with **defaults OK** or a short override list. After lock-in, mark this doc **Accepted** and only then start Phase 0.
+
+---
+
+## 7. Explicit non-goals
+
+- Patching / forking Dreambox `webinterface` on the box.
+- Depending on OpenWebif-only APIs.
+- Reintroducing the 2014 N× unbounded `epgservice` full-bouquet sync as the happy path.
+- Replacing list EPG in v1 (unless operator chooses otherwise).

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -91,6 +91,29 @@ Open MultiEPG(bouquet B)
 | Fallback | Throttled serial `/web/epgservice` per channel only if `epgmulti` unavailable |
 | Unbounded `epgmulti` | Forbidden in app code |
 
+```mermaid
+sequenceDiagram
+  participant UI as MultiEpgScreen
+  participant Sync as MultiEpgSync
+  participant Room as Room cache
+  participant Box as Dreambox /web/epgmulti
+
+  UI->>Sync: open(bouquet, visibleWindow)
+  Sync->>Room: lookup chunk(profile, bRef, day)
+  alt fresh TTL hit
+    Room-->>Sync: events
+    Sync-->>UI: paint
+  else miss / stale
+    Sync->>Box: bRef + time + endTime (bounded)
+    Box-->>Sync: e2eventlist XML
+    Sync->>Room: upsert events + chunk meta
+    Sync-->>UI: paint
+  end
+  UI->>Sync: pan past chunk edge
+  Sync->>Box: adjacent window (single-flight)
+  Note over Sync,Box: never omit endTime; cancel on leave
+```
+
 One windowed `epgmulti` is still one heavy cache lookup on the box; bounds + TTL + single-flight are the load controls. Progressive row paint is optional polish if responses are large.
 
 ---
@@ -189,6 +212,17 @@ Reply with **defaults OK** or a short override list. After lock-in, mark this do
 - [ ] Doc status line set to **Accepted**
 - [ ] Phase 0 spike owner / box availability noted
 - [ ] Explicit: no feature code before Phase 0 notes land
+
+### Planning Definition of Done
+
+This **planning** goal is complete when all of the following are true:
+
+1. `docs/multiepg.md` describes product, Dreambox `/web/epgmulti` sync model, phases 0–4, and non-goals (present).
+2. Operator has explicitly accepted the Decision brief / §6 (or recorded overrides in this doc).
+3. Status line is **Accepted** (not merely “design only”).
+4. No MultiEPG feature implementation has started before that acceptance.
+
+Until (2)–(3), keep status as design-only and do not open implementation PRs.
 
 ---
 

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -18,7 +18,7 @@ Related history in dreamDroid: 2014 EPG-sync sketches (`aa657268`), unfinished t
 | **Out** | No webif patches; no OpenWebif-only APIs; no TV v1; timer overlays = v1.1 |
 | **Next after OK** | Mark **Accepted** → Phase 0 spike on a real Dreambox → then Phase 1+ code |
 
-Reply **defaults OK** (or overrides). Full detail in §§1–7 below.
+Reply **defaults OK** (or overrides). Full detail in §§1–8 below.
 
 ---
 
@@ -38,6 +38,19 @@ Reply **defaults OK** (or overrides). Full detail in §§1–7 below.
 | List EPG | **Keep** drawer list EPG; add separate **MultiEPG** entry |
 
 Not in v1: STB-style colour-key chrome, AutoTimer, TMDb, clock-vs-bar timer modes from the Vu+ skin.
+
+### Vu+ GraphMultiEPG → phone mapping
+
+| Vu+ / skin behaviour | dreamDroid v1 |
+| --- | --- |
+| Channel rows × time columns | Same metaphor (Compose grid) |
+| Bouquet switch (CH±) | Bouquet picker (reuse existing) |
+| Zoom density (1/2/3) | Time-scale zoom (2 / 4 / 6 h visible) |
+| Jump now / ±day / prime time | Now + ±day; prime time later |
+| OK → channel list EPG | Tap bar → existing detail sheet |
+| Green timer create | Via detail sheet actions (already present) |
+| Timer bars on grid | **v1.1** |
+| Colour remote keys / AutoTimer / TMDb | Out of scope |
 
 ---
 
@@ -82,7 +95,7 @@ Open MultiEPG(bouquet B)
 | Rule | Default |
 | --- | --- |
 | Primary API | Windowed `/web/epgmulti` |
-| Chunk size | 24 h (`endTime = time + 86400`) |
+| Chunk size | Rolling **24 h** windows (`endTime = time + 86400`), aligned to the viewport’s day/hour floor — not “full EPG dump” |
 | Visible span | 3–4 h (UI only; data is the chunk) |
 | Concurrency | **One** in-flight MultiEPG request (no parallel bouquet dumps) |
 | TTL | ~20–30 minutes |
@@ -226,7 +239,19 @@ Until (2)–(3), keep status as design-only and do not open implementation PRs.
 
 ---
 
-## 7. Explicit non-goals
+## 7. Risks (planning)
+
+| Risk | Mitigation |
+| --- | --- |
+| Large bouquets + 24 h still heavy on weak boxes | Always bound window; single-flight; TTL; optional later “visible channels first” if spike shows pain |
+| `endTime` units differ from OpenWebif docs | Phase 0 confirms unix vs minutes on genuine Dreambox WebIf |
+| Very old WebIf without `epgmulti` | Spike records it; only then enable throttled `epgservice` fallback |
+| Orphan `DatabaseHelper.events` confusion | New cache is Room-only; do not revive old writers |
+| Grid jank with hundreds of bars | Virtualize rows; recycle bar composables; paint from Room off main thread |
+
+---
+
+## 8. Explicit non-goals
 
 - Patching / forking Dreambox `webinterface` on the box.
 - Depending on OpenWebif-only APIs.

--- a/docs/multiepg.md
+++ b/docs/multiepg.md
@@ -58,6 +58,15 @@ Not in v1: STB colour-key remapping, AutoTimer, TMDb/IMDB from skin mods.
 
 Sticky channel column + time header; vertical channel scroll; horizontal time pan; density via `[2h▾]` (1/2/4/5 h).
 
+### v1 product edges
+
+| Topic | v1 behaviour |
+| --- | --- |
+| Picons | Optional in channel column if already available via existing picon helpers; text name always shown (GraphMultiEPG `servicetitle_mode` can be name-only) |
+| Offline / stale | If Room chunk exists past TTL, still paint it with a subtle stale/refresh affordance; if no chunk and box unreachable, show existing connection-error pattern (do not spin forever) |
+| Orientation | Phone portrait primary; landscape uses same grid with more horizontal hours visible |
+| Profile switch | Invalidate MultiEPG UI state; Room rows are `profileId`-keyed so another profile’s cache is not mixed |
+
 ### On-box GraphMultiEPG → phone mapping
 
 | GraphMultiEPG (DreamOS plugin) | dreamDroid v1 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Planning-only PR for a phone **GraphMultiEPG**-style MultiEPG (channel×time grid) backed by Dreambox `/web/epgmulti` + Room cache.

**Status: Accepted** (operator 2026-09-12 — “Defaults look good”). Planning DoD is met. No feature implementation in this PR.

### Locked defaults

- Keep list EPG; add drawer **MultiEPG**
- Visible window **2 h**; zoom 1 / 2 / 4 / 5 h
- Prefetch **+24 h** Room chunks; TTL ~20–30 min; single-flight; no idle sync in v1
- Defer `epgservice` fallback until Phase 0 proves need
- Phone-only v1; timer clocks **v1.1**
- No webif patches; no OpenWebif-only APIs

### Docs

- [`docs/multiepg.md`](docs/multiepg.md) — full plan (product, sync, phases 0–4, risks, hooks)
- [`docs/modernize-dreamdroid.md`](docs/modernize-dreamdroid.md) Appendix I — Accepted pointer

### Next (separate work)

Phase 0 spike on a real Dreambox: compare 2 h / 24 h / unbounded `/web/epgmulti` sizes and confirm `endTime` units before any app code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f5010fb-db1c-4f34-8d14-9c43410e9a2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f5010fb-db1c-4f34-8d14-9c43410e9a2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

