### PR TITLE
Replace deprecated Android APIs in Compose destinations

### DIFF
--- a/app/androidTest/java/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetViewsTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetViewsTest.kt
@@ -1,6 +1,6 @@
 package net.reichholf.dreamdroid.appwidget
 
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogsHostTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogsHostTest.kt
@@ -118,6 +118,20 @@ class ChoiceDialogsHostTest {
     }
 
     @Test
+    fun blankTitleOmitsHeadingAndShowsMessage() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                IndeterminateProgressDialog(
+                    title = "",
+                    message = "Saving",
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Saving").assertIsDisplayed()
+    }
+
+    @Test
     fun confirmContentColorIsOnSurface() {
         var localContent = Color.Unspecified
         var onSurface = Color.Unspecified

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/epg/EpgDetailDialogHostTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/epg/EpgDetailDialogHostTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.performClick
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.enigma.Event
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -103,5 +105,29 @@ class EpgDetailDialogHostTest {
         composeRule.onNodeWithText("Die Nachrichten um 20 Uhr.").assertIsDisplayed()
         composeRule.onNodeWithText("Set Timer").assertDoesNotExist()
         composeRule.onNodeWithText("Edit Timer").assertDoesNotExist()
+    }
+
+    @Test
+    fun sheetHostShowsSavingProgress() {
+        val session = EpgEventDialogSession()
+        session.showDetail(
+            Event(
+                title = "Tagesschau",
+                serviceName = "Das Erste HD",
+                description = "News",
+                descriptionExtended = "Die Nachrichten um 20 Uhr.",
+                startReadable = "20:00",
+                durationReadable = "15",
+            ),
+        )
+        session.progress = IndeterminateProgressState(message = "Saving")
+        composeRule.setContent {
+            DreamDroidTheme {
+                EpgEventDetailSheetHost(session)
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Tagesschau").assertIsDisplayed()
+        composeRule.onNodeWithText("Saving").assertIsDisplayed()
     }
 }

--- a/app/androidTest/java/net/reichholf/dreamdroid/ui/share/ShareProfilesScreenTest.kt
+++ b/app/androidTest/java/net/reichholf/dreamdroid/ui/share/ShareProfilesScreenTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.performClick
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
 import net.reichholf.dreamdroid.DreamDroid
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.profiles.ProfileListItem
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 import org.junit.Assert.assertEquals
@@ -42,5 +44,24 @@ class ShareProfilesScreenTest {
         composeRule.onNodeWithText("dm7080.local").assertIsDisplayed()
         composeRule.onNodeWithText("Bedroom").assertIsDisplayed().performClick()
         assertEquals(second, clicked)
+    }
+
+    @Test
+    fun progressOverlayShowsLoadingMessage() {
+        composeRule.setContent {
+            DreamDroidTheme {
+                ShareProfilesScreen(
+                    profiles = listOf(
+                        ProfileListItem(id = 1, name = "Living Room", host = "dm7080.local", active = false),
+                    ),
+                    onProfileClick = {},
+                )
+                IndeterminateProgressHost(
+                    IndeterminateProgressState(message = "Loading"),
+                )
+            }
+        }
+        composeRule.onNodeWithText("Living Room").assertIsDisplayed()
+        composeRule.onNodeWithText("Loading").assertIsDisplayed()
     }
 }

--- a/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
+++ b/app/src/net/reichholf/dreamdroid/activities/MainActivity.kt
@@ -108,8 +108,8 @@ class MainActivity :
                 MaterialAlertDialogBuilder(this@MainActivity)
                     .setTitle(R.string.leave_confirm)
                     .setMessage(R.string.leave_confirm_long)
-                    .setPositiveButton(android.R.string.yes) { _, _ -> finish() }
-                    .setNegativeButton(android.R.string.no, null)
+                    .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                    .setNegativeButton(R.string.cancel, null)
                     .show()
             } else {
                 finish()

--- a/app/src/net/reichholf/dreamdroid/activities/ShareActivity.kt
+++ b/app/src/net/reichholf/dreamdroid/activities/ShareActivity.kt
@@ -6,7 +6,6 @@
 
 package net.reichholf.dreamdroid.activities
 
-import android.app.ProgressDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -27,6 +26,7 @@ import net.reichholf.dreamdroid.helpers.SimpleHttpClient
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.SimpleResultRequestHandler
 import net.reichholf.dreamdroid.room.AppDatabase
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.profiles.ProfileListItem
 import net.reichholf.dreamdroid.ui.share.ShareProfilesListState
 import net.reichholf.dreamdroid.ui.share.bindShareProfilesScreen
@@ -40,7 +40,6 @@ class ShareActivity : AppCompatActivity() {
     private var mSimpleResultJob: Job? = null
     private var mShc: SimpleHttpClient? = null
     private lateinit var mListState: ShareProfilesListState
-    private var mProgress: ProgressDialog? = null
     private var mTitle: String? = null
 
     private var mProfiles: List<Profile>? = null
@@ -65,8 +64,7 @@ class ShareActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        mProgress?.dismiss()
-        mProgress = null
+        mListState.progress = null
         mSimpleResultJob?.cancel(null)
         mSimpleResultJob = null
         super.onDestroy()
@@ -151,7 +149,10 @@ class ShareActivity : AppCompatActivity() {
 
     fun execSimpleResultTask(params: ArrayList<NameValuePair>) {
         mSimpleResultJob?.cancel(null)
-        mProgress = ProgressDialog.show(this, getString(R.string.loading), getString(R.string.loading))
+        mListState.progress = IndeterminateProgressState(
+            title = getString(R.string.loading),
+            message = getString(R.string.loading),
+        )
         val handler = SimpleResultRequestHandler(URIStore.MEDIA_PLAYER_PLAY)
         mSimpleResultJob = launchSimpleResultLoad(handler, params) { _, result, http ->
             mSimpleResultJob = null
@@ -160,8 +161,7 @@ class ShareActivity : AppCompatActivity() {
     }
 
     fun onSimpleResult(success: Boolean, result: ExtendedHashMap?, http: SimpleHttpClient) {
-        mProgress?.dismiss()
-        mProgress = null
+        mListState.progress = null
 
         if (mTitle == null) mTitle = "..."
         var toastText = getString(R.string.sent_as, mTitle)

--- a/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetConfiguration.kt
+++ b/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetConfiguration.kt
@@ -4,7 +4,7 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity

--- a/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetViews.kt
+++ b/app/src/net/reichholf/dreamdroid/appwidget/VirtualRemoteWidgetViews.kt
@@ -3,7 +3,7 @@ package net.reichholf.dreamdroid.appwidget
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.view.View
 import android.widget.RemoteViews
 import net.reichholf.dreamdroid.DreamDroid

--- a/app/src/net/reichholf/dreamdroid/helpers/backup/BackupService.kt
+++ b/app/src/net/reichholf/dreamdroid/helpers/backup/BackupService.kt
@@ -2,7 +2,7 @@ package net.reichholf.dreamdroid.helpers.backup
 
 import android.content.ContentValues
 import android.content.Context
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.provider.MediaStore
 import android.util.Log
 import com.google.gson.GsonBuilder

--- a/app/src/net/reichholf/dreamdroid/helpers/enigma2/Picon.kt
+++ b/app/src/net/reichholf/dreamdroid/helpers/enigma2/Picon.kt
@@ -8,7 +8,7 @@ package net.reichholf.dreamdroid.helpers.enigma2
 
 import android.content.Context
 import android.os.Environment
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.view.View
 import android.widget.ImageView
 import com.squareup.picasso.Callback

--- a/app/src/net/reichholf/dreamdroid/intents/IntentFactory.kt
+++ b/app/src/net/reichholf/dreamdroid/intents/IntentFactory.kt
@@ -4,7 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.util.Log
 import net.reichholf.dreamdroid.DreamDroid
 import net.reichholf.dreamdroid.activities.VideoActivity

--- a/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceDestination.kt
@@ -24,21 +24,21 @@ import net.reichholf.dreamdroid.enigma.Event
 import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.enigma.loadCurrentService
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
-import net.reichholf.dreamdroid.ui.dialogs.DialogActionListener
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
-import net.reichholf.dreamdroid.helpers.Statics
-import net.reichholf.dreamdroid.ui.epg.EpgDetailModalSheet
-import net.reichholf.dreamdroid.ui.epg.toEpgDetailContent
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
+import net.reichholf.dreamdroid.helpers.Statics
+import net.reichholf.dreamdroid.helpers.enigma2.Event as EventKeys
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
 import net.reichholf.dreamdroid.helpers.enigma2.Timer
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerAddByEventIdRequestHandler
 import net.reichholf.dreamdroid.intents.IntentFactory
 import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
 import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
+import net.reichholf.dreamdroid.ui.dialogs.DialogActionListener
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
+import net.reichholf.dreamdroid.ui.epg.EpgDetailModalSheet
 import net.reichholf.dreamdroid.ui.epg.EpgListMapper
-import net.reichholf.dreamdroid.helpers.enigma2.Event as EventKeys
+import net.reichholf.dreamdroid.ui.epg.toEpgDetailContent
 
 private const val KEY_SAVED_CURRENT = "current_service"
 private const val KEY_SAVED_ITEM = "current_item"

--- a/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/current/CurrentServiceDestination.kt
@@ -1,6 +1,5 @@
 package net.reichholf.dreamdroid.ui.current
 
-import android.app.ProgressDialog
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -26,6 +25,8 @@ import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.enigma.loadCurrentService
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.ui.dialogs.DialogActionListener
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.ui.epg.EpgDetailModalSheet
 import net.reichholf.dreamdroid.ui.epg.toEpgDetailContent
@@ -236,6 +237,7 @@ fun CurrentServiceDestination(
         }
     }
 
+    IndeterminateProgressHost(session.progress)
 }
 
 private class CurrentServiceSession : DialogActionListener {
@@ -244,10 +246,9 @@ private class CurrentServiceSession : DialogActionListener {
     var ready: Boolean = false
     var hostFragment: PhoneNavHostFragment? = null
     var context: android.content.Context? = null
-    private var progress: ProgressDialog? = null
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
 
     fun dismissProgress() {
-        progress?.takeIf { it.isShowing }?.dismiss()
         progress = null
     }
 
@@ -257,8 +258,7 @@ private class CurrentServiceSession : DialogActionListener {
         when (action) {
             Statics.ACTION_SET_TIMER -> {
                 val event = currentItem ?: return
-                dismissProgress()
-                progress = ProgressDialog.show(ctx, "", ctx.getText(R.string.saving), true)
+                progress = IndeterminateProgressState(message = ctx.getString(R.string.saving))
                 host.launchSimpleResultLoad(
                     TimerAddByEventIdRequestHandler(),
                     Timer.getEventIdParams(event),

--- a/app/src/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogs.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogs.kt
@@ -149,7 +149,11 @@ fun IndeterminateProgressDialog(
 ) {
     AlertDialog(
         onDismissRequest = {},
-        title = title.takeIf { it.isNotBlank() }?.let { { Text(it) } },
+        title = if (title.isBlank()) {
+            null
+        } else {
+            { Text(title) }
+        },
         text = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 CircularProgressIndicator(modifier = Modifier.padding(end = 16.dp))
@@ -166,7 +170,6 @@ fun IndeterminateProgressHost(progress: IndeterminateProgressState?) {
         IndeterminateProgressDialog(title = progress.title, message = progress.message)
     }
 }
-
 
 @Composable
 fun ConfirmAlertDialog(

--- a/app/src/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogs.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/dialogs/ChoiceDialogs.kt
@@ -136,6 +136,12 @@ fun SimpleChoiceAlertDialog(
     )
 }
 
+/** In-composition stand-in for a blocking [android.app.ProgressDialog]. */
+data class IndeterminateProgressState(
+    val message: String,
+    val title: String = "",
+)
+
 @Composable
 fun IndeterminateProgressDialog(
     title: String,
@@ -143,7 +149,7 @@ fun IndeterminateProgressDialog(
 ) {
     AlertDialog(
         onDismissRequest = {},
-        title = { Text(title) },
+        title = title.takeIf { it.isNotBlank() }?.let { { Text(it) } },
         text = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 CircularProgressIndicator(modifier = Modifier.padding(end = 16.dp))
@@ -154,6 +160,13 @@ fun IndeterminateProgressDialog(
     )
 }
 
+@Composable
+fun IndeterminateProgressHost(progress: IndeterminateProgressState?) {
+    if (progress != null) {
+        IndeterminateProgressDialog(title = progress.title, message = progress.message)
+    }
+}
+
 
 @Composable
 fun ConfirmAlertDialog(
@@ -161,8 +174,8 @@ fun ConfirmAlertDialog(
     message: String,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
-    confirmLabel: String = stringResource(android.R.string.yes),
-    dismissLabel: String = stringResource(android.R.string.no),
+    confirmLabel: String = stringResource(R.string.ok),
+    dismissLabel: String = stringResource(R.string.cancel),
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/app/src/net/reichholf/dreamdroid/ui/epg/EpgEventDialogSession.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/epg/EpgEventDialogSession.kt
@@ -1,6 +1,5 @@
 package net.reichholf.dreamdroid.ui.epg
 
-import android.app.ProgressDialog
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
@@ -18,6 +17,8 @@ import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
 import net.reichholf.dreamdroid.helpers.enigma2.Timer
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerAddByEventIdRequestHandler
 import net.reichholf.dreamdroid.intents.IntentFactory
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 
 /**
  * Shared EPG detail-sheet actions for bouquet / service / search / hub destinations.
@@ -29,7 +30,7 @@ class EpgEventDialogSession {
     var currentItem: ExtendedHashMap? = null
     var detailEvent by mutableStateOf<Event?>(null)
         private set
-    private var progress: ProgressDialog? = null
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
 
     fun showDetail(event: Event) {
         currentItem = EpgListMapper.toExtendedHashMap(event)
@@ -41,7 +42,6 @@ class EpgEventDialogSession {
     }
 
     fun dismissProgress() {
-        progress?.takeIf { it.isShowing }?.dismiss()
         progress = null
     }
 
@@ -49,8 +49,7 @@ class EpgEventDialogSession {
         val host = hostFragment ?: return
         val ctx = context ?: return
         val item = currentItem ?: return
-        dismissProgress()
-        progress = ProgressDialog.show(ctx, "", ctx.getText(R.string.saving), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.saving))
         host.launchSimpleResultLoad(
             TimerAddByEventIdRequestHandler(),
             Timer.getEventIdParams(item),
@@ -89,18 +88,22 @@ class EpgEventDialogSession {
 /** Renders [EpgEventDialogSession.detailEvent] as a Material 3 modal sheet when set. */
 @Composable
 fun EpgEventDetailSheetHost(session: EpgEventDialogSession) {
-    val event = session.detailEvent ?: return
-    val minutesShort = stringResource(R.string.minutes_short)
-    val content = event.toEpgDetailContent(minutesShort) ?: run {
-        session.dismissDetail()
-        return
+    val event = session.detailEvent
+    if (event != null) {
+        val minutesShort = stringResource(R.string.minutes_short)
+        val content = event.toEpgDetailContent(minutesShort)
+        if (content == null) {
+            session.dismissDetail()
+        } else {
+            EpgDetailModalSheet(
+                content = content,
+                onDismiss = { session.dismissDetail() },
+                onSetTimer = { session.onSetTimer() },
+                onEditTimer = { session.onEditTimer() },
+                onImdb = { session.onImdb() },
+                onSimilar = { session.onFindSimilar() },
+            )
+        }
     }
-    EpgDetailModalSheet(
-        content = content,
-        onDismiss = { session.dismissDetail() },
-        onSetTimer = { session.onSetTimer() },
-        onEditTimer = { session.onEditTimer() },
-        onImdb = { session.onImdb() },
-        onSimilar = { session.onFindSimilar() },
-    )
+    IndeterminateProgressHost(session.progress)
 }

--- a/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/profiles/ProfilesDestination.kt
@@ -1,7 +1,7 @@
 package net.reichholf.dreamdroid.ui.profiles
 
 import android.app.Activity
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem

--- a/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/remote/VirtualRemoteDestination.kt
@@ -1,8 +1,8 @@
 package net.reichholf.dreamdroid.ui.remote
 
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.os.VibrationEffect
 import android.os.Vibrator
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -69,7 +69,7 @@ fun VirtualRemoteDestination(
     val handler = remember { Handler(Looper.getMainLooper()) }
     var pendingScreenshot by remember { mutableStateOf<Runnable?>(null) }
     val vibrator = remember {
-        context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        context.getSystemService(Vibrator::class.java)
     }
     val showScreenshot = LocalConfiguration.current.screenWidthDp >= 720
 
@@ -109,8 +109,9 @@ fun VirtualRemoteDestination(
 
     fun onKey(keyCode: Int, longClick: Boolean) {
         val msec = if (longClick) 100L else 25L
-        @Suppress("DEPRECATION")
-        vibrator.vibrate(msec)
+        vibrator?.vibrate(
+            VibrationEffect.createOneShot(msec, VibrationEffect.DEFAULT_AMPLITUDE),
+        )
         val params = ArrayList<NameValuePair>().apply {
             add(NameValuePair("command", keyCode.toString()))
             add(NameValuePair("rcu", if (simpleRemote) "standard" else "advanced"))

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubMovieListPage.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubMovieListPage.kt
@@ -39,18 +39,12 @@ import net.reichholf.dreamdroid.enigma.Movie
 import net.reichholf.dreamdroid.enigma.launchMovieListLoad
 import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
-import net.reichholf.dreamdroid.ui.movies.MovieDetailContent
-import net.reichholf.dreamdroid.ui.movies.MovieDetailModalSheet
-import net.reichholf.dreamdroid.ui.movies.toMovieDetailContent
-import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
-import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.NameValuePair
 import net.reichholf.dreamdroid.helpers.Python
 import net.reichholf.dreamdroid.helpers.SimpleHttpClient
 import net.reichholf.dreamdroid.helpers.Statics
+import net.reichholf.dreamdroid.helpers.enigma2.Movie as MovieKeys
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
 import net.reichholf.dreamdroid.helpers.enigma2.Tag
 import net.reichholf.dreamdroid.helpers.enigma2.URIStore
@@ -59,8 +53,14 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.ZapRequestHandler
 import net.reichholf.dreamdroid.intents.IntentFactory
 import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
 import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
+import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
+import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
+import net.reichholf.dreamdroid.ui.movies.MovieDetailContent
+import net.reichholf.dreamdroid.ui.movies.MovieDetailModalSheet
+import net.reichholf.dreamdroid.ui.movies.toMovieDetailContent
 import net.reichholf.dreamdroid.widget.AnchorPopup
-import net.reichholf.dreamdroid.helpers.enigma2.Movie as MovieKeys
 
 /**
  * Phase 2.7h: one Movies hub location page as Compose (parity with former MovieListFragment).
@@ -196,6 +196,7 @@ fun HubMovieListPage(
             },
         )
     }
+
     IndeterminateProgressHost(session.progress)
 }
 

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubMovieListPage.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubMovieListPage.kt
@@ -1,8 +1,6 @@
 package net.reichholf.dreamdroid.ui.services
 
-import android.app.ProgressDialog
 import android.content.ActivityNotFoundException
-import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.view.Menu
@@ -45,6 +43,8 @@ import net.reichholf.dreamdroid.ui.movies.MovieDetailContent
 import net.reichholf.dreamdroid.ui.movies.MovieDetailModalSheet
 import net.reichholf.dreamdroid.ui.movies.toMovieDetailContent
 import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.NameValuePair
@@ -196,6 +196,7 @@ fun HubMovieListPage(
             },
         )
     }
+    IndeterminateProgressHost(session.progress)
 }
 
 /**
@@ -227,13 +228,12 @@ class HubMovieListSession :
     private var selectedMovie: ExtendedHashMap? = null
     private var tagsChanged = false
     private var reloadOnSimpleResult = false
-    private var progress: ProgressDialog? = null
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
     private var loadJob: Job? = null
     private var zapJob: Job? = null
     private var deleteJob: Job? = null
 
     fun dismissProgress() {
-        progress?.takeIf { it.isShowing }?.dismiss()
         progress = null
     }
 
@@ -367,8 +367,7 @@ class HubMovieListSession :
         val host = hostFragment ?: return
         val ctx = context ?: return
         val movie = selectedMovie ?: return
-        dismissProgress()
-        progress = ProgressDialog.show(ctx, "", ctx.getText(R.string.deleting), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.deleting))
         reloadOnSimpleResult = true
         deleteJob?.cancel()
         deleteJob = host.launchSimpleResultLoad(

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubTimerListPage.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubTimerListPage.kt
@@ -1,7 +1,6 @@
 package net.reichholf.dreamdroid.ui.services
 
 import android.app.Activity
-import android.app.ProgressDialog
 import android.content.Intent
 import android.util.Log
 import android.view.Menu
@@ -39,6 +38,8 @@ import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.enigma.loadTimerList
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
 import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
@@ -158,6 +159,7 @@ fun HubTimerListPage(
             },
         )
     }
+    IndeterminateProgressHost(session.progress)
 }
 
 /**
@@ -187,7 +189,7 @@ class HubTimerListSession :
     private var loadGeneration = 0
     private var loadJob: Job? = null
     private var mutateJob: Job? = null
-    private var progress: ProgressDialog? = null
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
     private var actionMode: ActionMode? = null
     private var actionModeActive = false
 
@@ -229,7 +231,6 @@ class HubTimerListSession :
     }
 
     fun dismissProgress() {
-        progress?.takeIf { it.isShowing }?.dismiss()
         progress = null
     }
 
@@ -322,8 +323,7 @@ class HubTimerListSession :
     fun deleteTimer(timer: ExtendedHashMap) {
         val host = hostFragment ?: return
         val ctx = context ?: return
-        dismissProgress()
-        progress = ProgressDialog.show(activity, "", ctx.getText(R.string.deleting), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.deleting))
         val params = Timer.getDeleteParams(timer)
         mutateJob?.cancel()
         mutateJob = host.launchSimpleResultLoad(TimerDeleteRequestHandler(), params) { _, result, http ->
@@ -341,8 +341,7 @@ class HubTimerListSession :
         } else {
             timerNew.put(Timer.KEY_DISABLED, "1")
         }
-        dismissProgress()
-        progress = ProgressDialog.show(activity, "", ctx.getText(R.string.saving), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.saving))
         val params = Timer.getSaveParams(timerNew, timer)
         mutateJob?.cancel()
         mutateJob = host.launchSimpleResultLoad(TimerChangeRequestHandler(), params) { _, result, http ->
@@ -354,8 +353,7 @@ class HubTimerListSession :
     private fun cleanupTimerList() {
         val host = hostFragment ?: return
         val ctx = context ?: return
-        dismissProgress()
-        progress = ProgressDialog.show(activity, "", ctx.getText(R.string.cleaning_timerlist), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.cleaning_timerlist))
         mutateJob?.cancel()
         mutateJob = host.launchSimpleResultLoad(
             TimerCleanupRequestHandler(),

--- a/app/src/net/reichholf/dreamdroid/ui/services/HubTimerListPage.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/services/HubTimerListPage.kt
@@ -23,8 +23,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.core.view.MenuProvider
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.Job
@@ -37,9 +37,6 @@ import net.reichholf.dreamdroid.enigma.Timer as TypedTimer
 import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.enigma.loadTimerList
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
-import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Statics
 import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
@@ -49,6 +46,9 @@ import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerCleanupReque
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerDeleteRequestHandler
 import net.reichholf.dreamdroid.ui.compose.ComposeRefreshState
 import net.reichholf.dreamdroid.ui.compose.DreamDroidPullRefresh
+import net.reichholf.dreamdroid.ui.dialogs.ConfirmAlertDialog
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 
 /**
  * Phase 2.7h: hub Timers page as Compose (parity with former TimerListFragment).
@@ -159,6 +159,7 @@ fun HubTimerListPage(
             },
         )
     }
+
     IndeterminateProgressHost(session.progress)
 }
 
@@ -183,7 +184,7 @@ class HubTimerListSession :
 
     var onRequestDeleteConfirm: ((String) -> Unit)? = null
 
-        private val timers = ArrayList<TypedTimer>()
+    private val timers = ArrayList<TypedTimer>()
     private val mapList = ArrayList<ExtendedHashMap>()
     private var selected: ExtendedHashMap = ExtendedHashMap()
     private var loadGeneration = 0

--- a/app/src/net/reichholf/dreamdroid/ui/share/ShareProfilesListState.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/share/ShareProfilesListState.kt
@@ -1,14 +1,20 @@
 package net.reichholf.dreamdroid.ui.share
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.profiles.ProfileListItem
 import net.reichholf.dreamdroid.ui.theme.DreamDroidTheme
 
 class ShareProfilesListState(initial: List<ProfileListItem> = emptyList()) {
     val profiles: SnapshotStateList<ProfileListItem> = initial.toMutableStateList()
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
 
     fun replaceAll(next: List<ProfileListItem>) {
         profiles.clear()
@@ -27,6 +33,7 @@ fun ComposeView.bindShareProfilesScreen(
                 profiles = state.profiles,
                 onProfileClick = onProfileClick,
             )
+            IndeterminateProgressHost(state.progress)
         }
     }
 }

--- a/app/src/net/reichholf/dreamdroid/ui/signal/SignalDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/signal/SignalDestination.kt
@@ -1,7 +1,7 @@
 package net.reichholf.dreamdroid.ui.signal
 
+import android.media.AudioAttributes
 import android.media.AudioFormat
-import android.media.AudioManager
 import android.media.AudioTrack
 import android.os.Handler
 import android.os.Looper
@@ -183,14 +183,23 @@ private fun playAcousticTone(freqOfTone: Double) {
     val sample = DoubleArray(numSamples)
     val generatedSnd = ByteArray(2 * numSamples)
     val audioTrack = try {
-        AudioTrack(
-            AudioManager.STREAM_MUSIC,
-            sampleRate,
-            AudioFormat.CHANNEL_OUT_MONO,
-            AudioFormat.ENCODING_PCM_16BIT,
-            numSamples * 2,
-            AudioTrack.MODE_STATIC,
-        )
+        AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build(),
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build(),
+            )
+            .setBufferSizeInBytes(numSamples * 2)
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .build()
     } catch (_: Exception) {
         return
     }

--- a/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditDestination.kt
@@ -11,10 +11,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -28,10 +28,6 @@ import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler
 import net.reichholf.dreamdroid.enigma.launchLocationsAndTagsLoad
 import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
-import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
-import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
-import net.reichholf.dreamdroid.ui.nav.NavExtras
 import net.reichholf.dreamdroid.helpers.DateTime
 import net.reichholf.dreamdroid.helpers.ExtendedHashMap
 import net.reichholf.dreamdroid.helpers.Python
@@ -41,7 +37,10 @@ import net.reichholf.dreamdroid.helpers.enigma2.SimpleResult
 import net.reichholf.dreamdroid.helpers.enigma2.Tag
 import net.reichholf.dreamdroid.helpers.enigma2.Timer
 import net.reichholf.dreamdroid.helpers.enigma2.requesthandler.TimerChangeRequestHandler
-import java.util.Arrays
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
+import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
+import net.reichholf.dreamdroid.ui.nav.NavExtras
 import java.util.Calendar
 import java.util.Collections
 
@@ -126,6 +125,7 @@ fun TimerEditDestination(
             },
         )
     }
+
     IndeterminateProgressHost(session.progress)
 }
 
@@ -277,7 +277,6 @@ class TimerEditSession(
 
     fun ensureLocationsAndTagsThenReload() {
         val host = hostFragment ?: return
-        context ?: return
         if (DreamDroid.getLocations().size == 0 || DreamDroid.getTags().size == 0) {
             if (locationsJob != null) {
                 return

--- a/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditDestination.kt
+++ b/app/src/net/reichholf/dreamdroid/ui/timers/TimerEditDestination.kt
@@ -1,8 +1,6 @@
 package net.reichholf.dreamdroid.ui.timers
 
 import android.app.Activity
-import android.app.ProgressDialog
-import android.content.DialogInterface
 import android.content.Intent
 import android.text.format.DateFormat
 import android.util.Log
@@ -30,6 +28,8 @@ import net.reichholf.dreamdroid.activities.abs.MultiPaneHandler
 import net.reichholf.dreamdroid.enigma.launchLocationsAndTagsLoad
 import net.reichholf.dreamdroid.enigma.launchSimpleResultLoad
 import net.reichholf.dreamdroid.fragment.PhoneNavHostFragment
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressHost
+import net.reichholf.dreamdroid.ui.dialogs.IndeterminateProgressState
 import net.reichholf.dreamdroid.ui.dialogs.MultiChoiceAlertDialog
 import net.reichholf.dreamdroid.ui.nav.NavExtras
 import net.reichholf.dreamdroid.helpers.DateTime
@@ -126,6 +126,7 @@ fun TimerEditDestination(
             },
         )
     }
+    IndeterminateProgressHost(session.progress)
 }
 
 /**
@@ -149,16 +150,12 @@ class TimerEditSession(
     var begin: Int = 0
     var end: Int = 0
     private var tagsChanged = false
-    private var progress: ProgressDialog? = null
-    private var locationsProgress: ProgressDialog? = null
+    var progress by mutableStateOf<IndeterminateProgressState?>(null)
     private var locationsJob: kotlinx.coroutines.Job? = null
     private var saveJob: kotlinx.coroutines.Job? = null
 
     fun dismissProgress() {
-        progress?.takeIf { it.isShowing }?.dismiss()
         progress = null
-        locationsProgress?.takeIf { it.isShowing }?.dismiss()
-        locationsProgress = null
         locationsJob?.cancel()
         locationsJob = null
         saveJob?.cancel()
@@ -280,23 +277,18 @@ class TimerEditSession(
 
     fun ensureLocationsAndTagsThenReload() {
         val host = hostFragment ?: return
-        val ctx = context ?: return
+        context ?: return
         if (DreamDroid.getLocations().size == 0 || DreamDroid.getTags().size == 0) {
             if (locationsJob != null) {
                 return
             }
             locationsJob = host.launchLocationsAndTagsLoad(
                 onProgress = { title, progressText ->
-                    if (locationsProgress?.isShowing == true) {
-                        locationsProgress?.setMessage(progressText)
-                    } else {
-                        locationsProgress = ProgressDialog.show(ctx, title, progressText)
-                    }
+                    progress = IndeterminateProgressState(title = title, message = progressText)
                 },
                 onReady = {
                     locationsJob = null
-                    locationsProgress?.dismiss()
-                    locationsProgress = null
+                    progress = null
                     reload()
                 },
             )
@@ -328,13 +320,11 @@ class TimerEditSession(
         val host = hostFragment ?: return
         val ctx = context ?: return
         Log.i(LOG_TAG, "saveTimer()")
-        progress?.takeIf { it.isShowing }?.dismiss()
-        progress = ProgressDialog.show(ctx, "", ctx.getText(R.string.saving), true)
+        progress = IndeterminateProgressState(message = ctx.getString(R.string.saving))
         editState.applyTo(timer)
         val params = Timer.getSaveParams(timer, timerOld)
         saveJob?.cancel()
         saveJob = host.launchSimpleResultLoad(TimerChangeRequestHandler(), params) { _, result, _ ->
-            progress?.dismiss()
             progress = null
             if (Python.TRUE.equals(result.getString(SimpleResult.KEY_STATE))) {
                 host.clearTimerEditSession()

--- a/app/src/net/reichholf/dreamdroid/widget/helper/ItemClickSupport.kt
+++ b/app/src/net/reichholf/dreamdroid/widget/helper/ItemClickSupport.kt
@@ -17,7 +17,7 @@ class ItemClickSupport private constructor(recyclerView: RecyclerView) {
         val listener = mOnItemClickListener
         if (listener != null) {
             val holder = mRecyclerView.getChildViewHolder(v)
-            listener.onItemClick(mRecyclerView, v, holder.adapterPosition, v.id.toLong())
+            listener.onItemClick(mRecyclerView, v, holder.bindingAdapterPosition, v.id.toLong())
         }
     }
 
@@ -28,7 +28,7 @@ class ItemClickSupport private constructor(recyclerView: RecyclerView) {
             return@OnLongClickListener listener.onItemLongClick(
                 mRecyclerView,
                 v,
-                holder.adapterPosition,
+                holder.bindingAdapterPosition,
                 v.id.toLong(),
             )
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Blocking `ProgressDialog`, platform `PreferenceManager`, the old `AudioTrack` constructor, `VIBRATOR_SERVICE`, and `ViewHolder.adapterPosition` were still firing Kotlin deprecation warnings on compile.

This swaps those call sites to current APIs:

- Platform `android.preference.PreferenceManager` → `androidx.preference.PreferenceManager` (same `_preferences` file).
- `ProgressDialog` on timer edit, hub movies/timers, current service, EPG set-timer, and share → in-composition `IndeterminateProgressDialog` (Phase 2.1g-ii-e).
- Virtual Remote: `Vibrator` class lookup + `VibrationEffect.createOneShot`.
- Signal acoustic tone: `AudioTrack.Builder` with `AudioAttributes`.
- RecyclerView clicks: `bindingAdapterPosition`.
- Confirm buttons: app `R.string.ok` / `R.string.cancel` instead of deprecated `android.R.string.yes` / `no`.

Instrumented coverage: blank-title progress dialog, EPG sheet + saving overlay, share loading overlay.

Other Kotlin deprecations (`NetworkInfo`, `onActivityResult`, `IntentService`, fragment menu APIs) are left for follow-up — they are larger chassis changes, not these compile warnings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae133028-9154-49b9-8efc-5ab76fe3c57a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae133028-9154-49b9-8efc-5ab76fe3c57a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

